### PR TITLE
docs(spec): target-format-driven CLI (roadmap phase 2)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,8 +22,8 @@ Everything else exists today.
 
 The internal import graph is acyclic today and must stay that way:
 `ffmpegtool`, `paths` and `profiles` are leaves, `jobs` depends on `ffmpegtool` +
-`profiles`, `batch` depends on `jobs` + `ffmpegtool` + `paths`, `cli` depends on
-all of them, `__main__` depends only on `cli`.
+`profiles`, `batch` depends on `jobs` + `ffmpegtool` + `paths` + `profiles`,
+`cli` depends on all of them, `__main__` depends only on `cli`.
 
 - `converter/profiles.py` must be a **leaf**: no internal imports at all. This is
   what makes the constitution's "a target format is data, not code" structurally
@@ -33,6 +33,10 @@ all of them, `__main__` depends only on `cli`.
   (encoder tuning is an explicit non-goal), so a data file would buy a parser and
   a schema validator while giving up type checking and ruff's view of the code.
 - `jobs.py` may import `profiles` and `ffmpegtool`, and nothing else.
+- `batch.py` imports `profiles` only for the type it is handed: it carries a
+  profile from `cli.py` to the engine and reads the label for its progress bar,
+  and asks `jobs.py` for every attempt. A profile field read for a *conversion*
+  decision in `batch.py` is format knowledge in the wrong module.
 - Nothing below `cli.py` may import `cli`.
 - `paths.py` knows nothing about ffmpeg, and `ffmpegtool.py` knows nothing about
   batches, jobs or profiles. Both are reusable in isolation, and both are tested
@@ -42,10 +46,12 @@ all of them, `__main__` depends only on `cli`.
 
 ## Key flows
 
-1. **Happy path.** `cli` resolves the output root, `paths.find_sources` collects
+1. **Happy path.** `cli` resolves the target profile and the output root,
+   `paths.find_sources` collects
    the inputs, `paths.find_collisions` refuses up front if two inputs would write
    to the same output, then `batch.run_batch` runs the profile's cheapest attempt
-   per file. On success nothing else happens — no ffprobe round-trip is ever spent.
+   per file through the engine in `jobs.py`. On success nothing else happens — no
+   ffprobe round-trip is ever spent.
 2. **Degradation.** The attempt exits non-zero, so *now* `ffmpegtool.probe_streams`
    describes the file. The engine matches each stream against the profile's copy
    mask: streams the mask accepts pass through unchanged — as a literal `copy`, or

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,8 +47,7 @@ The internal import graph is acyclic today and must stay that way:
 ## Key flows
 
 1. **Happy path.** `cli` resolves the target profile and the output root,
-   `paths.find_sources` collects
-   the inputs, `paths.find_collisions` refuses up front if two inputs would write
+   `paths.find_sources` collects the inputs, `paths.find_collisions` refuses up front if two inputs would write
    to the same output, then `batch.run_batch` runs the profile's cheapest attempt
    per file through the engine in `jobs.py`. On success nothing else happens — no
    ffprobe round-trip is ever spent.
@@ -66,8 +65,8 @@ The internal import graph is acyclic today and must stay that way:
    `docs/design/degradation-ladder.md` and `docs/design/stream-decision.md`.
 3. **Idempotent re-run.** An output that already exists and no `--overwrite` makes
    the file `skipped` without starting a process, so a second run over a finished
-   tree does no work. A source whose output path would be its own input path is
-   `skipped` too — reported rather than passed over in silence, and counted, per
+   tree does no work for the files it already converted. A source whose output
+   path would be its own input path is `skipped` too — reported rather than passed over in silence, and counted, per
    `docs/design/source-selection.md`.
 4. **Failure.** The partially written output is removed, the file is recorded as
    `failed` with ffmpeg's stderr, the batch keeps going for every other file, and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,8 +47,8 @@ The internal import graph is acyclic today and must stay that way:
 ## Key flows
 
 1. **Happy path.** `cli` resolves the target profile and the output root,
-   `paths.find_sources` collects the inputs, `paths.find_collisions` refuses up front if two inputs would write
-   to the same output, then `batch.run_batch` runs the profile's cheapest attempt
+   `paths.find_sources` collects the inputs, `paths.find_collisions` refuses up
+   front if two inputs would write to the same output, then `batch.run_batch` runs the profile's cheapest attempt
    per file through the engine in `jobs.py`. On success nothing else happens — no
    ffprobe round-trip is ever spent.
 2. **Degradation.** The attempt exits non-zero, so *now* `ffmpegtool.probe_streams`
@@ -66,8 +66,8 @@ The internal import graph is acyclic today and must stay that way:
 3. **Idempotent re-run.** An output that already exists and no `--overwrite` makes
    the file `skipped` without starting a process, so a second run over a finished
    tree does no work for the files it already converted. A source whose output
-   path would be its own input path is `skipped` too — reported rather than passed over in silence, and counted, per
-   `docs/design/source-selection.md`.
+   path would be its own input path is `skipped` too — reported rather than passed
+   over in silence, and counted, per `docs/design/source-selection.md`.
 4. **Failure.** The partially written output is removed, the file is recorded as
    `failed` with ffmpeg's stderr, the batch keeps going for every other file, and
    the process exits 1 at the end.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,7 +66,9 @@ The internal import graph is acyclic today and must stay that way:
    `docs/design/degradation-ladder.md` and `docs/design/stream-decision.md`.
 3. **Idempotent re-run.** An output that already exists and no `--overwrite` makes
    the file `skipped` without starting a process, so a second run over a finished
-   tree does no work.
+   tree does no work. A source whose output path would be its own input path is
+   `skipped` too — reported rather than passed over in silence, and counted, per
+   `docs/design/source-selection.md`.
 4. **Failure.** The partially written output is removed, the file is recorded as
    `failed` with ffmpeg's stderr, the batch keeps going for every other file, and
    the process exits 1 at the end.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,9 +48,9 @@ The internal import graph is acyclic today and must stay that way:
 
 1. **Happy path.** `cli` resolves the target profile and the output root,
    `paths.find_sources` collects the inputs, `paths.find_collisions` refuses up
-   front if two inputs would write to the same output, then `batch.run_batch` runs the profile's cheapest attempt
-   per file through the engine in `jobs.py`. On success nothing else happens — no
-   ffprobe round-trip is ever spent.
+   front if two inputs would write to the same output, then `batch.run_batch`
+   runs the profile's cheapest attempt per file through the engine in `jobs.py`.
+   On success nothing else happens — no ffprobe round-trip is ever spent.
 2. **Degradation.** The attempt exits non-zero, so *now* `ffmpegtool.probe_streams`
    describes the file. The engine matches each stream against the profile's copy
    mask: streams the mask accepts pass through unchanged — as a literal `copy`, or

--- a/docs/design/source-selection.md
+++ b/docs/design/source-selection.md
@@ -2,41 +2,38 @@
 
 > Design artifact (`docs/design.md`, `kind: concept`). The third diagram, next to
 > `degradation-ladder.md` (the order of attempts) and `stream-decision.md` (one
-> stream's fate). This one decides which files under the input root become tasks
-> at all — the question `--to <format>` creates and every coverage phase re-opens
-> by adding suffixes to the set.
->
-> Declared deviation from `docs/design.md`'s per-stream convention: this is not a
-> per-stream decision, so it follows the *attempt ladder* rules instead — every
-> edge labelled with its condition, and the one node that costs a subprocess
-> marked.
+> stream's fate). This is the batch-item state flow `docs/design.md` names as the
+> secondary decision a diagram may settle — extended one step upstream, to the
+> question `--to <format>` creates: which files become items at all. Every
+> coverage phase reopens it by adding suffixes to the set.
 
 ## The decision this settles
 
 Given an input root and a target format, which files are converted, which are
-refused before any process starts, and which are silently not candidates at all.
-Nothing here spends a subprocess call: selection is finished before ffmpeg is
-ever located.
+refused before any process starts, and which are never candidates. **No node in
+this diagram spends a subprocess call** — that is the point of drawing it:
+selection is complete before ffmpeg is even located, which is what lets
+`--dry-run` and a collision refusal work on a machine with no ffmpeg installed.
 
 ```mermaid
 flowchart TD
     F["file under the input root<br/>(recursive only with -r)"]
     MEDIA{"is its suffix in the registry's<br/>source-suffix set?"}
-    SAME{"is its suffix the target's own suffix?"}
     OUT["derive the output path:<br/>mirror the tree, swap the suffix"]
+    SELF{"does the output path resolve to<br/>the input path itself?"}
     COLL{"does another input map to<br/>the same output path?"}
     EXISTS{"does the output already exist,<br/>and no --overwrite?"}
     TASK["task — handed to the ladder"]
-    SKIP["skipped — reported, exit 0"]
+    SKIP["skipped — counted and reported, exit 0"]
     NOTCAND["not a candidate — never counted, never reported"]
     REFUSE["the whole run is refused before any conversion<br/>(exit 2, every colliding pair printed)"]
 
     F --> MEDIA
     MEDIA -->|"no"| NOTCAND
-    MEDIA -->|"yes"| SAME
-    SAME -->|"yes"| NOTCAND
-    SAME -->|"no"| OUT
-    OUT --> COLL
+    MEDIA -->|"yes"| OUT
+    OUT --> SELF
+    SELF -->|"yes"| SKIP
+    SELF -->|"no"| COLL
     COLL -->|"yes"| REFUSE
     COLL -->|"no"| EXISTS
     EXISTS -->|"yes"| SKIP
@@ -45,24 +42,32 @@ flowchart TD
 
 ## Rules the diagram encodes
 
-- **A file that is not a media file is not a candidate**, not a failure. The
-  set of source suffixes is curated data in the profile registry, for the same
-  reason the copy mask is (`docs/prior-art.md`): ffmpeg can be asked what it
-  contains, never what it will accept. A tree full of `.txt` and `.nfo` produces
-  no work and no noise.
-- **A file already in the target format is not a candidate either.** Its output
-  path would be its own input path, which is not a conversion — and under
-  `--overwrite` it would be ffmpeg reading and writing one file at once. This is
-  the rule that makes `--to <format>` safe to point at a mixed tree.
+- **A file that is not a media file is not a candidate**, not a failure. The set
+  of source suffixes is curated data in the profile registry, for the same reason
+  the copy mask is (`docs/prior-art.md`): ffmpeg can be asked what it contains,
+  never what it will accept. A tree full of `.txt` and `.nfo` produces no work and
+  no noise.
+- **The self-write guard is about the path, not the suffix.** A source is excluded
+  only when its derived output path *is* its input path — comparing with the same
+  case-folding the collision check uses, because Windows would otherwise let
+  `A.MP4` and `a.mp4` be two names for one file. Excluding every file that merely
+  shares the target's suffix would be wrong: with a separate output root,
+  `In\a.mp4` -> `Out\a.mp4` is a legitimate remux, and dropping it would leave the
+  output tree quietly incomplete.
+- **A self-write is reported, never silently dropped.** It leaves the run as a
+  counted `skipped` with a reason, because a file the user pointed at and did not
+  get is exactly what `docs/constitution.md` forbids passing over in silence.
 - **Collisions are refused for the whole run, never per file.** Two sources that
-  differ only in suffix (`ep1.mkv`, `ep1.avi`) map to one output. Refusing up
-  front (exit 2) keeps the run from converting half a tree and then discovering
-  the conflict — the existing behaviour, unchanged by the target-driven CLI, and
-  the reason it now matters more: one target draws in far more sources than one
-  format pair did.
-- **Skipped is a reported outcome; not-a-candidate is not.** A file that was
-  already converted is counted in the summary, because "0 converted, 12 skipped"
-  is the idempotent-re-run evidence the vision promises. A `.txt` is not counted,
-  because a count of everything the directory happens to hold means nothing.
-- **Selection completes before ffmpeg is located.** `--dry-run` therefore works
-  on a machine with no ffmpeg installed, and a collision is reported without one.
+  differ only in suffix (`ep1.mkv`, `ep1.avi`) map to one output. Refusing up front
+  keeps the run from converting half a tree and then discovering the conflict —
+  existing behaviour, and it matters more now that one target draws in many more
+  sources than one format pair did.
+- **Skipped is a reported outcome; not-a-candidate is not.** An already-converted
+  file is counted, because `0 converted, 12 skipped` is the idempotent-re-run
+  evidence the vision promises. A `.txt` is not, because counting everything a
+  directory happens to hold means nothing.
+- **Selection cannot tell whether a source can *produce* the target.** Whether a
+  video-only file has audio to put in a WAV is only knowable from a probe, and a
+  probe on the happy path is forbidden. That question therefore belongs to the
+  ladder, not here — see `degradation-ladder.md` and the spec that owns the
+  outcome it ends in.

--- a/docs/design/source-selection.md
+++ b/docs/design/source-selection.md
@@ -1,0 +1,68 @@
+# Source selection
+
+> Design artifact (`docs/design.md`, `kind: concept`). The third diagram, next to
+> `degradation-ladder.md` (the order of attempts) and `stream-decision.md` (one
+> stream's fate). This one decides which files under the input root become tasks
+> at all — the question `--to <format>` creates and every coverage phase re-opens
+> by adding suffixes to the set.
+>
+> Declared deviation from `docs/design.md`'s per-stream convention: this is not a
+> per-stream decision, so it follows the *attempt ladder* rules instead — every
+> edge labelled with its condition, and the one node that costs a subprocess
+> marked.
+
+## The decision this settles
+
+Given an input root and a target format, which files are converted, which are
+refused before any process starts, and which are silently not candidates at all.
+Nothing here spends a subprocess call: selection is finished before ffmpeg is
+ever located.
+
+```mermaid
+flowchart TD
+    F["file under the input root<br/>(recursive only with -r)"]
+    MEDIA{"is its suffix in the registry's<br/>source-suffix set?"}
+    SAME{"is its suffix the target's own suffix?"}
+    OUT["derive the output path:<br/>mirror the tree, swap the suffix"]
+    COLL{"does another input map to<br/>the same output path?"}
+    EXISTS{"does the output already exist,<br/>and no --overwrite?"}
+    TASK["task — handed to the ladder"]
+    SKIP["skipped — reported, exit 0"]
+    NOTCAND["not a candidate — never counted, never reported"]
+    REFUSE["the whole run is refused before any conversion<br/>(exit 2, every colliding pair printed)"]
+
+    F --> MEDIA
+    MEDIA -->|"no"| NOTCAND
+    MEDIA -->|"yes"| SAME
+    SAME -->|"yes"| NOTCAND
+    SAME -->|"no"| OUT
+    OUT --> COLL
+    COLL -->|"yes"| REFUSE
+    COLL -->|"no"| EXISTS
+    EXISTS -->|"yes"| SKIP
+    EXISTS -->|"no"| TASK
+```
+
+## Rules the diagram encodes
+
+- **A file that is not a media file is not a candidate**, not a failure. The
+  set of source suffixes is curated data in the profile registry, for the same
+  reason the copy mask is (`docs/prior-art.md`): ffmpeg can be asked what it
+  contains, never what it will accept. A tree full of `.txt` and `.nfo` produces
+  no work and no noise.
+- **A file already in the target format is not a candidate either.** Its output
+  path would be its own input path, which is not a conversion — and under
+  `--overwrite` it would be ffmpeg reading and writing one file at once. This is
+  the rule that makes `--to <format>` safe to point at a mixed tree.
+- **Collisions are refused for the whole run, never per file.** Two sources that
+  differ only in suffix (`ep1.mkv`, `ep1.avi`) map to one output. Refusing up
+  front (exit 2) keeps the run from converting half a tree and then discovering
+  the conflict — the existing behaviour, unchanged by the target-driven CLI, and
+  the reason it now matters more: one target draws in far more sources than one
+  format pair did.
+- **Skipped is a reported outcome; not-a-candidate is not.** A file that was
+  already converted is counted in the summary, because "0 converted, 12 skipped"
+  is the idempotent-re-run evidence the vision promises. A `.txt` is not counted,
+  because a count of everything the directory happens to hold means nothing.
+- **Selection completes before ffmpeg is located.** `--dry-run` therefore works
+  on a machine with no ffmpeg installed, and a collision is reported without one.

--- a/docs/design/source-selection.md
+++ b/docs/design/source-selection.md
@@ -19,23 +19,29 @@ selection is complete before ffmpeg is even located, which is what lets
 flowchart TD
     F["file under the input root<br/>(recursive only with -r)"]
     MEDIA{"is its suffix in the registry's<br/>source-suffix set?"}
+    OWN{"does it lie under the output root,<br/>which is not the input root itself?"}
     OUT["derive the output path:<br/>mirror the tree, swap the suffix"]
-    SELF{"does the output path resolve to<br/>the input path itself?"}
-    COLL{"does another input map to<br/>the same output path?"}
+    SELF{"does the output path resolve to<br/>this file's own input path?"}
+    COLL{"does another non-self-writing source<br/>map to the same output path?"}
+    HAZ{"--overwrite, and this output path is<br/>another selected source's input path?"}
     EXISTS{"does the output already exist,<br/>and no --overwrite?"}
     TASK["task — handed to the ladder"]
     SKIP["skipped — counted and reported, exit 0"]
     NOTCAND["not a candidate — never counted, never reported"]
-    REFUSE["the whole run is refused before any conversion<br/>(exit 2, every colliding pair printed)"]
+    REFUSE["the whole run is refused before any conversion<br/>(exit 2, every offending pair printed)"]
 
     F --> MEDIA
     MEDIA -->|"no"| NOTCAND
-    MEDIA -->|"yes"| OUT
-    OUT --> COLL
-    COLL -->|"yes"| REFUSE
-    COLL -->|"no"| SELF
+    MEDIA -->|"yes"| OWN
+    OWN -->|"yes"| NOTCAND
+    OWN -->|"no"| OUT
+    OUT --> SELF
     SELF -->|"yes"| SKIP
-    SELF -->|"no"| EXISTS
+    SELF -->|"no"| COLL
+    COLL -->|"yes"| REFUSE
+    COLL -->|"no"| HAZ
+    HAZ -->|"yes"| REFUSE
+    HAZ -->|"no"| EXISTS
     EXISTS -->|"yes"| SKIP
     EXISTS -->|"no"| TASK
 ```
@@ -47,37 +53,52 @@ flowchart TD
   the copy mask is (`docs/prior-art.md`): ffmpeg can be asked what it contains,
   never what it will accept. A tree full of `.txt` and `.nfo` produces no work and
   no noise.
+- **The tool's own output tree is not an input.** A nested output root
+  (`--to mp4 -r D:\Media D:\Media\converted`) is the natural invocation, and
+  without this rule it never converges: run 2 would find `converted\a.mp4`, write
+  `converted\converted\a.mp4`, and every run would add one more generation while
+  reporting `1 converted`. Excluding what lies under the output root is what makes
+  a re-run reach `0 converted`. The exception is an output root that resolves to
+  the input root itself — there everything would be excluded, and the self-write
+  rule below is the one that answers the question instead.
 - **The self-write guard is about the path, not the suffix.** A source is excluded
   only when its derived output path *is* its input path. Both sides are resolved
   before they are compared, and then compared case-folded — unlike
   `paths.find_collisions`, which case-folds the paths **as given**. The difference
-  is load-bearing here: `--mirror-to` derives the output root from a resolved
-  input path while discovery returns paths built from the root as typed, so
-  comparing as given would miss the self-write entirely. Excluding every file that
-  merely shares the target's suffix would be wrong in the other direction: with a
-  separate output root, `In\a.mp4` -> `Out\a.mp4` is a legitimate remux, and
-  dropping it would leave the output tree quietly incomplete.
-- **A self-write is reported, never silently dropped.** It leaves the run as a
-  counted `skipped` with a reason, because a file the user pointed at and did not
-  get is exactly what `docs/constitution.md` forbids passing over in silence.
-- **A self-writing source takes part in the collision check, and the check runs
-  first.** Otherwise `a.mkv` and `a.mp4` in one directory, converting to `mp4` in
-  place, would report `a.mp4` as skipped and then destroy it in the same run under
-  `--overwrite` — a file named as kept and then deleted. Two sources claiming one
-  output is a conflict whether or not one of them is already sitting at that path,
-  so it refuses the run like any other collision, and the message is what tells
-  the user to pick a different output directory.
+  is load-bearing: `--mirror-to` derives the output root from a resolved input
+  path while discovery returns paths built from the root as typed, so comparing as
+  given would miss the self-write. The guard resolves the output path the same way
+  the write will see it; note that a bare-drive `OUTPUT` (`converter --to mp4 IN
+  E:`) is drive-relative by construction, so it resolves against the current
+  directory on `E:` — `--mirror-to E:` is the spelling that normalises it, which is
+  what `paths.mirror_to_drive`'s docstring exists to explain.
+- Excluding every file that merely shares the target's suffix would be wrong in
+  the other direction: with a separate output root, `In\a.mp4` -> `Out\a.mp4` is a
+  legitimate remux, and dropping it would leave the output tree quietly incomplete.
+- **A self-write is reported, never silently dropped**, and it does **not** refuse
+  the run. It leaves the run as a counted `skipped` with a reason, because a file
+  the user pointed at and did not get is exactly what `docs/constitution.md`
+  forbids passing over in silence — and because converting a tree in place must
+  stay idempotent: `--to mp4 IN IN` over an already-converted directory reports
+  `0 converted, N skipped`, exit 0, which `docs/vision.md` requires.
 - **Collisions are refused for the whole run, never per file.** Two sources that
   differ only in suffix (`ep1.mkv`, `ep1.avi`) map to one output. Refusing up front
   keeps the run from converting half a tree and then discovering the conflict —
   existing behaviour, and it matters more now that one target draws in many more
-  sources than one format pair did.
+  sources than one format pair did. A self-writing source is not counted here: it
+  produces no conversion, so it cannot contend for its own path.
+- **The destructive case is `--overwrite`, and only that.** With `IN` as its own
+  output and both `a.mkv` and `a.mp4` present, `a.mp4` is skipped as a self-write
+  and `a.mkv` wants to write over it. Without `--overwrite` nothing happens —
+  `a.mkv` sees an existing output and is skipped too. With `--overwrite` the run
+  would report a file as kept and then destroy it, so the run is refused up front
+  and names both files. Refusing only under `--overwrite` is what keeps the
+  harmless in-place re-run from exiting 2.
 - **Skipped is a reported outcome; not-a-candidate is not.** An already-converted
   file is counted, because `0 converted, 12 skipped` is the idempotent-re-run
-  evidence the vision promises. A `.txt` is not, because counting everything a
-  directory happens to hold means nothing.
+  evidence the vision promises. A `.txt`, or a file inside the output tree, is not,
+  because counting everything a directory happens to hold means nothing.
 - **Selection cannot tell whether a source can *produce* the target.** Whether a
   video-only file has audio to put in a WAV is only knowable from a probe, and a
-  probe on the happy path is forbidden. That question therefore belongs to the
-  ladder, not here — see `degradation-ladder.md` and the spec that owns the
-  outcome it ends in.
+  probe on the happy path is forbidden. That question belongs to the ladder, not
+  here — see `degradation-ladder.md` and the spec that owns the outcome it ends in.

--- a/docs/design/source-selection.md
+++ b/docs/design/source-selection.md
@@ -31,11 +31,11 @@ flowchart TD
     F --> MEDIA
     MEDIA -->|"no"| NOTCAND
     MEDIA -->|"yes"| OUT
-    OUT --> SELF
-    SELF -->|"yes"| SKIP
-    SELF -->|"no"| COLL
+    OUT --> COLL
     COLL -->|"yes"| REFUSE
-    COLL -->|"no"| EXISTS
+    COLL -->|"no"| SELF
+    SELF -->|"yes"| SKIP
+    SELF -->|"no"| EXISTS
     EXISTS -->|"yes"| SKIP
     EXISTS -->|"no"| TASK
 ```
@@ -48,15 +48,25 @@ flowchart TD
   never what it will accept. A tree full of `.txt` and `.nfo` produces no work and
   no noise.
 - **The self-write guard is about the path, not the suffix.** A source is excluded
-  only when its derived output path *is* its input path — comparing with the same
-  case-folding the collision check uses, because Windows would otherwise let
-  `A.MP4` and `a.mp4` be two names for one file. Excluding every file that merely
-  shares the target's suffix would be wrong: with a separate output root,
-  `In\a.mp4` -> `Out\a.mp4` is a legitimate remux, and dropping it would leave the
-  output tree quietly incomplete.
+  only when its derived output path *is* its input path. Both sides are resolved
+  before they are compared, and then compared case-folded — unlike
+  `paths.find_collisions`, which case-folds the paths **as given**. The difference
+  is load-bearing here: `--mirror-to` derives the output root from a resolved
+  input path while discovery returns paths built from the root as typed, so
+  comparing as given would miss the self-write entirely. Excluding every file that
+  merely shares the target's suffix would be wrong in the other direction: with a
+  separate output root, `In\a.mp4` -> `Out\a.mp4` is a legitimate remux, and
+  dropping it would leave the output tree quietly incomplete.
 - **A self-write is reported, never silently dropped.** It leaves the run as a
   counted `skipped` with a reason, because a file the user pointed at and did not
   get is exactly what `docs/constitution.md` forbids passing over in silence.
+- **A self-writing source takes part in the collision check, and the check runs
+  first.** Otherwise `a.mkv` and `a.mp4` in one directory, converting to `mp4` in
+  place, would report `a.mp4` as skipped and then destroy it in the same run under
+  `--overwrite` — a file named as kept and then deleted. Two sources claiming one
+  output is a conflict whether or not one of them is already sitting at that path,
+  so it refuses the run like any other collision, and the message is what tells
+  the user to pick a different output directory.
 - **Collisions are refused for the whole run, never per file.** Two sources that
   differ only in suffix (`ep1.mkv`, `ep1.avi`) map to one output. Refusing up front
   keeps the run from converting half a tree and then discovering the conflict —

--- a/docs/design/source-selection.md
+++ b/docs/design/source-selection.md
@@ -19,7 +19,7 @@ selection is complete before ffmpeg is even located, which is what lets
 flowchart TD
     F["file under the input root<br/>(recursive only with -r)"]
     MEDIA{"is its suffix in the registry's<br/>source-suffix set?"}
-    OWN{"does it lie under the output root,<br/>which is not the input root itself?"}
+    OWN{"is the output root a strict descendant of<br/>the input root, and does this file lie under it?"}
     OUT["derive the output path:<br/>mirror the tree, swap the suffix"]
     SELF{"does the output path resolve to<br/>this file's own input path?"}
     COLL{"does another non-self-writing source<br/>map to the same output path?"}
@@ -53,14 +53,19 @@ flowchart TD
   the copy mask is (`docs/prior-art.md`): ffmpeg can be asked what it contains,
   never what it will accept. A tree full of `.txt` and `.nfo` produces no work and
   no noise.
-- **The tool's own output tree is not an input.** A nested output root
-  (`--to mp4 -r D:\Media D:\Media\converted`) is the natural invocation, and
-  without this rule it never converges: run 2 would find `converted\a.mp4`, write
-  `converted\converted\a.mp4`, and every run would add one more generation while
-  reporting `1 converted`. Excluding what lies under the output root is what makes
-  a re-run reach `0 converted`. The exception is an output root that resolves to
-  the input root itself — there everything would be excluded, and the self-write
-  rule below is the one that answers the question instead.
+- **The tool's own output tree is not an input — but only when it really is
+  nested.** A nested output root (`--to mp4 -r D:\Media D:\Media\converted`) is
+  the natural invocation, and without this rule it never converges: run 2 would
+  find `converted\a.mp4`, write `converted\converted\a.mp4`, and every run would
+  add one more generation while reporting `1 converted`. The rule fires only when
+  the output root is a **strict descendant** of the input root, because that is
+  the only shape where the walk can reach its own output. An output root that is
+  a *sibling*, on another drive, or an *ancestor* of the input root is already
+  outside the walked tree: `--to mp4 -r D:\Media\Season1 D:\Media` writes one
+  level up, run 2 walks only `Season1` and never sees it. Testing "lies under the
+  output root" alone would exclude every candidate there and report a successful
+  run that did nothing. "Strict" is also what keeps output-root-equals-input-root
+  out of this rule, leaving it to the self-write guard below.
 - **The self-write guard is about the path, not the suffix.** A source is excluded
   only when its derived output path *is* its input path. Both sides are resolved
   before they are compared, and then compared case-folded — unlike
@@ -94,6 +99,21 @@ flowchart TD
   would report a file as kept and then destroy it, so the run is refused up front
   and names both files. Refusing only under `--overwrite` is what keeps the
   harmless in-place re-run from exiting 2.
+- **`COLL` and `HAZ` are whole-set passes, not per-file questions.** The diagram
+  draws them in the per-file flow for readability, but neither can be answered
+  while visiting one file: both need the full candidate list first, the two-pass
+  shape `paths.find_collisions` already has. Their memberships differ, and the
+  difference is what makes `HAZ` work at all:
+  - `COLL` looks at the outputs of sources that will actually convert — **self-
+    writing sources are excluded**, since they produce no conversion and cannot
+    contend for a path. It compares paths **as given**, like `find_collisions`
+    does today.
+  - `HAZ` looks at the input paths of **every selected source, self-writers
+    included** — the motivating case is precisely a self-writer, `a.mp4`, being
+    overwritten by `a.mkv`. Reading "selected" as "reached `TASK`" would build a
+    guard that never fires for the case it exists for. Like `SELF`, it compares an
+    output path against an input path, so it **resolves both sides** before
+    comparing; comparing as given would miss the hazard under `--mirror-to`.
 - **Skipped is a reported outcome; not-a-candidate is not.** An already-converted
   file is counted, because `0 converted, 12 skipped` is the idempotent-re-run
   evidence the vision promises. A `.txt`, or a file inside the output tree, is not,

--- a/docs/design/source-selection.md
+++ b/docs/design/source-selection.md
@@ -59,7 +59,10 @@ flowchart TD
   find `converted\a.mp4`, write `converted\converted\a.mp4`, and every run would
   add one more generation while reporting `1 converted`. The rule fires only when
   the output root is a **strict descendant** of the input root, because that is
-  the only shape where the walk can reach its own output. An output root that is
+  the only shape where the walk can reach its own output. Both roots are resolved
+  before the descendancy test, for the same reason the two guards below resolve:
+  `--mirror-to` derives the output root from a resolved input path while the input
+  root is whatever was typed, so comparing as given would test the wrong pair. An output root that is
   a *sibling*, on another drive, or an *ancestor* of the input root is already
   outside the walked tree: `--to mp4 -r D:\Media\Season1 D:\Media` writes one
   level up, run 2 walks only `Season1` and never sees it. Testing "lies under the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,7 +12,7 @@
 | Phase | Name | Spec | Milestone |
 |---|---|---|---|
 | 1 | profile-registry | [spec-profile-registry.md](specs/spec-profile-registry.md) | [#1](https://github.com/bhemsen/converter/milestone/1) |
-| 2 | target-driven-cli | [spec-target-driven-cli.md](specs/spec-target-driven-cli.md) | — |
+| 2 | target-driven-cli | [spec-target-driven-cli.md](specs/spec-target-driven-cli.md) | [#2](https://github.com/bhemsen/converter/milestone/2) |
 | 3 | audio-formats | — | — |
 | 4 | video-formats | — | — |
 | 5 | image-formats | — | — |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,7 +12,7 @@
 | Phase | Name | Spec | Milestone |
 |---|---|---|---|
 | 1 | profile-registry | [spec-profile-registry.md](specs/spec-profile-registry.md) | [#1](https://github.com/bhemsen/converter/milestone/1) |
-| 2 | target-driven-cli | — | — |
+| 2 | target-driven-cli | [spec-target-driven-cli.md](specs/spec-target-driven-cli.md) | — |
 | 3 | audio-formats | — | — |
 | 4 | video-formats | — | — |
 | 5 | image-formats | — | — |

--- a/docs/specs/spec-target-driven-cli.md
+++ b/docs/specs/spec-target-driven-cli.md
@@ -17,7 +17,8 @@ milestone. A completed spec is moved to `docs/specs/archive/`.
       sub-commands had (`-r`, `-j`, `--overwrite`, `--dry-run`, `-q`,
       `--mirror-to`, `--ffmpeg`, `--ffprobe`) unchanged in name and meaning.
 - [ ] `converter video ...` and `converter audio ...` exit 2 with a message that
-      names the command to run instead.
+      says the sub-commands are gone, shows the `--to` shape, and points at
+      `--list-formats` — without naming a format (see the Prior decision).
 - [ ] `converter --list-formats` prints every target the registry holds and exits
       0 without resolving tools or touching the filesystem.
 - [ ] The interactive prompt (bare `converter`) offers the registry's targets and
@@ -27,7 +28,8 @@ milestone. A completed spec is moved to `docs/specs/archive/`.
 - [ ] Adding a target format still produces no diff in `cli.py`, `batch.py` or
       `paths.py` — the check phases 3-5 will actually run.
 - [ ] A source the target cannot produce at all resolves to the outcome decided
-      at the acceptance gate, and a mixed tree does not fail the run for it.
+      at the acceptance gate, and a mixed tree does not fail the run for it —
+      so a re-run over it still reports `0 converted, 0 failed`, exit 0.
 - [ ] `README.md` documents the `--to` CLI, carries the migration note, names
       `main` as the pull-request target, and no longer tells a reader to add a
       `Job` to `converter/jobs.py`.
@@ -42,8 +44,10 @@ milestone. A completed spec is moved to `docs/specs/archive/`.
 - `converter/cli.py`: the parser split, the `main()` routing, `--to`,
   `--list-formats`, the reworked prompt, and splitting `convert_command` under
   50 lines.
-- `converter/profiles.py`: a `name` and a one-line `description` on the profile
-  value type, lookup by target name, and the curated source-suffix set.
+- `converter/profiles.py`: a `PROFILES` mapping (target name -> profile) — the
+  registry itself, which the merged module does not yet have — plus a `name` and
+  a one-line `description` on the profile value type, lookup by that name, and
+  the curated source-suffix set.
 - `converter/batch.py`: taking a profile where it takes a `Job` today, the
   progress-bar description, and whatever the gate decides about a source the
   target cannot produce.
@@ -123,13 +127,16 @@ milestone. A completed spec is moved to `docs/specs/archive/`.
 | The convert parser's `--help` epilog names `converter mirror --help` and `--list-formats` | With `mirror` off the sub-parser list it would otherwise vanish from `--help`, which would be a discoverability regression nobody decided on | 2026-08-25 |
 | The profile value type gains a `name` (the `--to` token) and a one-line `description`. This **extends phase 1's value type**, whose field list did not include either | `--list-formats` and the prompt both need a human-readable line per target, and the text that serves that today lives in `JOB_BINDINGS`, which this phase deletes. Recorded as a visible change to phase 1's shape rather than a silent one | 2026-08-25 |
 | `Job`, `JOBS` and `JOB_BINDINGS` are deleted. `batch.run_batch` takes the profile, calls the engine through the entry points `jobs.first_attempt(profile)` and `jobs.retries(profile, streams)`, and takes the progress-bar description from the profile's label — so the bar reads `MP4` where it read `mkv-to-mp4` | They exist only to keep phase 1's diff out of `cli.py` and `batch.py`; phase 2 is the breaking change that was always going to remove them. The constitution's no-diff rule is about *adding a format*, which this is not. Naming the entry points here stops the implementer from inventing a third shape | 2026-08-25 |
+| The entry-point names above are **phase 2's to establish**: if phase 1's engine issue lands with different ones, phase 2 adopts those rather than renaming them. The wrapper around `profile.cheap_attempt` is not redundant — it is where `container_options` are placed per `docs/design/degradation-ladder.md`, and `batch.py` reading the field directly would be exactly the format knowledge the new architecture bullet forbids | The merged `Profile` stores `cheap_attempt` as a plain `Attempt` field rather than a callable, so the wrapper looks removable until you notice what it does | 2026-08-25 |
 | `docs/architecture.md`'s Boundaries gains the `batch` -> `profiles` edge, amended in this PR | `run_batch(profile, ...)` needs the type for its annotation, so the edge is real. Phase 1 set the precedent of amending architecture in the spec's own PR rather than letting it drift | 2026-08-25 |
 | A run that finds no candidates prints the ordinary summary line on stdout and a one-line hint on stderr, and exits 0 — it no longer prints `No .mkv files found` | The suffix set is now dozens of entries, so interpolating it is unreadable, and an error-channel message for an empty directory reads like a failure. `docs/vision.md` requires a re-run over a finished tree to *report* `0 converted, 0 failed`, which needs the summary to be printed | 2026-08-25 |
 | No version bump, no `CHANGELOG.md` entry, no tag in this phase | `docs/release.md` computes the version from the conventional commits in the range and has the human curate the changelog at the `/loopkit:ship` preview. A bump here would be recomputed and could disagree with the tag | 2026-08-25 |
 | The commit that removes the sub-commands is subject-marked `refactor!`, and the PR body carries the migration lines `converter video IN OUT` -> `converter --to mp4 IN OUT` and `converter audio IN OUT` -> `converter --to wav IN OUT` | `docs/release.md` derives the major bump from the `!` marker and requires a migration note in the breaking release's changelog entry; the text has to exist for `/ship` to curate | 2026-08-25 |
 | `--list-formats` prints one line per target — the name, the suffix it writes, and the description — sorted by name | It is the discoverability half of `--to`: a user who guessed a format name wrong needs the list without owning a valid input directory | 2026-08-25 |
 | The prompt lists the registry's targets numbered in the same sorted order `--list-formats` uses, with `mirror` as the last entry and the first target as the default. It also accepts a format name typed instead of a number | Keeps today's shape (a numbered menu with a default) while the list grows; typing the name is the escape hatch once 17 entries make counting silly. The prompt stays an argv builder, so the parser remains the single code path | 2026-08-25 |
-| OPEN — what happens to a source the target cannot produce at all (a video-only `.mkv` under `--to wav`), and whether this phase ships a `--from <suffix>` filter | resolved at the spec-acceptance gate; see the note below | — |
+| The legacy-token message is **generic**: it says the sub-commands are gone, shows `converter --to <format> IN OUT`, and points at `--list-formats`. The concrete `video` -> `--to mp4` and `audio` -> `--to wav` mapping lives in the README and in the PR body, not in `cli.py` | Naming `mp4` in `cli.py` would be the one string that defeats the `ast` check this phase installs to keep format names out of the CLI — and that check is what phases 3-5 rely on. A user who has just been told about `--list-formats` is one command from the answer | 2026-08-25 |
+| Routing runs on `raw` **after** the bare-invocation prompt has filled it, so a prompt that returns a `mirror` argv reaches the mirror parser. The `if not hasattr(args, "handler")` fallback in `main()` is removed — with explicit routing both parsers always set one | The prompt is an argv builder, so its output must travel the same path a typed argv does; that is the property the round-trip test exists to protect | 2026-08-25 |
+| OPEN — the `unsupported` outcome alone, or together with a `--from <suffix>` filter | resolved at the spec-acceptance gate; see the note below | — |
 
 ### The one open decision, in full
 
@@ -138,16 +145,29 @@ probe, and a probe on the happy path is forbidden. So under `--to wav`, a
 video-only `.mkv` is selected, its attempt fails, the probe finds no audio, the
 selective rung has no streams to map, WAV declares no last-resort rung — and the
 file lands as `failed`, exit 1. Pointing `--to wav` at any mixed tree therefore
-fails the run today. Three ways out, and the gate picks:
+fails the run today, and keeps failing on every re-run, which is the one thing
+`docs/vision.md`'s idempotent-re-run criterion forbids.
 
-1. **A `--from <suffix>` filter**, so the user narrows the sources by hand. Cheap,
-   explicit, and leaves the failure semantics untouched — but the default
-   invocation still fails on a mixed tree.
-2. **An `unsupported` outcome**: when the ladder ends with no rung that mapped a
-   single stream, the file is reported as unsupported with the reason rather than
-   as `failed`, and it does not set the exit code. Costs a new outcome in
-   `batch.py` and a line in every summary.
-3. **Both.**
+That criterion is why the phase needs an **`unsupported` outcome** either way: a
+file that cannot produce the target produces no output, so a re-run re-attempts
+it forever unless the run stops calling it a failure. Its discriminator is taken
+from the probe, never from ffmpeg's stderr (`docs/constitution.md`): the source
+carries no stream of any type the profile declares a rule for. A file that *does*
+carry usable streams and still fails is a genuine `failed` — the distinction
+matters, or a corrupt file would be quietly relabelled.
+
+The gate therefore picks between two answers, not three:
+
+1. **The `unsupported` outcome alone.** Costs a new outcome in `batch.py` and a
+   column in every summary line. A mixed tree converts what it can and reports
+   the rest by name.
+2. **The `unsupported` outcome plus a `--from <suffix>` filter**, so a user who
+   knows their tree can narrow it up front and never see the unsupported lines.
+   More surface, more tests, and a flag phases 3-5 must keep working.
+
+A `--from` filter *alone* was considered and dropped: it leaves the default
+invocation failing on a mixed tree, which contradicts this spec's own Outcome and
+the vision criterion above.
 
 ## Tracking
 
@@ -171,13 +191,23 @@ Machine checks:
       different output root **is** converted, a collision exits 2 before any
       conversion, an existing output is `skipped`, and `--dry-run` works with no
       ffmpeg resolvable.
+- [ ] A test that `a.mkv` and `a.mp4` in one directory, converting to `mp4` in
+      place, exits 2 — **with** `--overwrite` as well as without. This is the
+      case where reporting `a.mp4` as skipped and then overwriting it would
+      destroy a file the run said it kept.
+- [ ] A test that the self-write guard still fires under `--mirror-to`, where the
+      output root is derived from a resolved input path and the source paths are
+      not — the case a compare-as-given check would miss, and that an absolute
+      `tmp_path` in a test would hide.
 - [ ] A test that `--to MP4`, `--to mp4` and `--to .mp4` select the same profile,
       and that an unknown target exits 2 listing the available ones.
 - [ ] A test that `--list-formats` prints a line per registry entry and exits 0
       without resolving tools, and that it works with `--to` and `INPUT` absent.
 - [ ] A test that `converter --version` still exits 0 with `--to` required.
-- [ ] A test driving `prompt_for_argv` through the real convert parser, so the
-      prompt and the flags cannot drift apart, plus one for a typed format name.
+- [ ] A test driving `prompt_for_argv`'s output through the same routing function
+      a typed argv takes — not through one parser, since a prompted `mirror` argv
+      the convert parser cannot parse is exactly what this protects — plus one
+      for a typed format name.
 - [ ] A test that `converter mirror ...` is unaffected, and one that a run with
       no candidates prints the summary and exits 0.
 - [ ] A test that walks `converter/cli.py` and `converter/batch.py` with `ast`
@@ -238,3 +268,11 @@ reusing the fixtures the phase-1 gate synthesises:
 - 2026-08-25: Spec review found that a source the target cannot produce at all
   fails the whole run, which no decision covered. Promoted to the phase's one
   open decision, with `--from` folded into it as one of three answers.
+- 2026-08-25: Review round 2 found that reporting a self-writing source as
+  skipped and then letting another source overwrite it in the same run is a
+  file named as kept and then deleted. Self-writing sources now take part in the
+  collision check, which runs first and refuses the run.
+- 2026-08-25: Review round 2 found that a `--from` filter alone cannot satisfy
+  the idempotent-re-run criterion on a mixed tree, so it was demoted from an
+  answer to an optional addition, and the `unsupported` outcome became the part
+  the phase needs either way.

--- a/docs/specs/spec-target-driven-cli.md
+++ b/docs/specs/spec-target-driven-cli.md
@@ -1,0 +1,170 @@
+# Spec: target-driven-cli (roadmap phase 2)
+
+> Created: 2026-08-25
+
+Replace the `video` and `audio` sub-commands with `converter --to <format>`,
+driven by the profile registry phase 1 built — plus `--list-formats`, a prompt
+that offers the registry instead of two hard-wired pairs, and a README that
+documents what the tool now is. This is the project's breaking change. This spec
+carries no lifecycle state — acceptance is the spec merged on the default branch
+with a milestone and issues, and all progress lives in the GitHub issues and
+milestone. A completed spec is moved to `docs/specs/archive/`.
+
+## Outcome
+
+- [ ] `converter --to <format> INPUT [OUTPUT]` converts every source under
+      `INPUT` into `<format>`, mirroring the tree, with the flags the old
+      sub-commands had (`-r`, `-j`, `--overwrite`, `--dry-run`, `-q`,
+      `--mirror-to`, `--ffmpeg`, `--ffprobe`) unchanged in name and meaning.
+- [ ] `converter video ...` and `converter audio ...` are **gone** — the parser
+      rejects them with a usage error naming the replacement.
+- [ ] `converter --list-formats` prints every target the registry holds and the
+      suffix each writes, and exits 0 without touching the filesystem.
+- [ ] The interactive prompt (bare `converter`) offers the registry's targets and
+      the `mirror` command, built from the registry rather than a literal list.
+- [ ] `converter mirror ...` still works exactly as it does today.
+- [ ] Adding a target format still produces no diff in `cli.py`, `batch.py` or
+      `paths.py` — the check phases 3-5 will actually run.
+- [ ] `README.md` documents the `--to` CLI, carries a migration note from the old
+      sub-commands, and names `main` as the pull-request target.
+- [ ] Both README tech-debt rows are gone from `docs/constitution.md`: the
+      `develop` row, and the `convert_command` over-50-lines row.
+- [ ] No version bump and no changelog entry land in this phase.
+
+## Scope
+
+### In scope
+
+- `converter/cli.py`: the parser shape, `--to`, `--list-formats`, the reworked
+  prompt, the `mirror` routing, and splitting `convert_command` under 50 lines.
+- `converter/profiles.py`: looking a profile up by target name, and the curated
+  set of source suffixes discovery uses.
+- `converter/batch.py`: taking a profile where it takes a `Job` today, and
+  deleting `Job` / `JOBS` / `JOB_BINDINGS` with the sub-commands they served.
+- `README.md`, and the two tech-debt rows in `docs/constitution.md`.
+- Source selection per `docs/design/source-selection.md`.
+
+### Out of scope
+
+- New target formats. Phase 2 ships the two profiles that exist; `--list-formats`
+  will print two lines until phase 3.
+- The conversion ladder itself. Phase 1 owns it; nothing in this phase touches
+  `jobs.py` beyond removing the `Job` scaffolding.
+- The version bump to 3.0.0, the changelog and the release. `docs/release.md`
+  makes that `/loopkit:ship`'s job, computed from the `refactor!` commit this
+  phase lands — a version bumped here would be bumped twice.
+- A deprecation shim that keeps `video` / `audio` working. `docs/release.md`
+  already plans this phase as the breaking change with a migration note.
+
+## Constraints
+
+- A target format is data, not code: this phase must leave `cli.py` free of any
+  format name, so phases 3-5 can add one by touching only `profiles.py`
+  (`docs/constitution.md`, `docs/architecture.md`).
+- Maximum 50 lines per function — `convert_command` is 54 today and is listed as
+  tech debt this phase clears.
+- `paths.py` knows nothing about ffmpeg or profiles; discovery keeps taking a
+  suffix set as an argument rather than reaching into the registry.
+- Selection finishes before `resolve_tools` runs, so `--dry-run` and a collision
+  refusal keep working on a machine with no ffmpeg installed.
+- Windows is a first-class target: `--mirror-to E:` behaviour is unchanged.
+
+## Prior art
+
+- [Format-driven converter CLI (Phase 2)](../prior-art.md#format-driven-converter-cli-phase-2)
+  — the concern that feeds this phase. pandoc's readers-plus-writers is the direct
+  precedent for `--to` over per-pair sub-commands: N+M implementations instead of
+  N*M, with the ffprobe stream list as the reader and the target profile as the
+  writer. ImageMagick's ADOPT (infer the target from the output extension) is the
+  reason `--to` accepts `.mp4` as readily as `mp4`. The batch-conversion entry's
+  AVOID (the GUI-first shape) is what keeps the interactive prompt a thin argv
+  builder rather than a second code path.
+
+## Design
+
+- `docs/design/source-selection.md` — which files under the input root become
+  tasks, which are refused up front, and which are never candidates.
+- The ladder is unchanged: `docs/design/degradation-ladder.md` and
+  `docs/design/stream-decision.md` still describe what happens per file.
+
+## Human prerequisites
+
+- none. No secret, no dependency, no external provisioning.
+
+## Prior decisions
+
+| Decision | Rationale | Date |
+|---|---|---|
+| `--to` accepts a format name or a suffix, case-insensitively: `mp4`, `MP4` and `.mp4` all select the MP4 profile | ImageMagick's precedent is that the target is already written down as an extension (`docs/prior-art.md`); refusing the dotted form would be pedantry, and normalising is three lines in the registry lookup | 2026-08-25 |
+| An unknown target is a usage error (exit 2) whose message lists the available targets | The same shape as the existing `--jobs must be 1 or more`; a wrong format name is a typo, not a conversion failure | 2026-08-25 |
+| Discovery uses a curated **source-suffix set** declared in `converter/profiles.py`, and files whose suffix equals the target's own suffix are never candidates | Drawn in `docs/design/source-selection.md`. The suffix set is curated for the same reason the copy mask is; the same-suffix exclusion is what stops an output path from being its own input | 2026-08-25 |
+| `mirror` stays a sub-command. `main()` routes on the first token: a leading `mirror` goes to the mirror parser, anything else to the convert parser | argparse cannot hold both a positional `INPUT` on the top-level parser and a sub-command, since it would read `INPUT` as a command name. Two parsers behind one routing line is honest and testable; the alternative — turning `mirror` into a flag — would break a working command for no reason | 2026-08-25 |
+| `Job`, `JOBS` and `JOB_BINDINGS` are deleted. `batch.run_batch` takes the profile, and the progress bar's description comes from the profile's label | They exist only to keep phase 1's diff out of `cli.py` and `batch.py`; phase 2 is the breaking change that was always going to remove them. The constitution's no-diff rule is about *adding a format*, which this is not | 2026-08-25 |
+| No version bump, no `CHANGELOG.md` entry, no tag in this phase | `docs/release.md` computes the version from the conventional commits in the range and has the human curate the changelog at the `/loopkit:ship` preview. A bump here would be recomputed and could disagree with the tag | 2026-08-25 |
+| The commit that removes the sub-commands is subject-marked `refactor!`, and the PR body carries the migration line `converter video IN OUT` -> `converter --to mp4 IN OUT`, `converter audio IN OUT` -> `converter --to wav IN OUT` | `docs/release.md` derives the major bump from the `!` marker and requires a migration note in the breaking release's changelog entry; the text has to exist somewhere for `/ship` to curate | 2026-08-25 |
+| `--list-formats` prints one line per target — the name, the suffix it writes, and the profile's one-line description — sorted by name, and exits before any path or tool resolution | It is the discoverability half of `--to`: a user who guessed a format name wrong needs the list without owning a valid input directory | 2026-08-25 |
+| The interactive prompt asks for the target format by name, offering the registry's list, and otherwise keeps today's questions and its argv-building shape | The prompt is not a second code path (`converter/cli.py`); keeping it an argv builder is what makes it testable against the same parser | 2026-08-25 |
+| OPEN — does this phase also ship a `--from <suffix>` source filter? | resolved at the spec-acceptance gate | — |
+
+## Tracking
+
+The decomposition into steps lives as GitHub issues, not in this file — one
+issue per step, grouped under a milestone. This spec owns the design; the issues
+own progress.
+
+- Milestone: target-driven-cli (created at the spec-acceptance gate)
+- Issues: created from this spec once it is merged (one per implementable step)
+
+## Verification
+
+Machine checks:
+
+- [ ] Verify passes (ruff check, ruff format --check, pytest) on the merge commit.
+- [ ] A test that `converter video ...` and `converter audio ...` exit 2 with a
+      message naming `--to`.
+- [ ] A test per selection rule in `docs/design/source-selection.md`: a
+      non-media file is not a candidate, a file already in the target format is
+      not a candidate, a collision exits 2 before any conversion, an existing
+      output is `skipped`, and `--dry-run` works with no ffmpeg resolvable.
+- [ ] A test that `--to MP4`, `--to mp4` and `--to .mp4` select the same profile,
+      and that an unknown target exits 2 listing the available ones.
+- [ ] A test that `--list-formats` prints a line per registry entry and exits 0
+      without resolving tools or touching the filesystem.
+- [ ] A test driving `prompt_for_argv` through the real parser, so the prompt and
+      the flags cannot drift apart.
+- [ ] A test that `converter mirror ...` is unaffected.
+- [ ] No function in `converter/cli.py` exceeds 50 lines, and both README-related
+      tech-debt rows are gone from `docs/constitution.md`.
+- [ ] `grep` finds no format name (`mp4`, `wav`, `mkv`, `opus`) in
+      `converter/cli.py`, `converter/batch.py` or `converter/paths.py`.
+
+Human milestone-QA gate — with the absolute ffmpeg paths from *This machine*,
+reusing the fixtures the phase-1 gate synthesises:
+
+- [ ] `converter --to mp4 in out` converts the MKV fixtures and reports a
+      summary; a second run reports `0 converted`, exit 0.
+- [ ] `converter --to wav in out` converts `tone.opus` and leaves the `.mkv`
+      files alone.
+- [ ] Pointing `--to mp4` at a directory that already contains `.mp4` files
+      converts the others and does not touch or destroy the existing ones.
+- [ ] `converter --list-formats` and bare `converter` (the prompt) both behave as
+      described, on a machine path where ffmpeg is not on PATH.
+- [ ] `converter video in out` fails with a message that tells the user what to
+      run instead.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `--to mp4` pointed at a large mixed tree silently tries to convert far more files than the old sub-commands did | The curated source-suffix set bounds it, `--dry-run` lists the tasks before any work, and the same-suffix exclusion keeps the target's own files out |
+| A source whose output path equals its input path corrupts the file under `--overwrite` | Excluded at selection, with a test per `docs/design/source-selection.md` |
+| Removing the sub-commands breaks someone's script silently | The parser names the replacement in its error, and the `refactor!` commit plus migration line drive the release note |
+| The prompt drifts from the flags it builds | The prompt test parses its output with the real parser, as today |
+| Phases 3-5 discover that `cli.py` still needs a diff per format | The `grep`-for-format-names check in Verification fails the gate rather than surfacing in phase 3 |
+
+## Decision log
+
+- 2026-08-25: `docs/design/source-selection.md` added as the phase's design
+  artifact. The CLI has no UI surface, but `--to` creates a selection decision
+  that every coverage phase re-opens by adding suffixes, which is exactly the
+  recurring-decision criterion `docs/design.md` names.

--- a/docs/specs/spec-target-driven-cli.md
+++ b/docs/specs/spec-target-driven-cli.md
@@ -16,58 +16,77 @@ milestone. A completed spec is moved to `docs/specs/archive/`.
       `INPUT` into `<format>`, mirroring the tree, with the flags the old
       sub-commands had (`-r`, `-j`, `--overwrite`, `--dry-run`, `-q`,
       `--mirror-to`, `--ffmpeg`, `--ffprobe`) unchanged in name and meaning.
-- [ ] `converter video ...` and `converter audio ...` are **gone** — the parser
-      rejects them with a usage error naming the replacement.
-- [ ] `converter --list-formats` prints every target the registry holds and the
-      suffix each writes, and exits 0 without touching the filesystem.
+- [ ] `converter video ...` and `converter audio ...` exit 2 with a message that
+      names the command to run instead.
+- [ ] `converter --list-formats` prints every target the registry holds and exits
+      0 without resolving tools or touching the filesystem.
 - [ ] The interactive prompt (bare `converter`) offers the registry's targets and
       the `mirror` command, built from the registry rather than a literal list.
-- [ ] `converter mirror ...` still works exactly as it does today.
+- [ ] `converter mirror ...` and `converter --version` still work exactly as they
+      do today, and `converter --help` still leads a reader to both.
 - [ ] Adding a target format still produces no diff in `cli.py`, `batch.py` or
       `paths.py` — the check phases 3-5 will actually run.
-- [ ] `README.md` documents the `--to` CLI, carries a migration note from the old
-      sub-commands, and names `main` as the pull-request target.
-- [ ] Both README tech-debt rows are gone from `docs/constitution.md`: the
-      `develop` row, and the `convert_command` over-50-lines row.
-- [ ] No version bump and no changelog entry land in this phase.
+- [ ] A source the target cannot produce at all resolves to the outcome decided
+      at the acceptance gate, and a mixed tree does not fail the run for it.
+- [ ] `README.md` documents the `--to` CLI, carries the migration note, names
+      `main` as the pull-request target, and no longer tells a reader to add a
+      `Job` to `converter/jobs.py`.
+- [ ] Both remaining tech-debt rows are gone from `docs/constitution.md`: the
+      README `develop` row, and the `convert_command` over-50-lines row.
+- [ ] No version bump, no changelog entry and no tag land in this phase.
 
 ## Scope
 
 ### In scope
 
-- `converter/cli.py`: the parser shape, `--to`, `--list-formats`, the reworked
-  prompt, the `mirror` routing, and splitting `convert_command` under 50 lines.
-- `converter/profiles.py`: looking a profile up by target name, and the curated
-  set of source suffixes discovery uses.
-- `converter/batch.py`: taking a profile where it takes a `Job` today, and
-  deleting `Job` / `JOBS` / `JOB_BINDINGS` with the sub-commands they served.
-- `README.md`, and the two tech-debt rows in `docs/constitution.md`.
+- `converter/cli.py`: the parser split, the `main()` routing, `--to`,
+  `--list-formats`, the reworked prompt, and splitting `convert_command` under
+  50 lines.
+- `converter/profiles.py`: a `name` and a one-line `description` on the profile
+  value type, lookup by target name, and the curated source-suffix set.
+- `converter/batch.py`: taking a profile where it takes a `Job` today, the
+  progress-bar description, and whatever the gate decides about a source the
+  target cannot produce.
+- `converter/jobs.py`: exposing the engine entry points `batch.py` now calls
+  directly. No change to the ladder itself.
+- Deleting `Job`, `JOBS` and `JOB_BINDINGS` with the sub-commands they served.
+- **The test migration this forces**, which is a substantial part of the work:
+  `tests/test_batch.py` imports `MKV_TO_MP4` / `OPUS_TO_WAV` across 17 call
+  sites, and `tests/test_cli.py`'s parser, output-root, convert-command,
+  exit-code and prompt classes are written entirely against `video` / `audio`.
+- `README.md`, the two tech-debt rows in `docs/constitution.md`, and the
+  `docs/architecture.md` amendment already made in this spec's PR (the
+  `batch` -> `profiles` edge, and `batch` calling the engine directly).
 - Source selection per `docs/design/source-selection.md`.
 
 ### Out of scope
 
 - New target formats. Phase 2 ships the two profiles that exist; `--list-formats`
-  will print two lines until phase 3.
-- The conversion ladder itself. Phase 1 owns it; nothing in this phase touches
-  `jobs.py` beyond removing the `Job` scaffolding.
+  prints two lines until phase 3.
+- The conversion ladder. Phase 1 owns it; this phase only exposes its entry
+  points and removes the `Job` scaffolding around them.
 - The version bump to 3.0.0, the changelog and the release. `docs/release.md`
   makes that `/loopkit:ship`'s job, computed from the `refactor!` commit this
   phase lands — a version bumped here would be bumped twice.
-- A deprecation shim that keeps `video` / `audio` working. `docs/release.md`
-  already plans this phase as the breaking change with a migration note.
+- A deprecation shim that keeps `video` / `audio` *working*. They are recognised
+  only to produce a useful error.
+- Rewriting `converter/paths.py`'s docstrings, which use `.mkv` and `.mp4` as
+  illustrations. They are examples in prose, not format knowledge in code; see
+  the Verification check that draws the line.
 
 ## Constraints
 
-- A target format is data, not code: this phase must leave `cli.py` free of any
-  format name, so phases 3-5 can add one by touching only `profiles.py`
-  (`docs/constitution.md`, `docs/architecture.md`).
+- A target format is data, not code: this phase must leave `cli.py` and
+  `batch.py` free of any format name, so phases 3-5 add one by touching only
+  `profiles.py` (`docs/constitution.md`, `docs/architecture.md`).
 - Maximum 50 lines per function — `convert_command` is 54 today and is listed as
   tech debt this phase clears.
 - `paths.py` knows nothing about ffmpeg or profiles; discovery keeps taking a
   suffix set as an argument rather than reaching into the registry.
-- Selection finishes before `resolve_tools` runs, so `--dry-run` and a collision
-  refusal keep working on a machine with no ffmpeg installed.
-- Windows is a first-class target: `--mirror-to E:` behaviour is unchanged.
+- Selection finishes before `resolve_tools` runs, so `--dry-run`,
+  `--list-formats` and a collision refusal keep working with no ffmpeg installed.
+- Windows is a first-class target: `--mirror-to E:` behaviour is unchanged, and
+  path comparison stays case-folded.
 
 ## Prior art
 
@@ -97,14 +116,38 @@ milestone. A completed spec is moved to `docs/specs/archive/`.
 |---|---|---|
 | `--to` accepts a format name or a suffix, case-insensitively: `mp4`, `MP4` and `.mp4` all select the MP4 profile | ImageMagick's precedent is that the target is already written down as an extension (`docs/prior-art.md`); refusing the dotted form would be pedantry, and normalising is three lines in the registry lookup | 2026-08-25 |
 | An unknown target is a usage error (exit 2) whose message lists the available targets | The same shape as the existing `--jobs must be 1 or more`; a wrong format name is a typo, not a conversion failure | 2026-08-25 |
-| Discovery uses a curated **source-suffix set** declared in `converter/profiles.py`, and files whose suffix equals the target's own suffix are never candidates | Drawn in `docs/design/source-selection.md`. The suffix set is curated for the same reason the copy mask is; the same-suffix exclusion is what stops an output path from being its own input | 2026-08-25 |
-| `mirror` stays a sub-command. `main()` routes on the first token: a leading `mirror` goes to the mirror parser, anything else to the convert parser | argparse cannot hold both a positional `INPUT` on the top-level parser and a sub-command, since it would read `INPUT` as a command name. Two parsers behind one routing line is honest and testable; the alternative — turning `mirror` into a flag — would break a working command for no reason | 2026-08-25 |
-| `Job`, `JOBS` and `JOB_BINDINGS` are deleted. `batch.run_batch` takes the profile, and the progress bar's description comes from the profile's label | They exist only to keep phase 1's diff out of `cli.py` and `batch.py`; phase 2 is the breaking change that was always going to remove them. The constitution's no-diff rule is about *adding a format*, which this is not | 2026-08-25 |
+| Source selection follows `docs/design/source-selection.md` | The mechanism lives in the diagram; repeating it here would let the two drift (`docs/design.md`) | 2026-08-25 |
+| There are **two parsers**: a convert parser (positional `INPUT`, optional `OUTPUT`, required `--to`) and the existing mirror parser. `main()` routes on the raw argv before parsing: a leading `mirror` goes to the mirror parser; a leading `video` or `audio` prints the migration line and returns 2; `--list-formats` anywhere prints the list and returns 0; anything else goes to the convert parser | The subparsers action is itself a positional, so with `INPUT` on the top-level parser argparse binds the first token to `INPUT` and reads the *next* one as the command name — the two shapes genuinely cannot coexist. Routing before parsing is also what makes `--list-formats` reachable at all, since a required `--to` and a required `INPUT` would otherwise reject it | 2026-08-25 |
+| `build_parser()` returns the **convert** parser; the mirror parser comes from a second builder, and both are exported | Every existing parser test calls `build_parser()`, and the convert path is the one the prompt round-trips through. Two builders keep each parser's `--help` honest about its own arguments | 2026-08-25 |
+| `--version` stays an `action="version"` optional on the convert parser | argparse runs a `version` action during parsing and exits before it checks required arguments, so `converter --version` keeps working with `--to` required. Pinned by the existing test rather than assumed | 2026-08-25 |
+| The convert parser's `--help` epilog names `converter mirror --help` and `--list-formats` | With `mirror` off the sub-parser list it would otherwise vanish from `--help`, which would be a discoverability regression nobody decided on | 2026-08-25 |
+| The profile value type gains a `name` (the `--to` token) and a one-line `description`. This **extends phase 1's value type**, whose field list did not include either | `--list-formats` and the prompt both need a human-readable line per target, and the text that serves that today lives in `JOB_BINDINGS`, which this phase deletes. Recorded as a visible change to phase 1's shape rather than a silent one | 2026-08-25 |
+| `Job`, `JOBS` and `JOB_BINDINGS` are deleted. `batch.run_batch` takes the profile, calls the engine through the entry points `jobs.first_attempt(profile)` and `jobs.retries(profile, streams)`, and takes the progress-bar description from the profile's label — so the bar reads `MP4` where it read `mkv-to-mp4` | They exist only to keep phase 1's diff out of `cli.py` and `batch.py`; phase 2 is the breaking change that was always going to remove them. The constitution's no-diff rule is about *adding a format*, which this is not. Naming the entry points here stops the implementer from inventing a third shape | 2026-08-25 |
+| `docs/architecture.md`'s Boundaries gains the `batch` -> `profiles` edge, amended in this PR | `run_batch(profile, ...)` needs the type for its annotation, so the edge is real. Phase 1 set the precedent of amending architecture in the spec's own PR rather than letting it drift | 2026-08-25 |
+| A run that finds no candidates prints the ordinary summary line on stdout and a one-line hint on stderr, and exits 0 — it no longer prints `No .mkv files found` | The suffix set is now dozens of entries, so interpolating it is unreadable, and an error-channel message for an empty directory reads like a failure. `docs/vision.md` requires a re-run over a finished tree to *report* `0 converted, 0 failed`, which needs the summary to be printed | 2026-08-25 |
 | No version bump, no `CHANGELOG.md` entry, no tag in this phase | `docs/release.md` computes the version from the conventional commits in the range and has the human curate the changelog at the `/loopkit:ship` preview. A bump here would be recomputed and could disagree with the tag | 2026-08-25 |
-| The commit that removes the sub-commands is subject-marked `refactor!`, and the PR body carries the migration line `converter video IN OUT` -> `converter --to mp4 IN OUT`, `converter audio IN OUT` -> `converter --to wav IN OUT` | `docs/release.md` derives the major bump from the `!` marker and requires a migration note in the breaking release's changelog entry; the text has to exist somewhere for `/ship` to curate | 2026-08-25 |
-| `--list-formats` prints one line per target — the name, the suffix it writes, and the profile's one-line description — sorted by name, and exits before any path or tool resolution | It is the discoverability half of `--to`: a user who guessed a format name wrong needs the list without owning a valid input directory | 2026-08-25 |
-| The interactive prompt asks for the target format by name, offering the registry's list, and otherwise keeps today's questions and its argv-building shape | The prompt is not a second code path (`converter/cli.py`); keeping it an argv builder is what makes it testable against the same parser | 2026-08-25 |
-| OPEN — does this phase also ship a `--from <suffix>` source filter? | resolved at the spec-acceptance gate | — |
+| The commit that removes the sub-commands is subject-marked `refactor!`, and the PR body carries the migration lines `converter video IN OUT` -> `converter --to mp4 IN OUT` and `converter audio IN OUT` -> `converter --to wav IN OUT` | `docs/release.md` derives the major bump from the `!` marker and requires a migration note in the breaking release's changelog entry; the text has to exist for `/ship` to curate | 2026-08-25 |
+| `--list-formats` prints one line per target — the name, the suffix it writes, and the description — sorted by name | It is the discoverability half of `--to`: a user who guessed a format name wrong needs the list without owning a valid input directory | 2026-08-25 |
+| The prompt lists the registry's targets numbered in the same sorted order `--list-formats` uses, with `mirror` as the last entry and the first target as the default. It also accepts a format name typed instead of a number | Keeps today's shape (a numbered menu with a default) while the list grows; typing the name is the escape hatch once 17 entries make counting silly. The prompt stays an argv builder, so the parser remains the single code path | 2026-08-25 |
+| OPEN — what happens to a source the target cannot produce at all (a video-only `.mkv` under `--to wav`), and whether this phase ships a `--from <suffix>` filter | resolved at the spec-acceptance gate; see the note below | — |
+
+### The one open decision, in full
+
+Selection cannot know whether a source *can* produce the target: that needs a
+probe, and a probe on the happy path is forbidden. So under `--to wav`, a
+video-only `.mkv` is selected, its attempt fails, the probe finds no audio, the
+selective rung has no streams to map, WAV declares no last-resort rung — and the
+file lands as `failed`, exit 1. Pointing `--to wav` at any mixed tree therefore
+fails the run today. Three ways out, and the gate picks:
+
+1. **A `--from <suffix>` filter**, so the user narrows the sources by hand. Cheap,
+   explicit, and leaves the failure semantics untouched — but the default
+   invocation still fails on a mixed tree.
+2. **An `unsupported` outcome**: when the ladder ends with no rung that mapped a
+   single stream, the file is reported as unsupported with the reason rather than
+   as `failed`, and it does not set the exit code. Costs a new outcome in
+   `batch.py` and a line in every summary.
+3. **Both.**
 
 ## Tracking
 
@@ -123,32 +166,49 @@ Machine checks:
 - [ ] A test that `converter video ...` and `converter audio ...` exit 2 with a
       message naming `--to`.
 - [ ] A test per selection rule in `docs/design/source-selection.md`: a
-      non-media file is not a candidate, a file already in the target format is
-      not a candidate, a collision exits 2 before any conversion, an existing
-      output is `skipped`, and `--dry-run` works with no ffmpeg resolvable.
+      non-media file is not a candidate, a source whose output path is its own
+      input path is a counted `skipped`, a source with the target's suffix but a
+      different output root **is** converted, a collision exits 2 before any
+      conversion, an existing output is `skipped`, and `--dry-run` works with no
+      ffmpeg resolvable.
 - [ ] A test that `--to MP4`, `--to mp4` and `--to .mp4` select the same profile,
       and that an unknown target exits 2 listing the available ones.
 - [ ] A test that `--list-formats` prints a line per registry entry and exits 0
-      without resolving tools or touching the filesystem.
-- [ ] A test driving `prompt_for_argv` through the real parser, so the prompt and
-      the flags cannot drift apart.
-- [ ] A test that `converter mirror ...` is unaffected.
-- [ ] No function in `converter/cli.py` exceeds 50 lines, and both README-related
-      tech-debt rows are gone from `docs/constitution.md`.
-- [ ] `grep` finds no format name (`mp4`, `wav`, `mkv`, `opus`) in
-      `converter/cli.py`, `converter/batch.py` or `converter/paths.py`.
+      without resolving tools, and that it works with `--to` and `INPUT` absent.
+- [ ] A test that `converter --version` still exits 0 with `--to` required.
+- [ ] A test driving `prompt_for_argv` through the real convert parser, so the
+      prompt and the flags cannot drift apart, plus one for a typed format name.
+- [ ] A test that `converter mirror ...` is unaffected, and one that a run with
+      no candidates prints the summary and exits 0.
+- [ ] A test that walks `converter/cli.py` and `converter/batch.py` with `ast`
+      and asserts no string literal other than a docstring contains a format name
+      or suffix from the registry. A plain `grep` cannot do this: `paths.py`
+      illustrates its rules with `.mkv` in prose, and a case-sensitive grep would
+      miss `.MKV` — the check has to look at code, not text.
+
+Checked in review, not by a machine — ruff's `select` carries no `PL` rules, so
+nothing measures function length:
+
+- [ ] No function in `converter/cli.py` exceeds 50 lines, and the
+      `convert_command` tech-debt row is gone from `docs/constitution.md`.
+- [ ] `README.md`: the `--to` CLI, the migration note, `main` as the PR target,
+      a `converter/profiles.py` row in the layout table, and no surviving
+      instruction to add a `Job` to `converter/jobs.py`.
 
 Human milestone-QA gate — with the absolute ffmpeg paths from *This machine*,
 reusing the fixtures the phase-1 gate synthesises:
 
 - [ ] `converter --to mp4 in out` converts the MKV fixtures and reports a
-      summary; a second run reports `0 converted`, exit 0.
-- [ ] `converter --to wav in out` converts `tone.opus` and leaves the `.mkv`
-      files alone.
-- [ ] Pointing `--to mp4` at a directory that already contains `.mp4` files
-      converts the others and does not touch or destroy the existing ones.
-- [ ] `converter --list-formats` and bare `converter` (the prompt) both behave as
-      described, on a machine path where ffmpeg is not on PATH.
+      summary; a second run reports `0 converted`, `N skipped`, exit 0.
+- [ ] `converter --to wav in out` over the same mixed directory behaves as the
+      gate's open decision resolved it — and does not exit 1 for the video-only
+      sources if the resolution says it should not.
+- [ ] Pointing `--to mp4` at a directory that already contains `.mp4` files,
+      **without** `--overwrite`, converts the others and leaves the existing ones
+      untouched; with `OUTPUT` equal to `INPUT` the `.mp4` files are reported as
+      skipped rather than silently passed over.
+- [ ] `converter --list-formats` and bare `converter` both behave as described
+      from a directory where ffmpeg is not on PATH.
 - [ ] `converter video in out` fails with a message that tells the user what to
       run instead.
 
@@ -156,15 +216,25 @@ reusing the fixtures the phase-1 gate synthesises:
 
 | Risk | Mitigation |
 |---|---|
-| `--to mp4` pointed at a large mixed tree silently tries to convert far more files than the old sub-commands did | The curated source-suffix set bounds it, `--dry-run` lists the tasks before any work, and the same-suffix exclusion keeps the target's own files out |
-| A source whose output path equals its input path corrupts the file under `--overwrite` | Excluded at selection, with a test per `docs/design/source-selection.md` |
-| Removing the sub-commands breaks someone's script silently | The parser names the replacement in its error, and the `refactor!` commit plus migration line drive the release note |
-| The prompt drifts from the flags it builds | The prompt test parses its output with the real parser, as today |
-| Phases 3-5 discover that `cli.py` still needs a diff per format | The `grep`-for-format-names check in Verification fails the gate rather than surfacing in phase 3 |
+| `--to X` pointed at a large mixed tree tries to convert far more files than the old sub-commands did | The curated source-suffix set bounds it, `--dry-run` lists the tasks before any work, and the gate's open decision settles what a source the target cannot hold reports |
+| A source whose output path equals its input path is read and written at once under `--overwrite` | Excluded at selection and reported as skipped, per `docs/design/source-selection.md`, with a test per rule |
+| Removing the sub-commands breaks someone's script silently | `main()` recognises both legacy tokens and names the replacement; the `refactor!` commit and migration lines drive the release note |
+| The prompt drifts from the flags it builds | The prompt test parses its output with the real convert parser, as today |
+| Phases 3-5 discover that `cli.py` still needs a diff per format | The `ast`-based format-name check fails the gate rather than surfacing in phase 3 |
+| The test migration is large enough to be rushed | It is named in Scope and gets its own issue, rather than riding along in the parser issue |
 
 ## Decision log
 
 - 2026-08-25: `docs/design/source-selection.md` added as the phase's design
-  artifact. The CLI has no UI surface, but `--to` creates a selection decision
-  that every coverage phase re-opens by adding suffixes, which is exactly the
-  recurring-decision criterion `docs/design.md` names.
+  artifact — the batch-item flow `docs/design.md` names as its secondary
+  decision, extended one step upstream to selection.
+- 2026-08-25: Spec review found the same-suffix exclusion wrong whenever the
+  output root differs from the input root: `In\a.mp4` -> `Out\a.mp4` is a
+  legitimate remux, and excluding it would leave the output tree quietly
+  incomplete. Replaced by a path-identity guard that reports rather than drops.
+- 2026-08-25: Spec review found `--list-formats` unreachable under this spec's
+  own parser decision, and the legacy sub-commands unable to produce the error
+  the Outcome promised. Both are now explicit routing steps in `main()`.
+- 2026-08-25: Spec review found that a source the target cannot produce at all
+  fails the whole run, which no decision covered. Promoted to the phase's one
+  open decision, with `--from` folded into it as one of three answers.

--- a/docs/specs/spec-target-driven-cli.md
+++ b/docs/specs/spec-target-driven-cli.md
@@ -193,7 +193,7 @@ The decomposition into steps lives as GitHub issues, not in this file — one
 issue per step, grouped under a milestone. This spec owns the design; the issues
 own progress.
 
-- Milestone: target-driven-cli (created at the spec-acceptance gate)
+- Milestone: [target-driven-cli](https://github.com/bhemsen/converter/milestone/2) (#2)
 - Issues: created from this spec once it is merged (one per implementable step)
 
 ## Verification

--- a/docs/specs/spec-target-driven-cli.md
+++ b/docs/specs/spec-target-driven-cli.md
@@ -189,10 +189,11 @@ The gate therefore picks between two answers, not three:
    flag is **repeatable** (`--from mkv --from avi`) and not comma-separated,
    matching how argparse expresses a list without a second parsing rule; it
    accepts the same dotted and cased forms `--to` does, normalised the same way;
-   it **intersects** the curated source-suffix set rather than replacing it, so a
-   typo cannot widen discovery to files ffmpeg was never going to read; and a
-   suffix outside that set is a usage error (exit 2) naming it, not an empty run
-   that looks like success.
+   and it is **two rules, not one** — validation first, then filtering. A suffix
+   outside the curated source-suffix set is a usage error (exit 2) naming it,
+   never an empty run that looks like success; what survives validation then
+   narrows discovery. Written as a single "intersect" the filter would silently
+   swallow a typo, which is the wrong half to implement.
 
 A `--from` filter *alone* was considered and dropped: it leaves the default
 invocation failing on a mixed tree, which contradicts this spec's own Outcome and
@@ -282,6 +283,11 @@ reusing the fixtures the phase-1 gate synthesises:
       from a directory where ffmpeg is not on PATH.
 - [ ] `converter video in out` fails with a message that tells the user what to
       run instead.
+- [ ] `converter --to mp4 -r in --mirror-to <second drive>` mirrors the fixture
+      tree onto a real second drive and a re-run reports `0 converted`. The
+      machine checks cover `--mirror-to` three times over, but this is the only
+      gate where a real drive is involved, and `docs/constitution.md` makes
+      Windows a first-class target.
 
 ## Risks and mitigations
 

--- a/docs/specs/spec-target-driven-cli.md
+++ b/docs/specs/spec-target-driven-cli.md
@@ -49,10 +49,12 @@ milestone. A completed spec is moved to `docs/specs/archive/`.
   a one-line `description` on the profile value type, lookup by that name, and
   the curated source-suffix set.
 - `converter/batch.py`: taking a profile where it takes a `Job` today, the
-  progress-bar description, and whatever the gate decides about a source the
-  target cannot produce.
+  progress-bar description, and mapping the engine's signal onto the outcome the
+  gate decides for a source the target cannot produce — mapping only, never
+  deciding.
 - `converter/jobs.py`: exposing the engine entry points `batch.py` now calls
-  directly. No change to the ladder itself.
+  directly, and reporting the "no rule matches any present stream" signal the
+  unsupported outcome rests on. No change to the ladder itself.
 - Deleting `Job`, `JOBS` and `JOB_BINDINGS` with the sub-commands they served.
 - **The test migration this forces**, which is a substantial part of the work:
   `tests/test_batch.py` imports `MKV_TO_MP4` / `OPUS_TO_WAV` across 17 call
@@ -156,6 +158,17 @@ carries no stream of any type the profile declares a rule for. A file that *does
 carry usable streams and still fails is a genuine `failed` — the distinction
 matters, or a corrupt file would be quietly relabelled.
 
+**The discriminator lives in `jobs.py`, not `batch.py`.** It reads the profile's
+rules against the probed streams, which is a conversion decision, and the
+architecture bullet this PR adds forbids `batch.py` from making one. The engine
+reports it as a distinguishable signal; `batch.py` maps that signal onto the
+outcome and counts it, and does nothing else with it.
+
+Note what the outcome does **not** buy: an unsupported file still costs one ffmpeg
+attempt and one ffprobe on every run, because nothing short of a probe can tell.
+The re-run reports honestly and exits 0, but it is not free — worth knowing before
+picking, on a large mixed tree.
+
 The gate therefore picks between two answers, not three:
 
 1. **The `unsupported` outcome alone.** Costs a new outcome in `batch.py` and a
@@ -191,10 +204,15 @@ Machine checks:
       different output root **is** converted, a collision exits 2 before any
       conversion, an existing output is `skipped`, and `--dry-run` works with no
       ffmpeg resolvable.
-- [ ] A test that `a.mkv` and `a.mp4` in one directory, converting to `mp4` in
-      place, exits 2 — **with** `--overwrite` as well as without. This is the
-      case where reporting `a.mp4` as skipped and then overwriting it would
-      destroy a file the run said it kept.
+- [ ] A test pair for `a.mkv` and `a.mp4` in one directory, converting to `mp4`
+      in place: **with** `--overwrite` it exits 2 naming both files, because
+      reporting `a.mp4` as skipped and then overwriting it would destroy a file
+      the run said it kept; **without** `--overwrite` it reports
+      `0 converted, 2 skipped` and exits 0, because nothing is at risk and an
+      in-place re-run must stay idempotent.
+- [ ] A test for a nested output root (`-r IN IN\converted`): run it twice, and
+      the second run reports `0 converted`. Without the output-tree exclusion this
+      grows a `converted\converted\...` generation per run, forever.
 - [ ] A test that the self-write guard still fires under `--mirror-to`, where the
       output root is derived from a resolved input path and the source paths are
       not — the case a compare-as-given check would miss, and that an absolute
@@ -247,9 +265,10 @@ reusing the fixtures the phase-1 gate synthesises:
 | Risk | Mitigation |
 |---|---|
 | `--to X` pointed at a large mixed tree tries to convert far more files than the old sub-commands did | The curated source-suffix set bounds it, `--dry-run` lists the tasks before any work, and the gate's open decision settles what a source the target cannot hold reports |
-| A source whose output path equals its input path is read and written at once under `--overwrite` | Excluded at selection and reported as skipped, per `docs/design/source-selection.md`, with a test per rule |
-| Removing the sub-commands breaks someone's script silently | `main()` recognises both legacy tokens and names the replacement; the `refactor!` commit and migration lines drive the release note |
-| The prompt drifts from the flags it builds | The prompt test parses its output with the real convert parser, as today |
+| A source whose output path equals its input path is read and written at once, or is overwritten by a sibling under `--overwrite` | Reported as a counted skip, and the sibling case refuses the run up front -- both per `docs/design/source-selection.md`, with a test for each and for the harmless no-`--overwrite` counterpart |
+| A nested output root makes every run convert one more generation of its own output | Files under the output root are not candidates, pinned by a run-it-twice test |
+| Removing the sub-commands breaks someone's script silently | `main()` recognises both legacy tokens and points at `--to` plus `--list-formats` -- generically, since naming a format in `cli.py` would defeat this phase's own format-name check; the concrete mapping lives in the README, and the `refactor!` commit plus migration lines drive the release note |
+| The prompt drifts from the flags it builds | The prompt test dispatches its output through the same routing function a typed argv takes, so a prompted `mirror` argv is covered too |
 | Phases 3-5 discover that `cli.py` still needs a diff per format | The `ast`-based format-name check fails the gate rather than surfacing in phase 3 |
 | The test migration is large enough to be rushed | It is named in Scope and gets its own issue, rather than riding along in the parser issue |
 
@@ -276,3 +295,10 @@ reusing the fixtures the phase-1 gate synthesises:
   the idempotent-re-run criterion on a mixed tree, so it was demoted from an
   answer to an optional addition, and the `unsupported` outcome became the part
   the phase needs either way.
+- 2026-08-25: Review round 3 found that routing self-writes through the ordinary
+  collision check over-corrected: an in-place re-run would exit 2 on the second
+  run of a command that worked on the first. The refusal now fires only under
+  `--overwrite`, where the destruction is real.
+- 2026-08-25: Review round 3 found that a nested output root never converges —
+  each run converts the previous run's output one level deeper. Files under the
+  output root are now excluded from discovery.

--- a/docs/specs/spec-target-driven-cli.md
+++ b/docs/specs/spec-target-driven-cli.md
@@ -52,6 +52,12 @@ milestone. A completed spec is moved to `docs/specs/archive/`.
   progress-bar description, and mapping the engine's signal onto the outcome the
   gate decides for a source the target cannot produce — mapping only, never
   deciding.
+- `converter/paths.py`: the three new selection predicates — self-write,
+  output-tree exclusion and the overwrite hazard — live here beside
+  `find_collisions`, as pure path logic with no ffmpeg or profile knowledge, and
+  the output-tree exclusion means `find_sources` grows a way to skip a subtree.
+  `cli.py` calls them; it does not reimplement them, which is also what keeps
+  `convert_command` under 50 lines. Their tests go to `tests/test_paths.py`.
 - `converter/jobs.py`: exposing the engine entry points `batch.py` now calls
   directly, and reporting the "no rule matches any present stream" signal the
   unsupported outcome rests on. No change to the ladder itself.
@@ -60,6 +66,7 @@ milestone. A completed spec is moved to `docs/specs/archive/`.
   `tests/test_batch.py` imports `MKV_TO_MP4` / `OPUS_TO_WAV` across 17 call
   sites, and `tests/test_cli.py`'s parser, output-root, convert-command,
   exit-code and prompt classes are written entirely against `video` / `audio`.
+  `tests/test_paths.py` gains the cases for the three new predicates.
 - `README.md`, the two tech-debt rows in `docs/constitution.md`, and the
   `docs/architecture.md` amendment already made in this spec's PR (the
   `batch` -> `profiles` edge, and `batch` calling the engine directly).
@@ -178,6 +185,15 @@ The gate therefore picks between two answers, not three:
    knows their tree can narrow it up front and never see the unsupported lines.
    More surface, more tests, and a flag phases 3-5 must keep working.
 
+   Picking this must not reopen planning, so its semantics are settled here: the
+   flag is **repeatable** (`--from mkv --from avi`) and not comma-separated,
+   matching how argparse expresses a list without a second parsing rule; it
+   accepts the same dotted and cased forms `--to` does, normalised the same way;
+   it **intersects** the curated source-suffix set rather than replacing it, so a
+   typo cannot widen discovery to files ffmpeg was never going to read; and a
+   suffix outside that set is a usage error (exit 2) naming it, not an empty run
+   that looks like success.
+
 A `--from` filter *alone* was considered and dropped: it leaves the default
 invocation failing on a mixed tree, which contradicts this spec's own Outcome and
 the vision criterion above.
@@ -213,6 +229,13 @@ Machine checks:
 - [ ] A test for a nested output root (`-r IN IN\converted`): run it twice, and
       the second run reports `0 converted`. Without the output-tree exclusion this
       grows a `converted\converted\...` generation per run, forever.
+- [ ] A test for an **ancestor** output root (`-r IN\Sub IN`): the files convert,
+      and a second run reports `0 converted`. A rule written as "lies under the
+      output root" without the strict-descendant clause excludes every candidate
+      here and reports a successful run that did nothing.
+- [ ] A `--mirror-to` variant of the `--overwrite` refusal test, so the hazard
+      guard is pinned on paths that differ as given and agree once resolved — the
+      one-directory test cannot tell the two comparisons apart.
 - [ ] A test that the self-write guard still fires under `--mirror-to`, where the
       output root is derived from a resolved input path and the source paths are
       not — the case a compare-as-given check would miss, and that an absolute

--- a/docs/specs/spec-target-driven-cli.md
+++ b/docs/specs/spec-target-driven-cli.md
@@ -27,9 +27,9 @@ milestone. A completed spec is moved to `docs/specs/archive/`.
       do today, and `converter --help` still leads a reader to both.
 - [ ] Adding a target format still produces no diff in `cli.py`, `batch.py` or
       `paths.py` — the check phases 3-5 will actually run.
-- [ ] A source the target cannot produce at all resolves to the outcome decided
-      at the acceptance gate, and a mixed tree does not fail the run for it —
-      so a re-run over it still reports `0 converted, 0 failed`, exit 0.
+- [ ] A source the target cannot produce at all is reported as `unsupported`,
+      counted in the summary and not setting the exit code, so a mixed tree does
+      not fail the run — and a re-run still reports `0 converted, 0 failed`, exit 0.
 - [ ] `README.md` documents the `--to` CLI, carries the migration note, names
       `main` as the pull-request target, and no longer tells a reader to add a
       `Job` to `converter/jobs.py`.
@@ -49,9 +49,8 @@ milestone. A completed spec is moved to `docs/specs/archive/`.
   a one-line `description` on the profile value type, lookup by that name, and
   the curated source-suffix set.
 - `converter/batch.py`: taking a profile where it takes a `Job` today, the
-  progress-bar description, and mapping the engine's signal onto the outcome the
-  gate decides for a source the target cannot produce — mapping only, never
-  deciding.
+  progress-bar description, and the new `unsupported` outcome — mapping the
+  engine's signal onto it and counting it, never deciding it.
 - `converter/paths.py`: the three new selection predicates — self-write,
   output-tree exclusion and the overwrite hazard — live here beside
   `find_collisions`, as pure path logic with no ffmpeg or profile knowledge, and
@@ -145,9 +144,9 @@ milestone. A completed spec is moved to `docs/specs/archive/`.
 | The prompt lists the registry's targets numbered in the same sorted order `--list-formats` uses, with `mirror` as the last entry and the first target as the default. It also accepts a format name typed instead of a number | Keeps today's shape (a numbered menu with a default) while the list grows; typing the name is the escape hatch once 17 entries make counting silly. The prompt stays an argv builder, so the parser remains the single code path | 2026-08-25 |
 | The legacy-token message is **generic**: it says the sub-commands are gone, shows `converter --to <format> IN OUT`, and points at `--list-formats`. The concrete `video` -> `--to mp4` and `audio` -> `--to wav` mapping lives in the README and in the PR body, not in `cli.py` | Naming `mp4` in `cli.py` would be the one string that defeats the `ast` check this phase installs to keep format names out of the CLI — and that check is what phases 3-5 rely on. A user who has just been told about `--list-formats` is one command from the answer | 2026-08-25 |
 | Routing runs on `raw` **after** the bare-invocation prompt has filled it, so a prompt that returns a `mirror` argv reaches the mirror parser. The `if not hasattr(args, "handler")` fallback in `main()` is removed — with explicit routing both parsers always set one | The prompt is an argv builder, so its output must travel the same path a typed argv does; that is the property the round-trip test exists to protect | 2026-08-25 |
-| OPEN — the `unsupported` outcome alone, or together with a `--from <suffix>` filter | resolved at the spec-acceptance gate; see the note below | — |
+| A source the target cannot produce becomes an **`unsupported` outcome**, and this phase ships **no `--from` filter** | Resolved at the spec-acceptance gate. The outcome is what the idempotent-re-run criterion needs and a filter cannot replace; `--from` would be extra surface plus a flag phases 3-5 must keep working, to save a cost the outcome already reports honestly. Revisit only if the repeated probe cost on large mixed trees turns out to bite | 2026-08-25 |
 
-### The one open decision, in full
+### The mixed-tree decision, in full
 
 Selection cannot know whether a source *can* produce the target: that needs a
 probe, and a probe on the happy path is forbidden. So under `--to wav`, a
@@ -176,28 +175,17 @@ attempt and one ffprobe on every run, because nothing short of a probe can tell.
 The re-run reports honestly and exits 0, but it is not free — worth knowing before
 picking, on a large mixed tree.
 
-The gate therefore picks between two answers, not three:
+**Resolved at the gate on 2026-08-25: the `unsupported` outcome alone.** A mixed
+tree converts what it can and reports the rest by name, in a new outcome that
+`batch.py` counts and that does not set the exit code.
 
-1. **The `unsupported` outcome alone.** Costs a new outcome in `batch.py` and a
-   column in every summary line. A mixed tree converts what it can and reports
-   the rest by name.
-2. **The `unsupported` outcome plus a `--from <suffix>` filter**, so a user who
-   knows their tree can narrow it up front and never see the unsupported lines.
-   More surface, more tests, and a flag phases 3-5 must keep working.
-
-   Picking this must not reopen planning, so its semantics are settled here: the
-   flag is **repeatable** (`--from mkv --from avi`) and not comma-separated,
-   matching how argparse expresses a list without a second parsing rule; it
-   accepts the same dotted and cased forms `--to` does, normalised the same way;
-   and it is **two rules, not one** — validation first, then filtering. A suffix
-   outside the curated source-suffix set is a usage error (exit 2) naming it,
-   never an empty run that looks like success; what survives validation then
-   narrows discovery. Written as a single "intersect" the filter would silently
-   swallow a typo, which is the wrong half to implement.
-
-A `--from` filter *alone* was considered and dropped: it leaves the default
-invocation failing on a mixed tree, which contradicts this spec's own Outcome and
-the vision criterion above.
+Two alternatives were considered and dropped. A **`--from <suffix>` filter alone**
+fails immediately: it leaves the default invocation failing on a mixed tree, which
+contradicts this spec's own Outcome and the vision criterion above. **The outcome
+plus `--from`** was a real option — it would let a user who knows their tree narrow
+it up front and skip the repeated probe cost — but it buys that with a flag every
+later phase has to keep working, to save a cost the outcome already reports
+honestly. Worth revisiting only if that cost turns out to bite on large trees.
 
 ## Tracking
 
@@ -272,9 +260,9 @@ reusing the fixtures the phase-1 gate synthesises:
 
 - [ ] `converter --to mp4 in out` converts the MKV fixtures and reports a
       summary; a second run reports `0 converted`, `N skipped`, exit 0.
-- [ ] `converter --to wav in out` over the same mixed directory behaves as the
-      gate's open decision resolved it — and does not exit 1 for the video-only
-      sources if the resolution says it should not.
+- [ ] `converter --to wav in out` over the same mixed directory converts the
+      audio-bearing sources, reports the video-only MKVs as `unsupported`, and
+      exits 0; a second run reports the same thing.
 - [ ] Pointing `--to mp4` at a directory that already contains `.mp4` files,
       **without** `--overwrite`, converts the others and leaves the existing ones
       untouched; with `OUTPUT` equal to `INPUT` the `.mp4` files are reported as
@@ -293,7 +281,7 @@ reusing the fixtures the phase-1 gate synthesises:
 
 | Risk | Mitigation |
 |---|---|
-| `--to X` pointed at a large mixed tree tries to convert far more files than the old sub-commands did | The curated source-suffix set bounds it, `--dry-run` lists the tasks before any work, and the gate's open decision settles what a source the target cannot hold reports |
+| `--to X` pointed at a large mixed tree tries to convert far more files than the old sub-commands did | The curated source-suffix set bounds it, `--dry-run` lists the tasks before any work, and a source the target cannot hold is reported as `unsupported` rather than converted or failed |
 | A source whose output path equals its input path is read and written at once, or is overwritten by a sibling under `--overwrite` | Reported as a counted skip, and the sibling case refuses the run up front -- both per `docs/design/source-selection.md`, with a test for each and for the harmless no-`--overwrite` counterpart |
 | A nested output root makes every run convert one more generation of its own output | Files under the output root are not candidates, pinned by a run-it-twice test |
 | Removing the sub-commands breaks someone's script silently | `main()` recognises both legacy tokens and points at `--to` plus `--list-formats` -- generically, since naming a format in `cli.py` would defeat this phase's own format-name check; the concrete mapping lives in the README, and the `refactor!` commit plus migration lines drive the release note |
@@ -331,3 +319,7 @@ reusing the fixtures the phase-1 gate synthesises:
 - 2026-08-25: Review round 3 found that a nested output root never converges —
   each run converts the previous run's output one level deeper. Files under the
   output root are now excluded from discovery.
+- 2026-08-25: Gate resolved the mixed-tree decision: the `unsupported` outcome
+  alone, no `--from` filter. The filter would have bought a saving on repeated
+  probe cost with a flag every later phase must keep working; the outcome already
+  reports that cost honestly. Recorded as revisitable if the cost bites.


### PR DESCRIPTION
Roadmap phase 2 — the planning package for `target-driven-cli`, the breaking change.

- `docs/specs/spec-target-driven-cli.md` — `converter --to <format>` replaces the `video` and `audio` sub-commands, plus `--list-formats`, a registry-driven prompt, and the README correction.
- `docs/design/source-selection.md` — which files under the input root become tasks, which are refused up front, and which are never candidates.

Depends on milestone #1 (profile-registry): there is no registry to drive a `--to` flag without it.

One decision is deliberately left open for the acceptance gate: whether this phase also ships a `--from <suffix>` source filter.
