### PR TITLE
docs(spec): profile-driven target registry (roadmap phase 1)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,8 +11,8 @@ Everything else exists today.
 | Component | Responsibility |
 | --------- | -------------- |
 | `converter/cli.py` | Argument parsing, target-format selection, the interactive prompt, usage errors, exit codes |
-| `converter/profiles.py` | One declarative profile per target format: the copy mask, the fallback encoder and the container flags, per stream type |
-| `converter/jobs.py` | The generic conversion engine: turns a profile plus a probed stream list into an ordered ladder of attempts |
+| `converter/profiles.py` | One declarative profile per target format: the copy mask, the fallback encoder and the drop reason per stream type, the container flags, and the cheap and last-resort attempts the format declares as data |
+| `converter/jobs.py` | The generic conversion engine: turns a profile plus a probed stream list into an ordered ladder of attempts. It owns the *order* of the rungs and how the selective rung is built; the profiles own what each declared rung contains |
 | `converter/batch.py` | Bounded parallel execution, the per-file outcome, progress reporting, the aggregate summary and the process exit code |
 | `converter/paths.py` | Input discovery, output-path construction, tree mirroring, collision detection, Windows path-length diagnosis |
 | `converter/ffmpegtool.py` | Locating ffmpeg and ffprobe, building argv, running without a shell, probing streams |
@@ -48,10 +48,16 @@ depends on `jobs` + `ffmpegtool` + `paths`, `cli` depends on all of them,
    per file. On success nothing else happens — no ffprobe round-trip is ever spent.
 2. **Degradation.** The attempt exits non-zero, so *now* `ffmpegtool.probe_streams`
    describes the file. The engine matches each stream against the profile's copy
-   mask: streams the mask accepts are copied, streams it does not are re-encoded
-   with the profile's fallback encoder, and streams the container cannot hold at
-   all are dropped. Every sacrifice becomes a note on the attempt. The final rung
-   is a full re-encode of one video plus all audio streams.
+   mask: streams the mask accepts pass through unchanged — as a literal `copy`, or
+   as the cheap in-kind transcode the rule declares, which is how a text subtitle
+   becomes `mov_text` — streams it does not are re-encoded with the profile's
+   fallback encoder, and streams are dropped when the container cannot hold that
+   stream type at all, when it is already holding as many streams of the type as
+   it can, or when the rule declares no fallback. Every sacrifice becomes a note
+   on the attempt. The last rung is the full re-encode the profile declares; a
+   profile may declare none, and then the rung before it ends the ladder. The
+   order of attempts and the per-stream branch are drawn in
+   `docs/design/degradation-ladder.md` and `docs/design/stream-decision.md`.
 3. **Idempotent re-run.** An output that already exists and no `--overwrite` makes
    the file `skipped` without starting a process, so a second run over a finished
    tree does no work.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,9 +21,9 @@ Everything else exists today.
 ## Boundaries
 
 The internal import graph is acyclic today and must stay that way:
-`ffmpegtool` and `paths` are leaves, `jobs` depends on `ffmpegtool`, `batch`
-depends on `jobs` + `ffmpegtool` + `paths`, `cli` depends on all of them,
-`__main__` depends only on `cli`.
+`ffmpegtool`, `paths` and `profiles` are leaves, `jobs` depends on `ffmpegtool` +
+`profiles`, `batch` depends on `jobs` + `ffmpegtool` + `paths`, `cli` depends on
+all of them, `__main__` depends only on `cli`.
 
 - `converter/profiles.py` must be a **leaf**: no internal imports at all. This is
   what makes the constitution's "a target format is data, not code" structurally

--- a/docs/design.md
+++ b/docs/design.md
@@ -105,9 +105,13 @@ Instead of UI components, these are the rules a diagram in this project follows.
 - **Attempt ladder** — one node per rung, ordered top to bottom cheapest-first.
   Every edge that leaves a rung is labelled with the condition that takes it
   (`exit 0`, `exit != 0`), so no branch is implicit.
-- **Per-stream decision** — a decision node per stream type (video, audio,
-  subtitle, other), each with exactly three outgoing edges: copy, re-encode,
-  drop. A dropped edge is labelled with the reason the container cannot hold it.
+- **Per-stream decision** — every stream ends on exactly one of three outcomes:
+  copy, re-encode, drop. Each drop edge is labelled with the reason the container
+  cannot hold the stream. Draw one decision chain per stream type (video, audio,
+  subtitle, other) while the code branches per type; draw the chain once,
+  type-agnostically, once the code is driven by per-type data rather than per-type
+  branches — a diagram that repeats an identical chain four times hides that the
+  engine is generic. A diagram that takes the generic form says so in its header.
 - **Cost markers** — any node that spends a subprocess call says so
   (`ffprobe`, `ffmpeg`). The point of the ladder is that ffprobe stays off the
   happy path, and a diagram that hides where processes start defeats that.

--- a/docs/design.md
+++ b/docs/design.md
@@ -106,7 +106,8 @@ Instead of UI components, these are the rules a diagram in this project follows.
   Every edge that leaves a rung is labelled with the condition that takes it
   (`exit 0`, `exit != 0`), so no branch is implicit.
 - **Per-stream decision** — every stream ends on exactly one of three outcomes:
-  copy, re-encode, drop. Each drop edge is labelled with the reason the container
+  accept, re-encode, drop. "Accept" rather than "copy" because a stream the target
+  accepts may still be transcoded in kind (a text subtitle becoming `mov_text`). Each drop edge is labelled with the reason the container
   cannot hold the stream. Draw one decision chain per stream type (video, audio,
   subtitle, other) while the code branches per type; draw the chain once,
   type-agnostically, once the code is driven by per-type data rather than per-type

--- a/docs/design.md
+++ b/docs/design.md
@@ -107,8 +107,9 @@ Instead of UI components, these are the rules a diagram in this project follows.
   (`exit 0`, `exit != 0`), so no branch is implicit.
 - **Per-stream decision** — every stream ends on exactly one of three outcomes:
   accept, re-encode, drop. "Accept" rather than "copy" because a stream the target
-  accepts may still be transcoded in kind (a text subtitle becoming `mov_text`). Each drop edge is labelled with the reason the container
-  cannot hold the stream. Draw one decision chain per stream type (video, audio,
+  accepts may still be transcoded in kind (a text subtitle becoming `mov_text`).
+  Each drop edge is labelled with the reason the container cannot hold the
+  stream. Draw one decision chain per stream type (video, audio,
   subtitle, other) while the code branches per type; draw the chain once,
   type-agnostically, once the code is driven by per-type data rather than per-type
   branches — a diagram that repeats an identical chain four times hides that the

--- a/docs/design/degradation-ladder.md
+++ b/docs/design/degradation-ladder.md
@@ -1,0 +1,54 @@
+# Degradation ladder
+
+> Design artifact (`docs/design.md`, `kind: concept`). One decision per diagram;
+> the per-stream branch is a separate file, `stream-decision.md`. Referenced from
+> the spec of every phase that changes the ladder — reference it, never restate it.
+
+## The decision this settles
+
+In which order the engine tries to produce one output file, where a subprocess is
+spent, and which conditions move it down a rung. The point of the ladder is that
+`ffprobe` never runs on the happy path (`docs/constitution.md`), so every node
+that costs a process call is marked.
+
+```mermaid
+flowchart TD
+    A["Attempt 1 — the profile's cheap attempt<br/>(ffmpeg)"]
+    P["describe the source's streams<br/>(ffprobe — first and only probe)"]
+    PLAN["build the selective plan<br/>(no subprocess — see stream-decision.md)"]
+    SEL["Attempt 2 — selective<br/>(ffmpeg)"]
+    FIN["Attempt 3 — the profile's last-resort attempt<br/>(ffmpeg; a profile may declare none)"]
+    OK["converted — the winning attempt's notes are reported"]
+    BAD["failed — partial output removed, ffmpeg's stderr kept per rung"]
+
+    A -->|"exit 0"| OK
+    A -->|"exit != 0"| P
+    P -->|"probe failed"| BAD
+    P -->|"stream list"| PLAN
+    PLAN -->|"no stream survives the profile's rules"| FIN
+    PLAN -->|"plan matches attempt 1 and sacrifices nothing"| FIN
+    PLAN -->|"otherwise"| SEL
+    SEL -->|"exit 0"| OK
+    SEL -->|"exit != 0"| FIN
+    FIN -->|"exit 0"| OK
+    FIN -->|"exit != 0, or no last-resort attempt declared"| BAD
+```
+
+## Rules the diagram encodes
+
+- **One probe per file, never on the happy path.** The `ffprobe` node sits behind
+  the first non-zero exit and is reached at most once; every later rung reuses the
+  same stream list.
+- **Cheapest first.** Rung 1 is whatever the profile declares as its cheap attempt
+  (a blind stream copy for a container that can hold the source codecs, an explicit
+  single-stream decode where it cannot).
+- **The selective rung is skipped when it would add nothing.** Two conditions do
+  that: nothing survives the profile's rules (there is no command to build), or the
+  plan keeps exactly the streams attempt 1 kept, with the same codecs, and gives up
+  nothing worth naming. Without this rule a profile whose cheap attempt already maps
+  streams explicitly would pay for a second, identical ffmpeg run.
+- **The last rung is optional.** A container that can always be reached by a full
+  re-encode declares one; a container with nothing further to give up (WAV) does not,
+  and a failure there is the end of the ladder.
+- **Every rung carries its own notes.** The notes of the attempt that actually
+  succeeded are what the batch reports — the discarded rungs' notes are not.

--- a/docs/design/degradation-ladder.md
+++ b/docs/design/degradation-ladder.md
@@ -26,7 +26,7 @@ flowchart TD
     P -->|"probe failed"| BAD
     P -->|"stream list"| PLAN
     PLAN -->|"no stream survives the profile's rules"| FIN
-    PLAN -->|"plan matches attempt 1 and sacrifices nothing"| FIN
+    PLAN -->|"the cheap attempt already selects streams explicitly<br/>and the plan gives up nothing"| FIN
     PLAN -->|"otherwise"| SEL
     SEL -->|"exit 0"| OK
     SEL -->|"exit != 0"| FIN
@@ -39,16 +39,22 @@ flowchart TD
 - **One probe per file, never on the happy path.** The `ffprobe` node sits behind
   the first non-zero exit and is reached at most once; every later rung reuses the
   same stream list.
-- **Cheapest first.** Rung 1 is whatever the profile declares as its cheap attempt
-  (a blind stream copy for a container that can hold the source codecs, an explicit
-  single-stream decode where it cannot).
+- **Cheapest first.** Rung 1 is whatever the profile declares as its cheap attempt:
+  a *blind* stream copy for a container that can hold the source codecs
+  (`-map 0:v? -map 0:a? ...`), or a *stream-explicit* selection where it cannot
+  (`-map 0:a:0 ...`). Which of the two it is, the profile declares — the engine
+  never parses an option list to find out.
 - **The selective rung is skipped when it would add nothing.** Two conditions do
-  that: nothing survives the profile's rules (there is no command to build), or the
-  plan keeps exactly the streams attempt 1 kept, with the same codecs, and gives up
-  nothing worth naming. Without this rule a profile whose cheap attempt already maps
-  streams explicitly would pay for a second, identical ffmpeg run.
+  that. Nothing survives the profile's rules, so there is no command to build. Or
+  the profile's cheap attempt is stream-explicit *and* the plan gives up nothing
+  worth naming — then the rung would be a second, equivalent ffmpeg run. A profile
+  whose cheap attempt is blind always gets the rung: the explicit per-stream
+  mapping is exactly what can rescue a file the blind copy could not.
 - **The last rung is optional.** A container that can always be reached by a full
-  re-encode declares one; a container with nothing further to give up (WAV) does not,
-  and a failure there is the end of the ladder.
+  re-encode declares one; a container with nothing further to give up (WAV) does
+  not, and a failure at the rung before it is then the end of the ladder.
 - **Every rung carries its own notes.** The notes of the attempt that actually
   succeeded are what the batch reports — the discarded rungs' notes are not.
+- **Container-wide options are appended by the engine, once, at the end of every
+  attempt.** The profile declares them in one place instead of repeating them in
+  each attempt it declares.

--- a/docs/design/stream-decision.md
+++ b/docs/design/stream-decision.md
@@ -29,7 +29,7 @@ flowchart TD
     COPY["accept — map stream i, emit the rule's pass-through codec<br/>(literal copy, or a cheap in-kind transcode such as mov_text)"]
     REENC["re-encode — map stream i, emit the fallback encoder<br/>note: t stream i (c) re-encoded to TARGET_CODEC<br/>(a rule may declare no note where the re-encode gives up nothing)"]
     D1["drop — note: t stream i (c) dropped: not supported by TARGET"]
-    D2["drop — note: t stream i (c) dropped: TARGET holds N t stream(s)"]
+    D2["drop — note: t stream i (c) dropped: TARGET holds LIMIT t stream<br/>(the noun agrees in number with LIMIT)"]
     D3["drop — note: t stream i (c) dropped: DROP_REASON"]
 
     S --> T
@@ -55,9 +55,13 @@ flowchart TD
   only codec is the definition of that target format, not a loss — WAV's PCM rule
   declares no note, MP4's `aac` and `h264` fallbacks do. Whether the note exists
   is the rule's data, never an engine heuristic.
-- **Output specifiers count per type, in mapping order.** The position used in
+- **Output specifiers count per type, in mapping order.** Where a rule's option
+  template carries the position placeholder, the value substituted into
   `-c:v:0`, `-c:a:1` is the count of streams of that type already kept, not the
-  input stream index — ffmpeg counts output streams per type.
+  input stream index — ffmpeg counts output streams per type. The placeholder is
+  optional: a rule whose stream limit is 1 can only ever produce one output stream
+  of its type, so it writes the bare specifier (`-c:a`) and the engine substitutes
+  nothing.
 - **The rung is emitted as maps, then codecs, then container options.** All
   `-map` pairs first in stream order, then every codec option in the same order,
   then the profile's container-wide options. Interleaving per stream would be

--- a/docs/design/stream-decision.md
+++ b/docs/design/stream-decision.md
@@ -1,0 +1,54 @@
+# Per-stream decision
+
+> Design artifact (`docs/design.md`, `kind: concept`). The sibling of
+> `degradation-ladder.md`: that file decides the order of attempts, this one
+> decides what happens to a single stream inside the selective rung.
+
+## The decision this settles
+
+Given one probed stream and the target profile's rule for that stream's type,
+whether the stream is copied, re-encoded, or dropped — and what the resulting
+note says. No node here spends a subprocess call: the whole plan is built in
+Python from one stream list.
+
+```mermaid
+flowchart TD
+    S["stream i — type t, codec c"]
+    T{"does the profile declare a rule for type t?"}
+    ROOM{"is there still room for a t stream?<br/>(the rule's stream limit)"}
+    MASK{"is c in the rule's copy mask?"}
+    ENC{"does the rule declare a fallback encoder?"}
+    COPY["copy — map stream i, emit the rule's pass-through codec<br/>(literal copy, or a cheap in-kind transcode such as mov_text)"]
+    REENC["re-encode — map stream i, emit the fallback encoder<br/>note: t stream i (c) re-encoded to <target codec>"]
+    D1["drop — note: t stream i (c) dropped: not supported by <target>"]
+    D2["drop — note: t stream i (c) dropped: <target> holds N t stream(s)"]
+    D3["drop — note: t stream i (c) dropped: <the rule's drop reason>"]
+
+    S --> T
+    T -->|"no"| D1
+    T -->|"yes"| ROOM
+    ROOM -->|"no"| D2
+    ROOM -->|"yes"| MASK
+    MASK -->|"yes"| COPY
+    MASK -->|"no"| ENC
+    ENC -->|"yes"| REENC
+    ENC -->|"no"| D3
+```
+
+## Rules the diagram encodes
+
+- **Three outcomes, never a fourth.** A stream is copied, re-encoded, or dropped.
+  Every drop edge names the reason, because a silent drop is exactly what the
+  vision forbids.
+- **Every note names three things:** the stream index, that stream's codec, and
+  what was given up (`docs/vision.md`). A note that omits one of them is a review
+  finding.
+- **Output specifiers count per type, in mapping order.** The position used in
+  `-c:v:0`, `-c:a:1` is the count of streams of that type already kept, not the
+  input stream index — ffmpeg counts output streams per type.
+- **The copy mask is curated, never discovered.** `ffmpeg -codecs` lists what a
+  build contains, not what a muxer legally accepts (`docs/prior-art.md`,
+  "Container/codec capability modelling"), so the mask is data written by hand.
+- **A missing rule is a drop, not a crash.** Attachments, data and timecode
+  streams reach the default branch and are dropped with a note; the ladder never
+  fails because a source carried an unexpected stream type.

--- a/docs/design/stream-decision.md
+++ b/docs/design/stream-decision.md
@@ -3,13 +3,21 @@
 > Design artifact (`docs/design.md`, `kind: concept`). The sibling of
 > `degradation-ladder.md`: that file decides the order of attempts, this one
 > decides what happens to a single stream inside the selective rung.
+>
+> Declared deviation from `docs/design.md`'s per-stream convention: the contract
+> asks for one decision node per stream type. A profile-driven engine has no
+> per-type code — video, audio and subtitle differ only in the rule they carry —
+> so the branch is drawn once, type-agnostically, and the contract bullet was
+> amended in the same PR to allow it.
 
 ## The decision this settles
 
 Given one probed stream and the target profile's rule for that stream's type,
 whether the stream is copied, re-encoded, or dropped — and what the resulting
 note says. No node here spends a subprocess call: the whole plan is built in
-Python from one stream list.
+Python from one stream list. `TARGET` below is the profile's display label
+(`MP4`, `WAV`), `TARGET_CODEC` the human-readable name of what the fallback
+encoder produces (`h264`, `aac`), `DROP_REASON` the reason the rule declares.
 
 ```mermaid
 flowchart TD
@@ -18,11 +26,11 @@ flowchart TD
     ROOM{"is there still room for a t stream?<br/>(the rule's stream limit)"}
     MASK{"is c in the rule's copy mask?"}
     ENC{"does the rule declare a fallback encoder?"}
-    COPY["copy — map stream i, emit the rule's pass-through codec<br/>(literal copy, or a cheap in-kind transcode such as mov_text)"]
-    REENC["re-encode — map stream i, emit the fallback encoder<br/>note: t stream i (c) re-encoded to <target codec>"]
-    D1["drop — note: t stream i (c) dropped: not supported by <target>"]
-    D2["drop — note: t stream i (c) dropped: <target> holds N t stream(s)"]
-    D3["drop — note: t stream i (c) dropped: <the rule's drop reason>"]
+    COPY["accept — map stream i, emit the rule's pass-through codec<br/>(literal copy, or a cheap in-kind transcode such as mov_text)"]
+    REENC["re-encode — map stream i, emit the fallback encoder<br/>note: t stream i (c) re-encoded to TARGET_CODEC<br/>(a rule may declare no note where the re-encode gives up nothing)"]
+    D1["drop — note: t stream i (c) dropped: not supported by TARGET"]
+    D2["drop — note: t stream i (c) dropped: TARGET holds N t stream(s)"]
+    D3["drop — note: t stream i (c) dropped: DROP_REASON"]
 
     S --> T
     T -->|"no"| D1
@@ -37,18 +45,27 @@ flowchart TD
 
 ## Rules the diagram encodes
 
-- **Three outcomes, never a fourth.** A stream is copied, re-encoded, or dropped.
-  Every drop edge names the reason, because a silent drop is exactly what the
-  vision forbids.
+- **Three outcomes, never a fourth.** A stream is accepted, re-encoded, or
+  dropped. Every drop edge names the reason, because a silent drop is exactly
+  what the vision forbids.
 - **Every note names three things:** the stream index, that stream's codec, and
   what was given up (`docs/vision.md`). A note that omits one of them is a review
-  finding.
+  finding. A stream with no codec name reported by ffprobe reads as `unknown`.
+- **A re-encode that gives up nothing carries no note.** Decoding to a container's
+  only codec is the definition of that target format, not a loss — WAV's PCM rule
+  declares no note, MP4's `aac` and `h264` fallbacks do. Whether the note exists
+  is the rule's data, never an engine heuristic.
 - **Output specifiers count per type, in mapping order.** The position used in
   `-c:v:0`, `-c:a:1` is the count of streams of that type already kept, not the
   input stream index — ffmpeg counts output streams per type.
+- **The rung is emitted as maps, then codecs, then container options.** All
+  `-map` pairs first in stream order, then every codec option in the same order,
+  then the profile's container-wide options. Interleaving per stream would be
+  equally valid ffmpeg and a different argv.
 - **The copy mask is curated, never discovered.** `ffmpeg -codecs` lists what a
   build contains, not what a muxer legally accepts (`docs/prior-art.md`,
   "Container/codec capability modelling"), so the mask is data written by hand.
+  A mask may legitimately be empty — WAV accepts no source codec as-is.
 - **A missing rule is a drop, not a crash.** Attachments, data and timecode
   streams reach the default branch and are dropped with a note; the ladder never
   fails because a source carried an unexpected stream type.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,7 +11,7 @@
 
 | Phase | Name | Spec | Milestone |
 |---|---|---|---|
-| 1 | profile-registry | — | — |
+| 1 | profile-registry | [spec-profile-registry.md](specs/spec-profile-registry.md) | — |
 | 2 | target-driven-cli | — | — |
 | 3 | audio-formats | — | — |
 | 4 | video-formats | — | — |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,8 +25,10 @@ lives.
 
 1. **profile-registry** — Create `converter/profiles.py` as a leaf module and turn
    the ladder in `converter/jobs.py` into a generic engine driven by a profile.
-   MKV-to-MP4 and Opus-to-WAV are *re-expressed* as profiles with identical
-   behaviour; the existing 141 tests are the safety net. No CLI change.
+   MKV-to-MP4 and Opus-to-WAV are *re-expressed* as profiles: the ffmpeg argv
+   stays identical, and a note changes only where it gains a fact today's wording
+   omits — each such change argued in the PR. The existing 141 tests are the
+   safety net. No CLI change.
 2. **target-driven-cli** — `converter --to <format>` replaces the `video` and
    `audio` sub-commands, plus `--list-formats` and a reworked interactive prompt.
    Corrects the README, including the stale `develop` pull-request target. This is

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,7 +11,7 @@
 
 | Phase | Name | Spec | Milestone |
 |---|---|---|---|
-| 1 | profile-registry | [spec-profile-registry.md](specs/spec-profile-registry.md) | — |
+| 1 | profile-registry | [spec-profile-registry.md](specs/spec-profile-registry.md) | [#1](https://github.com/bhemsen/converter/milestone/1) |
 | 2 | target-driven-cli | — | — |
 | 3 | audio-formats | — | — |
 | 4 | video-formats | — | — |

--- a/docs/specs/spec-profile-registry.md
+++ b/docs/specs/spec-profile-registry.md
@@ -127,14 +127,15 @@ from this file.
 | A stream rule holds: the copy mask (a `frozenset` of codec names, possibly empty), the option template emitted for an accepted stream, an optional fallback-encoder option template, the human-readable name of what that encoder produces or `None` when the re-encode gives up nothing worth naming, an optional limit on how many streams of the type the container holds, and the reason a stream is dropped when there is no fallback | Covers every branch the two existing recipes take, including MP4's subtitle case where an accepted stream is transcoded to `mov_text` rather than copied, and WAV's case where nothing is copyable and the PCM conversion is the point of the format rather than a loss | 2026-08-25 |
 | WAV's audio rule has an **empty** copy mask, a `pcm_s16le` fallback, and **no** re-encode note; its stream limit is 1. WAV declares no rule for any other stream type | Reproduces today's output exactly: `wav_pcm()` emits no note, and a second audio stream is dropped with one. An empty mask is a legitimate value — a container may accept nothing as-is | 2026-08-25 |
 | Positional output specifiers are written into the option template as a literal `{n}` placeholder, e.g. `flags("-c:v:{n} libx264 -crf:v:{n} 18")`, and the engine replaces every `{n}` with the per-type output position | Keeps the `flags("...")` convention — the template still reads like the command line you would type — and avoids the engine guessing which flags take a stream specifier (`-preset` does not) | 2026-08-25 |
+| The placeholder is **optional**. A rule whose stream limit is 1 can only ever produce one output stream of its type, so it writes the bare specifier and the engine substitutes nothing. WAV's audio templates are therefore placeholder-free: `flags("-c:a pcm_s16le")` | This is what keeps `tests/test_argv.py`'s `("-map", "0:0", "-c:a", "pcm_s16le")` byte-for-byte rather than turning it into `-c:a:0`. The alternative — a universal placeholder plus a fourth accepted delta — would weaken the safety net to buy uniformity that a limit-1 container cannot use | 2026-08-25 |
 | The cheap attempt and the last-resort attempt are **declared per profile as data**, not derived by the engine | `docs/architecture.md`: a new target format must be one profile entry and nothing else. A derived last rung would need MP4's `-pix_fmt yuv420p` and WAV's absence of a video rung to live as branching in `jobs.py`, i.e. format knowledge in the engine. Declaring them also guarantees the two existing argv strings survive byte-for-byte | 2026-08-25 |
-| Container-wide options are declared once on the profile and appended by the engine, exactly once, at the **end** of every attempt — including the declared ones, whose data therefore excludes them | Today `+faststart` is the tail of all three MP4 attempts. Appending centrally keeps that argv and stops a profile from repeating the flag; drawn in `docs/design/degradation-ladder.md` | 2026-08-25 |
-| The engine-built rung emits **all `-map` pairs first in stream order, then all codec options in the same order, then the container options** | `tests/test_argv.py` pins exactly this grouping; per-stream interleaving would be equally valid ffmpeg and a different argv. Drawn in `docs/design/stream-decision.md` | 2026-08-25 |
+| Container-wide options are declared once on the profile, and the engine places them as `docs/design/degradation-ladder.md` specifies; the declared attempts' own data therefore excludes them | Today `+faststart` is the tail of all three MP4 attempts. Declaring it once keeps that argv and stops a profile from repeating the flag | 2026-08-25 |
+| The engine-built rung emits its options in the order `docs/design/stream-decision.md` specifies | `tests/test_argv.py` pins exactly that grouping; any other order would be equally valid ffmpeg and a different argv | 2026-08-25 |
 | The selective rung is emitted per `docs/design/degradation-ladder.md`; the one datum the engine cannot derive — whether the cheap attempt already selects streams explicitly — is declared by the profile (MP4: no, WAV: yes) | The alternative, comparing the plan against the cheap attempt, would require the engine to parse ffmpeg option syntax, putting CLI knowledge back into `jobs.py`. With the flag, MP4 keeps its rung for `[h264]` and WAV keeps returning no rung for a single audio stream — both existing tests hold | 2026-08-25 |
 | The engine-built rung is labelled `"selective"` for every profile; the declared attempts keep their current labels (`remux`, `pcm_s16le`, `re-encode`). WAV's `first-audio-stream` label disappears | `tests/test_batch.py` pins `remux` and `selective`; nothing pins `first-audio-stream`. One label for one engine-built rung is what makes the label meaningful across 17 formats | 2026-08-25 |
-| A note's `<target>` is the profile's **display label** (`MP4`, `WAV`); a stream whose `codec_name` ffprobe leaves empty reads as `unknown` | Both reproduce today's strings in `converter/jobs.py` | 2026-08-25 |
+| A note's `TARGET` is the profile's **display label** (`MP4`, `WAV`). A stream whose `codec_name` ffprobe leaves empty reads as `unknown`, and so does a stream whose `codec_type` it leaves empty | All three reproduce today's strings in `converter/jobs.py`, which already falls back to `unknown` for both fields | 2026-08-25 |
 | `Attempt` moves to `profiles.py` and `jobs.py` imports it; `jobs.py` does **not** re-export it | A profile declares attempts, so the type must sit in the leaf. One import path per type, so a test cannot accidentally pin the wrong one | 2026-08-25 |
-| `Job` keeps its public shape (`name`, `description`, `suffixes`, `target_suffix`, `first_attempt`, `retries`) and `JOBS` keeps its keys. The source-pair data behind them — sub-command name, description, source suffixes, target profile — lives in one `JOB_BINDINGS` table in `jobs.py`, explicitly exempted from the no-format-knowledge outcome and marked in the module as phase-2 scaffolding | Delivers the empty diff in `cli.py` and `batch.py`. The data is a *source-pair* binding, not target-format knowledge, so putting it on the profile would contaminate the value type phase 2 consumes by target alone | 2026-08-25 |
+| `Job` keeps its public shape (`name`, `description`, `suffixes`, `target_suffix`, `first_attempt`, `retries`) and `JOBS` keeps its keys. The source-pair data behind them — the `JOBS` key (`video`, `audio`), the `Job.name` that `batch.py` prints as the progress-bar description (`mkv-to-mp4`, `opus-to-wav`), the help text, the source suffixes and the target profile — lives in one `JOB_BINDINGS` table in `jobs.py`, explicitly exempted from the no-format-knowledge outcome and marked in the module as phase-2 scaffolding | Delivers the empty diff in `cli.py` and `batch.py`. The data is a *source-pair* binding, not target-format knowledge, so putting it on the profile would contaminate the value type phase 2 consumes by target alone | 2026-08-25 |
 | `flags()` moves from `jobs.py` to `profiles.py`; `jobs.py` imports it from there | `profiles.py` writes the recipes and may not import `jobs`; duplicating the function instead would be two definitions of one convention | 2026-08-25 |
 | The module-level recipe functions `mp4_remux`, `mp4_retries`, `wav_pcm`, `wav_retries` may disappear | They are internal — nothing outside `jobs.py` and its tests imports them, and the README documents no Python API | 2026-08-25 |
 | Every argv assertion in the test suite is preserved verbatim. A note assertion may change only for one of the three *Accepted behaviour deltas* below; any other diff to the safety net fails review | The tests are this refactor's safety net; a refactor that silently rewrites its own safety net proves nothing | 2026-08-25 |
@@ -151,8 +152,9 @@ with the test that pins it.
    `attachment stream 1 (ttf) dropped: not supported by MP4`.
 2. **The surplus-audio-stream note is re-worded per stream instead of per file.**
    Today: `2 audio streams present; kept stream 0 only (WAV holds one)`. It
-   becomes `audio stream 1 (opus) dropped: WAV holds 1 audio stream`, which names
-   the stream that was actually lost and its codec.
+   becomes what `D2` in `docs/design/stream-decision.md` renders for this case —
+   `audio stream 1 (opus) dropped: WAV holds 1 audio stream` — which names the
+   stream that was actually lost and its codec. The rung's argv is unchanged.
 3. **A WAV source carrying a non-audio stream gains a rung on the failure path.**
    An `.opus` with embedded cover art currently produces no retry at all; it now
    reaches a selective rung that drops the cover-art stream with a note. The rung
@@ -198,29 +200,39 @@ Machine checks — Verify is the per-iteration gate (`docs/workflow.md`):
 
 Human milestone-QA gate — the machine checks stub the subprocess boundary and so
 prove nothing about a real conversion (`docs/workflow.md`). The repository ships
-no media fixtures; synthesise them first, with the absolute ffmpeg path from
-*This machine*:
+no media fixtures; synthesise them first. `$FF` is the absolute ffmpeg path from
+*This machine*; the shell is PowerShell, one command per line, and `ffmpeg` does
+not create the directory itself:
 
 ```text
-ffmpeg -f lavfi -i testsrc=size=320x240:rate=10:duration=2 \
-       -f lavfi -i sine=duration=2 -c:v libx264 -c:a aac  in/clip.mkv
-ffmpeg -f lavfi -i sine=duration=2 -c:a libopus            in/tone.opus
-ffmpeg -f lavfi -i testsrc=size=320x240:rate=10:duration=2 \
-       -c:v ffv1                                           in/lossless.mkv
+New-Item -ItemType Directory -Force in
+& $FF -f lavfi -i testsrc=size=320x240:rate=10:duration=2 -f lavfi -i sine=duration=2 -c:v libx264 -c:a aac in/clip.mkv
+& $FF -f lavfi -i testsrc=size=320x240:rate=10:duration=2 -c:v ffv1 in/lossless.mkv
+& $FF -f lavfi -i testsrc=size=320x240:rate=10:duration=2 -c:v libx264 -attach LICENSE -metadata:s:t mimetype=text/plain in/attached.mkv
+& $FF -f lavfi -i sine=duration=2 -c:a libopus in/tone.opus
+& $FF -f lavfi -i sine=frequency=440:duration=2 -f lavfi -i sine=frequency=880:duration=2 -map 0:a -map 1:a -c:a libopus in/two-tone.opus
 ```
 
-`ffv1` is the ladder-forcing case: MP4 cannot hold it, so the remux fails and the
-selective rung has to re-encode the video.
+`lossless.mkv` is the ladder-forcing case: MP4 cannot hold `ffv1`, so the remux
+fails and the selective rung has to re-encode the video. `attached.mkv` and
+`two-tone.opus` exist to make deltas 1 and 2 observable — the other fixtures
+never reach those branches. The WAV job only accepts `.opus` sources, which is
+why both audio fixtures use that suffix.
 
 - [ ] `converter video in out` converts `clip.mkv` to a playable `.mp4` and
-      reports `1 converted, 0 skipped, 0 failed`, exit 0.
+      reports `converted`, `0 failed`, exit 0.
 - [ ] `converter audio in out` converts `tone.opus` to a playable `.wav`.
-- [ ] `converter video in out` over `lossless.mkv` still converts, and prints a
-      note naming the stream index, `ffv1`, and the re-encode to h264.
+- [ ] `lossless.mkv` still converts, and prints a note naming the stream index,
+      `ffv1`, and the re-encode to h264.
 - [ ] A second run of each over the same output tree reports `0 converted`,
       `N skipped`, `0 failed`, exit 0.
-- [ ] The three *Accepted behaviour deltas* are the only differences a human can
-      observe against the same commands run on `main`.
+- [ ] Delta 1: `attached.mkv` converts and its attachment note names the codec,
+      which the same command on `main` omits.
+- [ ] Delta 2: `two-tone.opus` converts and names the dropped audio stream and
+      its codec, where `main` reports the count instead.
+- [ ] Delta 3: an `.opus` carrying cover art reaches a selective rung on the
+      failure path only — no successful conversion above differs from `main`
+      beyond deltas 1 and 2.
 
 ## Risks and mitigations
 
@@ -246,6 +258,12 @@ selective rung has to re-encode the video.
   cheap attempt is not computable from declared data without parsing ffmpeg
   option syntax. Replaced by a declared flag on the profile; both existing
   suppression behaviours were re-checked against `tests/test_argv.py`.
+- 2026-08-25: Closing the equivalence escape hatch in review round 2 introduced a
+  contradiction of its own: the universal `{n}` placeholder would have turned
+  WAV's pinned `-c:a pcm_s16le` into `-c:a:0`, which the closed delta list forbids.
+  Resolved by making the placeholder optional for a rule that can only produce one
+  output stream, rather than by admitting a fourth delta — the strict reading of
+  "the argv stays identical" is worth more than template uniformity.
 - 2026-08-25: Spec review found `docs/architecture.md` describing a ladder this
   phase does not build (a mandatory last rung, copy-only acceptance, two drop
   reasons). Amended here rather than left to drift, since architecture is the

--- a/docs/specs/spec-profile-registry.md
+++ b/docs/specs/spec-profile-registry.md
@@ -21,7 +21,7 @@ and milestone. A completed spec is moved to `docs/specs/archive/`.
 - [ ] `converter/cli.py`, `converter/batch.py` and `converter/paths.py` have an
       empty diff for this phase.
 - [ ] Every argv the test suite pins is produced byte-for-byte by the new engine.
-      The three note and rung changes listed under *Accepted behaviour deltas* are
+      The four changes listed under *Accepted behaviour deltas* are
       the complete set of behaviour differences; anything else is a defect.
 - [ ] Both profiles have a test pinning the exact argv they build, for the
       copyable and the non-copyable case each profile actually has
@@ -138,12 +138,12 @@ from this file.
 | `Job` keeps its public shape (`name`, `description`, `suffixes`, `target_suffix`, `first_attempt`, `retries`) and `JOBS` keeps its keys. The source-pair data behind them — the `JOBS` key (`video`, `audio`), the `Job.name` that `batch.py` prints as the progress-bar description (`mkv-to-mp4`, `opus-to-wav`), the help text, the source suffixes and the target profile — lives in one `JOB_BINDINGS` table in `jobs.py`, explicitly exempted from the no-format-knowledge outcome and marked in the module as phase-2 scaffolding | Delivers the empty diff in `cli.py` and `batch.py`. The data is a *source-pair* binding, not target-format knowledge, so putting it on the profile would contaminate the value type phase 2 consumes by target alone | 2026-08-25 |
 | `flags()` moves from `jobs.py` to `profiles.py`; `jobs.py` imports it from there | `profiles.py` writes the recipes and may not import `jobs`; duplicating the function instead would be two definitions of one convention | 2026-08-25 |
 | The module-level recipe functions `mp4_remux`, `mp4_retries`, `wav_pcm`, `wav_retries` may disappear | They are internal — nothing outside `jobs.py` and its tests imports them, and the README documents no Python API | 2026-08-25 |
-| Every argv assertion in the test suite is preserved verbatim. A note assertion may change only for one of the three *Accepted behaviour deltas* below; any other diff to the safety net fails review | The tests are this refactor's safety net; a refactor that silently rewrites its own safety net proves nothing | 2026-08-25 |
+| Every argv assertion in the test suite is preserved verbatim. A note assertion may change only for one of the *Accepted behaviour deltas* below; any other diff to the safety net fails review | The tests are this refactor's safety net; a refactor that silently rewrites its own safety net proves nothing | 2026-08-25 |
 | Genuinely open decisions: **none**. Every fork this phase raises is answered in the rows above, resolved from `docs/prior-art.md`, `docs/constitution.md` or `docs/architecture.md` | Recorded so the acceptance gate is a deliberate "nothing was guessed", not an omission | 2026-08-25 |
 
 ### Accepted behaviour deltas
 
-These three are the complete set of intended differences from `main`. Each ships
+These four are the complete set of intended differences from `main`. Each ships
 with the test that pins it.
 
 1. **The attachment/unknown-stream note gains the codec.** Today it reads
@@ -155,7 +155,12 @@ with the test that pins it.
    becomes what `D2` in `docs/design/stream-decision.md` renders for this case —
    `audio stream 1 (opus) dropped: WAV holds 1 audio stream` — which names the
    stream that was actually lost and its codec. The rung's argv is unchanged.
-3. **A WAV source carrying a non-audio stream gains a rung on the failure path.**
+3. **WAV's fallback rung is labelled `selective` instead of `first-audio-stream`.**
+   Not visible on a successful conversion — the label only surfaces in the
+   per-rung error line `batch.py` builds when every rung failed, so a WAV file
+   that fails outright now reports `[selective] ...` where `main` reports
+   `[first-audio-stream] ...`.
+4. **A WAV source carrying a non-audio stream gains a rung on the failure path.**
    An `.opus` with embedded cover art currently produces no retry at all; it now
    reaches a selective rung that drops the cover-art stream with a note. The rung
    is only ever built after the cheap attempt has already failed, and its argv is
@@ -192,6 +197,10 @@ Machine checks — Verify is the per-iteration gate (`docs/workflow.md`):
       attempt's own two notes (lossy re-encode; 10-bit/HDR reduced to 8-bit).
 - [ ] A test asserting WAV's PCM conversion emits **no** note — the one re-encode
       that is not a degradation.
+- [ ] A test per failure-path delta, since the QA gate cannot reach them: the
+      engine-built rung is labelled `selective` for WAV too (delta 3), and a WAV
+      source carrying a non-audio stream yields exactly one rung that drops it
+      with a note (delta 4).
 - [ ] `git diff main -- converter/cli.py converter/batch.py converter/paths.py`
       is empty.
 - [ ] No function in `converter/jobs.py` or `converter/profiles.py` exceeds 50
@@ -208,7 +217,7 @@ not create the directory itself:
 New-Item -ItemType Directory -Force in
 & $FF -f lavfi -i testsrc=size=320x240:rate=10:duration=2 -f lavfi -i sine=duration=2 -c:v libx264 -c:a aac in/clip.mkv
 & $FF -f lavfi -i testsrc=size=320x240:rate=10:duration=2 -c:v ffv1 in/lossless.mkv
-& $FF -f lavfi -i testsrc=size=320x240:rate=10:duration=2 -c:v libx264 -attach LICENSE -metadata:s:t mimetype=text/plain in/attached.mkv
+& $FF -f lavfi -i testsrc=size=320x240:rate=10:duration=2 -c:v libx264 -attach C:\Windows\Fonts\arial.ttf -metadata:s:t mimetype=application/x-truetype-font in/attached.mkv
 & $FF -f lavfi -i sine=duration=2 -c:a libopus in/tone.opus
 & $FF -f lavfi -i sine=frequency=440:duration=2 -f lavfi -i sine=frequency=880:duration=2 -map 0:a -map 1:a -c:a libopus in/two-tone.opus
 ```
@@ -226,13 +235,15 @@ why both audio fixtures use that suffix.
       `ffv1`, and the re-encode to h264.
 - [ ] A second run of each over the same output tree reports `0 converted`,
       `N skipped`, `0 failed`, exit 0.
-- [ ] Delta 1: `attached.mkv` converts and its attachment note names the codec,
-      which the same command on `main` omits.
+- [ ] Delta 1: `attached.mkv` converts and its attachment note names the font
+      codec (`ttf`), which the same command on `main` omits entirely.
 - [ ] Delta 2: `two-tone.opus` converts and names the dropped audio stream and
       its codec, where `main` reports the count instead.
-- [ ] Delta 3: an `.opus` carrying cover art reaches a selective rung on the
-      failure path only — no successful conversion above differs from `main`
-      beyond deltas 1 and 2.
+- [ ] Deltas 3 and 4 are **not QA-checkable**, by construction: both only surface
+      once an attempt has already failed, which no synthesised fixture triggers
+      reliably. They are covered by the machine checks instead. What this gate
+      does check is the negative — no successful conversion above differs from
+      `main` beyond deltas 1 and 2.
 
 ## Risks and mitigations
 

--- a/docs/specs/spec-profile-registry.md
+++ b/docs/specs/spec-profile-registry.md
@@ -4,42 +4,56 @@
 
 Turn the two hand-written conversion recipes in `converter/jobs.py` into one
 generic, profile-driven engine, and move every format-specific fact into a new
-leaf module `converter/profiles.py` — with the observable ffmpeg behaviour of
-MKV -> MP4 and Opus -> WAV unchanged. This spec carries no lifecycle state —
-acceptance is the spec merged on the default branch with a milestone and issues,
-and all progress lives in the GitHub issues and milestone. A completed spec is
-moved to `docs/specs/archive/`.
+leaf module `converter/profiles.py` — with the ffmpeg argv unchanged and the
+notes changed only where today's wording omits a fact the vision requires. This
+spec carries no lifecycle state — acceptance is the spec merged on the default
+branch with a milestone and issues, and all progress lives in the GitHub issues
+and milestone. A completed spec is moved to `docs/specs/archive/`.
 
 ## Outcome
 
 - [ ] `converter/profiles.py` exists, imports nothing from `converter`, and holds
       the value types plus exactly two profile entries: MP4 and WAV.
-- [ ] `converter/jobs.py` contains no format-specific constant, codec name or
-      note string: it builds the attempt ladder from a profile plus a probed
-      stream list, and from nothing else.
+- [ ] `converter/jobs.py` holds no ffmpeg knowledge of a target format — no codec
+      name, no container option, no degradation-note wording. The one exception is
+      the `JOB_BINDINGS` table described in Prior decisions, which is CLI wiring,
+      is marked as such in the module, and disappears in phase 2.
 - [ ] `converter/cli.py`, `converter/batch.py` and `converter/paths.py` have an
       empty diff for this phase.
-- [ ] For every input the test suite covers, the argv reaching ffmpeg and the
-      notes reaching the user are the same as before the change, or differ only
-      in a way that is ffmpeg-equivalent and listed in the PR body.
-- [ ] Both profiles have a test pinning the exact argv they build, for a
-      copyable and for a non-copyable input (`docs/constitution.md`).
+- [ ] Every argv the test suite pins is produced byte-for-byte by the new engine.
+      The three note and rung changes listed under *Accepted behaviour deltas* are
+      the complete set of behaviour differences; anything else is a defect.
+- [ ] Both profiles have a test pinning the exact argv they build, for the
+      copyable and the non-copyable case each profile actually has
+      (`docs/constitution.md`; see Verification for WAV, whose copy mask is empty).
 - [ ] `converter --version`, `converter video ...` and `converter audio ...`
       behave exactly as they do on `main`; no user-visible CLI surface changed.
+- [ ] `docs/architecture.md`, `docs/design.md` and `docs/roadmap.md` describe the
+      shape this phase actually builds — amended in this spec's own PR, not left
+      to the implementer.
 
 ## Scope
 
 ### In scope
 
 - The new leaf module `converter/profiles.py`: the profile and per-stream-rule
-  value types, the `flags()` recipe helper moved into it, and the MP4 and WAV
-  profile entries.
+  value types, the `Attempt` value type, the `flags()` recipe helper moved into
+  it, and the MP4 and WAV profile entries.
 - Rewriting the ladder in `converter/jobs.py` as a generic engine over a profile,
   per `docs/design/degradation-ladder.md` and `docs/design/stream-decision.md`.
 - Keeping `Job` and `JOBS` in place with an unchanged public shape, so `cli.py`
   and `batch.py` need no diff.
-- Porting the existing `tests/test_argv.py` recipe tests onto the new API and
-  adding the constitution's per-profile argv-pinning tests.
+- Porting the safety net onto the new API: `tests/test_argv.py` (the recipe
+  tests) and `tests/test_batch.py` (which imports `MKV_TO_MP4` / `OPUS_TO_WAV`
+  and pins the `remux` and `selective` rung labels), plus the constitution's
+  per-profile argv-pinning tests.
+- Removing the `_mp4_selective` row from the tech-debt table in
+  `docs/constitution.md` once the function is gone.
+- Foundation-doc amendments, already made in this spec's PR:
+  `docs/architecture.md` (the profile owns its declared attempts; the last rung
+  is optional; an accepted stream may be transcoded in kind; a stream limit is a
+  drop reason), `docs/design.md` (a generic engine draws the per-stream branch
+  once), `docs/roadmap.md` (what "identical behaviour" means here).
 
 ### Out of scope
 
@@ -58,7 +72,8 @@ moved to `docs/specs/archive/`.
 - `converter/profiles.py` must be a **leaf**: no `converter.*` import at all
   (`docs/architecture.md`). This is what makes "a target format is data, not
   code" structurally enforceable — a module that cannot import anything cannot
-  hold logic. It is why `flags()` has to move rather than be imported.
+  hold logic. It is why `flags()` and `Attempt` have to move rather than be
+  imported.
 - `jobs.py` may import `profiles` and `ffmpegtool`, and nothing else. The import
   graph stays acyclic.
 - `ffprobe` never runs on the happy path (`docs/constitution.md`): the engine
@@ -90,12 +105,13 @@ moved to `docs/specs/archive/`.
 ## Design
 
 - `docs/design/degradation-ladder.md` — the order of attempts, where a subprocess
-  is spent, and the two conditions under which the selective rung is skipped.
-- `docs/design/stream-decision.md` — copy / re-encode / drop for one stream, and
-  what each resulting note must name.
+  is spent, when the selective rung is skipped, and where container options land.
+- `docs/design/stream-decision.md` — accept / re-encode / drop for one stream,
+  what each resulting note must name, and the order options are emitted in.
 
 Both are part of this spec package and are reviewed at the spec-acceptance gate.
-Implement against them; do not restate them in an issue.
+Implement against them; the mechanism lives there and is referenced, not repeated,
+from this file.
 
 ## Human prerequisites
 
@@ -107,16 +123,41 @@ Implement against them; do not restate them in an issue.
 
 | Decision | Rationale | Date |
 |---|---|---|
-| A profile is a frozen dataclass holding a display label, the target suffix, container-wide options, a cheap first attempt, an optional last-resort attempt, and one rule per stream type | HandBrake's copy-mask + encoder-fallback vocabulary as data per target (`docs/prior-art.md`), expressed in the value-type style the constitution already requires | 2026-08-25 |
-| A stream rule holds: the copy mask (a `frozenset` of codec names), the option template emitted for an accepted stream, an optional fallback-encoder option template, the human-readable name of what that encoder produces, an optional limit on how many streams of the type the container holds, and the reason a stream is dropped when there is no fallback | Covers every branch the two existing recipes take, including MP4's subtitle case where an accepted stream is not literally copied but transcoded to `mov_text` | 2026-08-25 |
+| A profile is a frozen dataclass holding a display label, the target suffix, container-wide options, a declared cheap attempt, a flag saying whether that cheap attempt selects streams explicitly, an optional declared last-resort attempt, and one rule per stream type | HandBrake's copy-mask + encoder-fallback vocabulary as data per target (`docs/prior-art.md`), expressed in the value-type style the constitution already requires | 2026-08-25 |
+| A stream rule holds: the copy mask (a `frozenset` of codec names, possibly empty), the option template emitted for an accepted stream, an optional fallback-encoder option template, the human-readable name of what that encoder produces or `None` when the re-encode gives up nothing worth naming, an optional limit on how many streams of the type the container holds, and the reason a stream is dropped when there is no fallback | Covers every branch the two existing recipes take, including MP4's subtitle case where an accepted stream is transcoded to `mov_text` rather than copied, and WAV's case where nothing is copyable and the PCM conversion is the point of the format rather than a loss | 2026-08-25 |
+| WAV's audio rule has an **empty** copy mask, a `pcm_s16le` fallback, and **no** re-encode note; its stream limit is 1. WAV declares no rule for any other stream type | Reproduces today's output exactly: `wav_pcm()` emits no note, and a second audio stream is dropped with one. An empty mask is a legitimate value — a container may accept nothing as-is | 2026-08-25 |
 | Positional output specifiers are written into the option template as a literal `{n}` placeholder, e.g. `flags("-c:v:{n} libx264 -crf:v:{n} 18")`, and the engine replaces every `{n}` with the per-type output position | Keeps the `flags("...")` convention — the template still reads like the command line you would type — and avoids the engine guessing which flags take a stream specifier (`-preset` does not) | 2026-08-25 |
-| The cheap first attempt and the last-resort attempt are **declared per profile as data**, not derived by the engine | `docs/architecture.md`: a new target format must be one profile entry and nothing else. A derived last rung would need MP4's `-pix_fmt yuv420p` and WAV's absence of a video rung to live as branching in `jobs.py`, i.e. format knowledge in the engine. Declaring them also guarantees the two existing argv strings survive byte-for-byte | 2026-08-25 |
-| The selective rung is suppressed when nothing survives the profile's rules, or when its plan keeps the same streams with the same codecs as the first attempt and sacrifices nothing | Reproduces today's `wav_retries([single audio]) == []` without a special case, and stops a profile whose first attempt already maps explicitly from paying for a duplicate ffmpeg run. Drawn in `docs/design/degradation-ladder.md` | 2026-08-25 |
-| `Job` keeps its public shape (`name`, `description`, `suffixes`, `target_suffix`, `first_attempt`, `retries`) and `JOBS` keeps its keys; both are built from a profile by a factory in `jobs.py` | Delivers the "empty diff in `cli.py` and `batch.py`" outcome, and leaves phase 2 a natural seam: the CLI will build a `Job` from a profile chosen by `--to` | 2026-08-25 |
+| The cheap attempt and the last-resort attempt are **declared per profile as data**, not derived by the engine | `docs/architecture.md`: a new target format must be one profile entry and nothing else. A derived last rung would need MP4's `-pix_fmt yuv420p` and WAV's absence of a video rung to live as branching in `jobs.py`, i.e. format knowledge in the engine. Declaring them also guarantees the two existing argv strings survive byte-for-byte | 2026-08-25 |
+| Container-wide options are declared once on the profile and appended by the engine, exactly once, at the **end** of every attempt — including the declared ones, whose data therefore excludes them | Today `+faststart` is the tail of all three MP4 attempts. Appending centrally keeps that argv and stops a profile from repeating the flag; drawn in `docs/design/degradation-ladder.md` | 2026-08-25 |
+| The engine-built rung emits **all `-map` pairs first in stream order, then all codec options in the same order, then the container options** | `tests/test_argv.py` pins exactly this grouping; per-stream interleaving would be equally valid ffmpeg and a different argv. Drawn in `docs/design/stream-decision.md` | 2026-08-25 |
+| The selective rung is emitted per `docs/design/degradation-ladder.md`; the one datum the engine cannot derive — whether the cheap attempt already selects streams explicitly — is declared by the profile (MP4: no, WAV: yes) | The alternative, comparing the plan against the cheap attempt, would require the engine to parse ffmpeg option syntax, putting CLI knowledge back into `jobs.py`. With the flag, MP4 keeps its rung for `[h264]` and WAV keeps returning no rung for a single audio stream — both existing tests hold | 2026-08-25 |
+| The engine-built rung is labelled `"selective"` for every profile; the declared attempts keep their current labels (`remux`, `pcm_s16le`, `re-encode`). WAV's `first-audio-stream` label disappears | `tests/test_batch.py` pins `remux` and `selective`; nothing pins `first-audio-stream`. One label for one engine-built rung is what makes the label meaningful across 17 formats | 2026-08-25 |
+| A note's `<target>` is the profile's **display label** (`MP4`, `WAV`); a stream whose `codec_name` ffprobe leaves empty reads as `unknown` | Both reproduce today's strings in `converter/jobs.py` | 2026-08-25 |
+| `Attempt` moves to `profiles.py` and `jobs.py` imports it; `jobs.py` does **not** re-export it | A profile declares attempts, so the type must sit in the leaf. One import path per type, so a test cannot accidentally pin the wrong one | 2026-08-25 |
+| `Job` keeps its public shape (`name`, `description`, `suffixes`, `target_suffix`, `first_attempt`, `retries`) and `JOBS` keeps its keys. The source-pair data behind them — sub-command name, description, source suffixes, target profile — lives in one `JOB_BINDINGS` table in `jobs.py`, explicitly exempted from the no-format-knowledge outcome and marked in the module as phase-2 scaffolding | Delivers the empty diff in `cli.py` and `batch.py`. The data is a *source-pair* binding, not target-format knowledge, so putting it on the profile would contaminate the value type phase 2 consumes by target alone | 2026-08-25 |
 | `flags()` moves from `jobs.py` to `profiles.py`; `jobs.py` imports it from there | `profiles.py` writes the recipes and may not import `jobs`; duplicating the function instead would be two definitions of one convention | 2026-08-25 |
-| Existing argv assertions in `tests/test_argv.py` are preserved verbatim wherever the new engine produces the same string; an assertion may only change when the new value is ffmpeg-equivalent (e.g. `-c:a` vs `-c:a:0` for a container that holds one audio stream) or when a note is re-worded, and every such change is listed in the PR body with its justification | The tests are this refactor's safety net; a refactor that silently rewrites its own safety net proves nothing. Re-worded notes still have to name the stream index, the stream's codec and what was given up (`docs/vision.md`) | 2026-08-25 |
 | The module-level recipe functions `mp4_remux`, `mp4_retries`, `wav_pcm`, `wav_retries` may disappear | They are internal — nothing outside `jobs.py` and its tests imports them, and the README documents no Python API | 2026-08-25 |
-| Genuinely open decisions: **none**. Every question this phase raises was settled by `docs/prior-art.md`, `docs/constitution.md` or `docs/architecture.md` | Recorded so the acceptance gate is a deliberate "nothing was guessed", not an omission | 2026-08-25 |
+| Every argv assertion in the test suite is preserved verbatim. A note assertion may change only for one of the three *Accepted behaviour deltas* below; any other diff to the safety net fails review | The tests are this refactor's safety net; a refactor that silently rewrites its own safety net proves nothing | 2026-08-25 |
+| Genuinely open decisions: **none**. Every fork this phase raises is answered in the rows above, resolved from `docs/prior-art.md`, `docs/constitution.md` or `docs/architecture.md` | Recorded so the acceptance gate is a deliberate "nothing was guessed", not an omission | 2026-08-25 |
+
+### Accepted behaviour deltas
+
+These three are the complete set of intended differences from `main`. Each ships
+with the test that pins it.
+
+1. **The attachment/unknown-stream note gains the codec.** Today it reads
+   `attachment stream 1 dropped: not supported by MP4`, omitting the codec —
+   which `docs/vision.md` requires every degradation note to name. It becomes
+   `attachment stream 1 (ttf) dropped: not supported by MP4`.
+2. **The surplus-audio-stream note is re-worded per stream instead of per file.**
+   Today: `2 audio streams present; kept stream 0 only (WAV holds one)`. It
+   becomes `audio stream 1 (opus) dropped: WAV holds 1 audio stream`, which names
+   the stream that was actually lost and its codec.
+3. **A WAV source carrying a non-audio stream gains a rung on the failure path.**
+   An `.opus` with embedded cover art currently produces no retry at all; it now
+   reaches a selective rung that drops the cover-art stream with a note. The rung
+   is only ever built after the cheap attempt has already failed, and its argv is
+   equivalent to the cheap attempt's, so no successful conversion changes.
 
 ## Tracking
 
@@ -136,40 +177,59 @@ Machine checks — Verify is the per-iteration gate (`docs/workflow.md`):
 - [ ] Verify passes (ruff check, ruff format --check, pytest) on the merge commit.
 - [ ] A test asserting `converter/profiles.py` contains no `from converter` or
       `import converter` statement — the leaf rule, checked rather than trusted.
-- [ ] A test pinning the full argv for MP4 with a copyable input (h264 + aac) and
-      with a non-copyable one (vp8 + pcm_s16le), and the same pair for WAV.
+- [ ] A test pinning the full argv MP4 builds for a copyable input
+      (h264 + aac) and for a non-copyable one (vp8 + pcm_s16le).
+- [ ] A test pinning the full argv WAV builds for a single-audio source and for a
+      two-audio source. WAV has no copyable case to pin — its copy mask is empty
+      by construction, so these are the two cases the constitution's rule can
+      have here, and the reason is recorded in Prior decisions.
 - [ ] A test per degradation branch asserting its note names the stream index,
       that stream's codec, and what was given up: audio re-encoded, video
       re-encoded, bitmap subtitle dropped, attachment dropped, surplus audio
-      stream dropped.
+      stream dropped, non-audio stream dropped by WAV, and the last-resort
+      attempt's own two notes (lossy re-encode; 10-bit/HDR reduced to 8-bit).
+- [ ] A test asserting WAV's PCM conversion emits **no** note — the one re-encode
+      that is not a degradation.
 - [ ] `git diff main -- converter/cli.py converter/batch.py converter/paths.py`
       is empty.
 - [ ] No function in `converter/jobs.py` or `converter/profiles.py` exceeds 50
-      lines, clearing the `_mp4_selective` tech-debt row in
+      lines, and the `_mp4_selective` row is gone from the tech-debt table in
       `docs/constitution.md`.
 
 Human milestone-QA gate — the machine checks stub the subprocess boundary and so
-prove nothing about a real conversion (`docs/workflow.md`). Run with the absolute
-ffmpeg paths from *This machine*:
+prove nothing about a real conversion (`docs/workflow.md`). The repository ships
+no media fixtures; synthesise them first, with the absolute ffmpeg path from
+*This machine*:
 
-- [ ] `converter video <dir> <out>` converts a real `.mkv` to a playable `.mp4`,
-      reporting `1 converted, 0 skipped, 0 failed`.
-- [ ] `converter audio <dir> <out>` converts a real `.opus` to a playable `.wav`.
-- [ ] A second run over the same output tree reports `0 converted`, `N skipped`,
-      `0 failed`, exit 0.
-- [ ] A source that forces the ladder down a rung (an MKV carrying a codec MP4
-      cannot hold) still converts, and prints a note naming what it gave up.
-- [ ] The `docs/constitution.md` tech-debt table has its `_mp4_selective` row
-      removed as part of this phase.
+```text
+ffmpeg -f lavfi -i testsrc=size=320x240:rate=10:duration=2 \
+       -f lavfi -i sine=duration=2 -c:v libx264 -c:a aac  in/clip.mkv
+ffmpeg -f lavfi -i sine=duration=2 -c:a libopus            in/tone.opus
+ffmpeg -f lavfi -i testsrc=size=320x240:rate=10:duration=2 \
+       -c:v ffv1                                           in/lossless.mkv
+```
+
+`ffv1` is the ladder-forcing case: MP4 cannot hold it, so the remux fails and the
+selective rung has to re-encode the video.
+
+- [ ] `converter video in out` converts `clip.mkv` to a playable `.mp4` and
+      reports `1 converted, 0 skipped, 0 failed`, exit 0.
+- [ ] `converter audio in out` converts `tone.opus` to a playable `.wav`.
+- [ ] `converter video in out` over `lossless.mkv` still converts, and prints a
+      note naming the stream index, `ffv1`, and the re-encode to h264.
+- [ ] A second run of each over the same output tree reports `0 converted`,
+      `N skipped`, `0 failed`, exit 0.
+- [ ] The three *Accepted behaviour deltas* are the only differences a human can
+      observe against the same commands run on `main`.
 
 ## Risks and mitigations
 
 | Risk | Mitigation |
 |---|---|
-| The generic engine silently changes an argv and the change is only found once a real file converts wrongly | The per-profile argv-pinning tests are written against the strings `main` produces today, before the engine is rewritten; any diff has to be argued in the PR body |
+| The generic engine silently changes an argv and the change is only found once a real file converts wrongly | The per-profile argv-pinning tests are written against the strings `main` produces today, before the engine is rewritten; the accepted-deltas list is closed, so any other diff fails review |
 | The profile value type is shaped around only two formats and needs breaking changes in phases 3-5 | Accepted deliberately: the roadmap sequences phase 1 before the coverage phases so the model is validated cheaply on audio first. Phases 3-5 may extend the value type; they may not push format knowledge back into `jobs.py` |
-| `Job` kept as an adapter becomes dead weight after phase 2 | It is one factory call; phase 2 removes or rewrites it as part of the breaking change it already ships |
-| Note wording drifts and a degradation stops naming what it cost | Every degradation branch ships with a test asserting its note (`docs/constitution.md`), listed in Verification above |
+| `JOB_BINDINGS` and the `Job` adapter become dead weight after phase 2 | Both are marked in the module as phase-2 scaffolding; phase 2 removes them as part of the breaking change it already ships |
+| Note wording drifts and a degradation stops naming what it cost | Every degradation branch ships with a test asserting its note (`docs/constitution.md`), enumerated in Verification above |
 | A refactor that also "tidies" `cli.py` or `batch.py` would break the empty-diff outcome | The empty-diff check is a Verification item, so it fails the gate rather than being noticed in review |
 
 ## Decision log
@@ -177,6 +237,16 @@ ffmpeg paths from *This machine*:
 - 2026-08-25: Two design diagrams rather than one — `degradation-ladder.md`
   decides the order of attempts, `stream-decision.md` decides one stream's fate.
   `docs/design.md` requires one decision per diagram.
-- 2026-08-25: The diagrams deliberately use conceptual labels ("the rule's copy
-  mask") rather than field names, so a rename during implementation does not rot
-  the design artifact.
+- 2026-08-25: The diagrams use conceptual labels ("the rule's copy mask") and
+  brace-free placeholders (`TARGET`, `TARGET_CODEC`, `DROP_REASON`) rather than
+  field names or angle brackets — a rename must not rot the artifact, and Mermaid
+  renders quoted node text as HTML, so `<target>` would vanish from the rendered
+  diagram at the review gate.
+- 2026-08-25: Spec review found that comparing the selective plan against the
+  cheap attempt is not computable from declared data without parsing ffmpeg
+  option syntax. Replaced by a declared flag on the profile; both existing
+  suppression behaviours were re-checked against `tests/test_argv.py`.
+- 2026-08-25: Spec review found `docs/architecture.md` describing a ladder this
+  phase does not build (a mandatory last rung, copy-only acceptance, two drop
+  reasons). Amended here rather than left to drift, since architecture is the
+  living doc this phase alters.

--- a/docs/specs/spec-profile-registry.md
+++ b/docs/specs/spec-profile-registry.md
@@ -1,0 +1,182 @@
+# Spec: profile-registry (roadmap phase 1)
+
+> Created: 2026-08-25
+
+Turn the two hand-written conversion recipes in `converter/jobs.py` into one
+generic, profile-driven engine, and move every format-specific fact into a new
+leaf module `converter/profiles.py` — with the observable ffmpeg behaviour of
+MKV -> MP4 and Opus -> WAV unchanged. This spec carries no lifecycle state —
+acceptance is the spec merged on the default branch with a milestone and issues,
+and all progress lives in the GitHub issues and milestone. A completed spec is
+moved to `docs/specs/archive/`.
+
+## Outcome
+
+- [ ] `converter/profiles.py` exists, imports nothing from `converter`, and holds
+      the value types plus exactly two profile entries: MP4 and WAV.
+- [ ] `converter/jobs.py` contains no format-specific constant, codec name or
+      note string: it builds the attempt ladder from a profile plus a probed
+      stream list, and from nothing else.
+- [ ] `converter/cli.py`, `converter/batch.py` and `converter/paths.py` have an
+      empty diff for this phase.
+- [ ] For every input the test suite covers, the argv reaching ffmpeg and the
+      notes reaching the user are the same as before the change, or differ only
+      in a way that is ffmpeg-equivalent and listed in the PR body.
+- [ ] Both profiles have a test pinning the exact argv they build, for a
+      copyable and for a non-copyable input (`docs/constitution.md`).
+- [ ] `converter --version`, `converter video ...` and `converter audio ...`
+      behave exactly as they do on `main`; no user-visible CLI surface changed.
+
+## Scope
+
+### In scope
+
+- The new leaf module `converter/profiles.py`: the profile and per-stream-rule
+  value types, the `flags()` recipe helper moved into it, and the MP4 and WAV
+  profile entries.
+- Rewriting the ladder in `converter/jobs.py` as a generic engine over a profile,
+  per `docs/design/degradation-ladder.md` and `docs/design/stream-decision.md`.
+- Keeping `Job` and `JOBS` in place with an unchanged public shape, so `cli.py`
+  and `batch.py` need no diff.
+- Porting the existing `tests/test_argv.py` recipe tests onto the new API and
+  adding the constitution's per-profile argv-pinning tests.
+
+### Out of scope
+
+- Any new target format. Phase 1 re-expresses the two that exist; `mp3`, `mkv`,
+  `png` and the rest are phases 3-5.
+- Any CLI change — `--to`, `--list-formats` and the reworked prompt are phase 2.
+  The `video` / `audio` sub-commands stay exactly as they are here.
+- Runtime-editable profiles (a TOML or JSON registry). `docs/architecture.md`
+  rules this out: profiles are declarative Python so they keep type checking and
+  ruff's view of the code.
+- Verifying at runtime that the installed ffmpeg build actually has a muxer
+  (`ffmpeg -formats`). Useful later, not needed for two formats that already work.
+
+## Constraints
+
+- `converter/profiles.py` must be a **leaf**: no `converter.*` import at all
+  (`docs/architecture.md`). This is what makes "a target format is data, not
+  code" structurally enforceable — a module that cannot import anything cannot
+  hold logic. It is why `flags()` has to move rather than be imported.
+- `jobs.py` may import `profiles` and `ffmpegtool`, and nothing else. The import
+  graph stays acyclic.
+- `ffprobe` never runs on the happy path (`docs/constitution.md`): the engine
+  probes at most once per file, and only after an attempt has already failed.
+- Maximum 50 lines per function, every parameter and return annotated, a
+  docstring on every module and public function (`docs/constitution.md`).
+  `_mp4_selective` is 51 lines today and is listed as tech debt to be cleared by
+  this phase's replacement.
+- ffmpeg options are written through `flags("...")` so a recipe reads like the
+  command line you would type (`docs/constitution.md`).
+- No `-map 0`: it selects attachments and data streams MP4 cannot hold.
+- The test suite must keep passing on a machine with no ffmpeg installed — the
+  subprocess boundary stays stubbed at `ffmpegtool.run()`.
+
+## Prior art
+
+- [Container/codec capability modelling (Phase 1)](../prior-art.md#containercodec-capability-modelling-phase-1)
+  — the whole concern feeds this phase. HandBrake's `AudioCopyMask` plus
+  `AudioEncoderFallback` is the vocabulary the profile value type adopts; the
+  ffmpeg-CLI entry is why the copy mask is curated by hand instead of discovered;
+  this codebase's own entry is why trial-and-fallback survives the refactor while
+  its per-pair ladders do not.
+- [Python wrapper structure around the ffmpeg CLI (Phase 3, Phase 4)](../prior-art.md#python-wrapper-structure-around-the-ffmpeg-cli-phase-3-phase-4)
+  — secondary: `ffmpeg-normalize`'s split into stream types, a command builder and
+  dedicated exceptions independently matches the layering this phase keeps, and
+  its AVOID note (never scrape ffmpeg's stderr to drive a second pass) is exactly
+  the temptation a fallback ladder creates.
+
+## Design
+
+- `docs/design/degradation-ladder.md` — the order of attempts, where a subprocess
+  is spent, and the two conditions under which the selective rung is skipped.
+- `docs/design/stream-decision.md` — copy / re-encode / drop for one stream, and
+  what each resulting note must name.
+
+Both are part of this spec package and are reviewed at the spec-acceptance gate.
+Implement against them; do not restate them in an issue.
+
+## Human prerequisites
+
+- none. This phase adds no dependency, touches no secret, and needs no external
+  provisioning. ffmpeg is only needed for the milestone-QA smoke test, and it is
+  already installed on this machine (`docs/workflow.md`, *This machine*).
+
+## Prior decisions
+
+| Decision | Rationale | Date |
+|---|---|---|
+| A profile is a frozen dataclass holding a display label, the target suffix, container-wide options, a cheap first attempt, an optional last-resort attempt, and one rule per stream type | HandBrake's copy-mask + encoder-fallback vocabulary as data per target (`docs/prior-art.md`), expressed in the value-type style the constitution already requires | 2026-08-25 |
+| A stream rule holds: the copy mask (a `frozenset` of codec names), the option template emitted for an accepted stream, an optional fallback-encoder option template, the human-readable name of what that encoder produces, an optional limit on how many streams of the type the container holds, and the reason a stream is dropped when there is no fallback | Covers every branch the two existing recipes take, including MP4's subtitle case where an accepted stream is not literally copied but transcoded to `mov_text` | 2026-08-25 |
+| Positional output specifiers are written into the option template as a literal `{n}` placeholder, e.g. `flags("-c:v:{n} libx264 -crf:v:{n} 18")`, and the engine replaces every `{n}` with the per-type output position | Keeps the `flags("...")` convention — the template still reads like the command line you would type — and avoids the engine guessing which flags take a stream specifier (`-preset` does not) | 2026-08-25 |
+| The cheap first attempt and the last-resort attempt are **declared per profile as data**, not derived by the engine | `docs/architecture.md`: a new target format must be one profile entry and nothing else. A derived last rung would need MP4's `-pix_fmt yuv420p` and WAV's absence of a video rung to live as branching in `jobs.py`, i.e. format knowledge in the engine. Declaring them also guarantees the two existing argv strings survive byte-for-byte | 2026-08-25 |
+| The selective rung is suppressed when nothing survives the profile's rules, or when its plan keeps the same streams with the same codecs as the first attempt and sacrifices nothing | Reproduces today's `wav_retries([single audio]) == []` without a special case, and stops a profile whose first attempt already maps explicitly from paying for a duplicate ffmpeg run. Drawn in `docs/design/degradation-ladder.md` | 2026-08-25 |
+| `Job` keeps its public shape (`name`, `description`, `suffixes`, `target_suffix`, `first_attempt`, `retries`) and `JOBS` keeps its keys; both are built from a profile by a factory in `jobs.py` | Delivers the "empty diff in `cli.py` and `batch.py`" outcome, and leaves phase 2 a natural seam: the CLI will build a `Job` from a profile chosen by `--to` | 2026-08-25 |
+| `flags()` moves from `jobs.py` to `profiles.py`; `jobs.py` imports it from there | `profiles.py` writes the recipes and may not import `jobs`; duplicating the function instead would be two definitions of one convention | 2026-08-25 |
+| Existing argv assertions in `tests/test_argv.py` are preserved verbatim wherever the new engine produces the same string; an assertion may only change when the new value is ffmpeg-equivalent (e.g. `-c:a` vs `-c:a:0` for a container that holds one audio stream) or when a note is re-worded, and every such change is listed in the PR body with its justification | The tests are this refactor's safety net; a refactor that silently rewrites its own safety net proves nothing. Re-worded notes still have to name the stream index, the stream's codec and what was given up (`docs/vision.md`) | 2026-08-25 |
+| The module-level recipe functions `mp4_remux`, `mp4_retries`, `wav_pcm`, `wav_retries` may disappear | They are internal — nothing outside `jobs.py` and its tests imports them, and the README documents no Python API | 2026-08-25 |
+| Genuinely open decisions: **none**. Every question this phase raises was settled by `docs/prior-art.md`, `docs/constitution.md` or `docs/architecture.md` | Recorded so the acceptance gate is a deliberate "nothing was guessed", not an omission | 2026-08-25 |
+
+## Tracking
+
+The decomposition into steps lives as GitHub issues, not in this file — one
+issue per step, grouped under a milestone. This spec owns the design; the issues
+own progress. Do not duplicate the step list here.
+
+- Milestone: profile-registry (created at the spec-acceptance gate)
+- Issues: created from this spec once it is merged (one per implementable step)
+
+Each issue references this spec path in its body.
+
+## Verification
+
+Machine checks — Verify is the per-iteration gate (`docs/workflow.md`):
+
+- [ ] Verify passes (ruff check, ruff format --check, pytest) on the merge commit.
+- [ ] A test asserting `converter/profiles.py` contains no `from converter` or
+      `import converter` statement — the leaf rule, checked rather than trusted.
+- [ ] A test pinning the full argv for MP4 with a copyable input (h264 + aac) and
+      with a non-copyable one (vp8 + pcm_s16le), and the same pair for WAV.
+- [ ] A test per degradation branch asserting its note names the stream index,
+      that stream's codec, and what was given up: audio re-encoded, video
+      re-encoded, bitmap subtitle dropped, attachment dropped, surplus audio
+      stream dropped.
+- [ ] `git diff main -- converter/cli.py converter/batch.py converter/paths.py`
+      is empty.
+- [ ] No function in `converter/jobs.py` or `converter/profiles.py` exceeds 50
+      lines, clearing the `_mp4_selective` tech-debt row in
+      `docs/constitution.md`.
+
+Human milestone-QA gate — the machine checks stub the subprocess boundary and so
+prove nothing about a real conversion (`docs/workflow.md`). Run with the absolute
+ffmpeg paths from *This machine*:
+
+- [ ] `converter video <dir> <out>` converts a real `.mkv` to a playable `.mp4`,
+      reporting `1 converted, 0 skipped, 0 failed`.
+- [ ] `converter audio <dir> <out>` converts a real `.opus` to a playable `.wav`.
+- [ ] A second run over the same output tree reports `0 converted`, `N skipped`,
+      `0 failed`, exit 0.
+- [ ] A source that forces the ladder down a rung (an MKV carrying a codec MP4
+      cannot hold) still converts, and prints a note naming what it gave up.
+- [ ] The `docs/constitution.md` tech-debt table has its `_mp4_selective` row
+      removed as part of this phase.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| The generic engine silently changes an argv and the change is only found once a real file converts wrongly | The per-profile argv-pinning tests are written against the strings `main` produces today, before the engine is rewritten; any diff has to be argued in the PR body |
+| The profile value type is shaped around only two formats and needs breaking changes in phases 3-5 | Accepted deliberately: the roadmap sequences phase 1 before the coverage phases so the model is validated cheaply on audio first. Phases 3-5 may extend the value type; they may not push format knowledge back into `jobs.py` |
+| `Job` kept as an adapter becomes dead weight after phase 2 | It is one factory call; phase 2 removes or rewrites it as part of the breaking change it already ships |
+| Note wording drifts and a degradation stops naming what it cost | Every degradation branch ships with a test asserting its note (`docs/constitution.md`), listed in Verification above |
+| A refactor that also "tidies" `cli.py` or `batch.py` would break the empty-diff outcome | The empty-diff check is a Verification item, so it fails the gate rather than being noticed in review |
+
+## Decision log
+
+- 2026-08-25: Two design diagrams rather than one — `degradation-ladder.md`
+  decides the order of attempts, `stream-decision.md` decides one stream's fate.
+  `docs/design.md` requires one decision per diagram.
+- 2026-08-25: The diagrams deliberately use conceptual labels ("the rule's copy
+  mask") rather than field names, so a rename during implementation does not rot
+  the design artifact.

--- a/docs/specs/spec-profile-registry.md
+++ b/docs/specs/spec-profile-registry.md
@@ -172,7 +172,7 @@ The decomposition into steps lives as GitHub issues, not in this file — one
 issue per step, grouped under a milestone. This spec owns the design; the issues
 own progress. Do not duplicate the step list here.
 
-- Milestone: profile-registry (created at the spec-acceptance gate)
+- Milestone: [profile-registry](https://github.com/bhemsen/converter/milestone/1) (#1)
 - Issues: created from this spec once it is merged (one per implementable step)
 
 Each issue references this spec path in its body.


### PR DESCRIPTION
Roadmap phase 1 — the planning package for `profile-registry`.

- `docs/specs/spec-profile-registry.md` — the spec: turn the two hand-written recipes into one profile-driven engine, with the observable ffmpeg behaviour of MKV -> MP4 and Opus -> WAV unchanged.
- `docs/design/degradation-ladder.md` — the attempt order, where a subprocess is spent, and when the selective rung is skipped.
- `docs/design/stream-decision.md` — copy / re-encode / drop for one stream, and what each note must name.

No source change. The milestone, its issues and the roadmap link follow at the spec-acceptance gate.
