### PR TITLE
fix: stop queued conversions on Ctrl+C instead of draining the batch

### DIFF
--- a/converter/batch.py
+++ b/converter/batch.py
@@ -13,7 +13,8 @@ Two deliberate departures from the code this replaces:
 import enum
 import os
 import sys
-from collections.abc import Iterable, Sequence
+import threading
+from collections.abc import Callable, Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import suppress
 from dataclasses import dataclass, field
@@ -109,6 +110,40 @@ def convert_one(job: Job, task: Task, tools: Tools, *, overwrite: bool) -> Resul
         return Result(task, Outcome.FAILED, error=f"{type(exc).__name__}: {exc}")
 
 
+def _interruptible(
+    job: Job,
+    tools: Tools,
+    *,
+    overwrite: bool,
+    interrupted: threading.Event,
+) -> Callable[[Task], Result]:
+    """Wrap :func:`convert_one` so a worker stops itself after any Ctrl+C.
+
+    ``cancel_futures`` on the pool is not enough on its own: every file is
+    submitted up front, and the interrupt only reaches the main thread when it
+    consumes the future carrying it -- by which time a fast worker has already
+    pulled the rest of the queue and converted it.  A worker that checks a shared
+    flag before starting does not depend on that timing, which is why the same
+    batch used to abort on one platform and drain to the end on another.
+    """
+
+    def work(task: Task) -> Result:
+        if interrupted.is_set():
+            # Raise rather than fabricate a Result: this file was never touched,
+            # and SKIPPED already means "the output was already there", which is
+            # a different statement.  KeyboardInterrupt specifically, so that
+            # whichever future the main thread happens to consume first still
+            # aborts the batch for the right reason.
+            raise KeyboardInterrupt
+        try:
+            return convert_one(job, task, tools, overwrite=overwrite)
+        except KeyboardInterrupt:
+            interrupted.set()
+            raise
+
+    return work
+
+
 def run_batch(
     job: Job,
     tasks: Sequence[Task],
@@ -129,15 +164,15 @@ def run_batch(
         ensure_directory(task.dst.parent)
 
     results: list[Result] = []
+    work = _interruptible(job, tools, overwrite=overwrite, interrupted=threading.Event())
+
     # Not ThreadPoolExecutor's own context manager: its __exit__ shuts down with
     # wait=True and no cancellation, so after Ctrl+C every queued file would
     # still be converted before the interrupt was ever noticed.
     pool = ThreadPoolExecutor(max_workers=workers)
     try:
         with tqdm(total=len(tasks), desc=job.name, unit="file", disable=not progress) as bar:
-            futures = [
-                pool.submit(convert_one, job, task, tools, overwrite=overwrite) for task in tasks
-            ]
+            futures = [pool.submit(work, task) for task in tasks]
             try:
                 # as_completed, so the bar advances when a file is actually done
                 # rather than in submission order.

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -229,7 +229,15 @@ class TestRunBatch:
     def test_interrupt_drops_work_that_has_not_started(self, tmp_path, monkeypatch):
         """Ctrl+C used to be noticed only after every queued file had converted:
         ThreadPoolExecutor's context manager shuts down with wait=True and no
-        cancellation, so the whole batch drained before the interrupt surfaced."""
+        cancellation, so the whole batch drained before the interrupt surfaced.
+
+        Asserted as an exact count, not as "fewer than all".  Cancelling the
+        futures alone left this timing-dependent -- the single worker can drain
+        the queue before the main thread ever consumes the future carrying the
+        interrupt -- so the loose bound passed on Windows while the same batch
+        ran to completion on Linux.  With one worker and the interrupt on the
+        third file, exactly three conversions may ever start.
+        """
         tasks = [make_task(tmp_path, f"clip{i:02d}") for i in range(12)]
         calls: list[list[str]] = []
 
@@ -244,7 +252,7 @@ class TestRunBatch:
         with pytest.raises(KeyboardInterrupt):
             run_batch(MKV_TO_MP4, tasks, TOOLS, jobs=1, progress=False)
 
-        assert len(calls) < len(tasks)
+        assert len(calls) == 3
 
 
 class TestSummarise:


### PR DESCRIPTION
Found by CI on #2, where it failed on ubuntu 3.12 and 3.13 while passing on
ubuntu 3.11, 3.14 and all three Windows jobs. It is a pre-existing defect on
`main`, not a regression from that PR — #1 simply got lucky on all seven jobs.

## The bug

`run_batch` calls `pool.shutdown(wait=False, cancel_futures=True)` when it sees a
`KeyboardInterrupt`, and a comment says it "drops everything that has not
started". Cancelling futures only covers work still sitting in the queue, though,
and every file is submitted up front. The interrupt reaches the main thread only
when it consumes the future that carries it — and a fast worker has already pulled
the rest of the queue and converted it by then.

`convert_one` catches `Exception`, and `KeyboardInterrupt` is a `BaseException`,
so it correctly propagates — the worker just never stops on its own.

That makes the outcome a scheduling race. On Windows the main thread wins; on
Linux 3.12/3.13 the worker drains all 12 files first.

## The fix

The worker stops itself rather than waiting for the main thread: whichever worker
sees the `KeyboardInterrupt` sets a shared `threading.Event`, and every worker
checks it before starting a file. No timing dependency left.

A file dropped this way raises instead of returning a `Result` — it was never
touched, and `SKIPPED` already means "the output was already there", a different
statement. It raises `KeyboardInterrupt` specifically, so the batch still aborts
for the right reason whichever future the main thread happens to consume first.

The wrapper sits at module level as `_interruptible` rather than as a closure
inside `run_batch`, which would have pushed that function to 67 lines and broken
the 50-line limit in `docs/constitution.md`.

## The test was too weak to catch it

It asserted `len(calls) < len(tasks)` — "fewer than all" — so on Windows it never
failed even against the broken code. It now pins the exact count, which is
deterministic with a single worker and the interrupt on the third file.

Measured on Windows / Python 3.13:

| | tightened assertion |
| --- | --- |
| unfixed `batch.py` | 9 of 10 passed (so it does catch it, ~10% of runs) |
| fixed `batch.py` | 40 of 40 passed |

The determinism comes from the fix; the tightened assertion is what makes the
regression visible on this platform at all.

## Verified

`ruff check` clean, `ruff format --check` clean, 141 tests pass. Bootstrapped and
run in a dedicated worktree per `docs/workflow.md`.
