### PR TITLE
feat(profiles): leaf module with the MP4 and WAV target profiles

### DIFF
--- a/converter/jobs.py
+++ b/converter/jobs.py
@@ -9,6 +9,7 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 
 from converter.ffmpegtool import Stream
+from converter.profiles import Attempt, flags
 
 #: Codecs a standard MP4 container accepts, so they can be stream-copied.
 MP4_VIDEO_CODECS = frozenset({"h264", "hevc", "av1", "vp9", "mpeg4", "mpeg2video", "mjpeg"})
@@ -18,26 +19,6 @@ TEXT_SUBTITLE_CODECS = frozenset({"subrip", "srt", "ass", "ssa", "mov_text", "we
 
 #: Move the MP4 index to the front so the file plays before it is fully read.
 FASTSTART = ("-movflags", "+faststart")
-
-
-def flags(spec: str) -> tuple[str, ...]:
-    """Split a command-line-shaped string into argv items.
-
-    Recipes then read exactly like what you would type after ``ffmpeg -i in.mkv``,
-    and flag/value pairs stay on one line regardless of how the formatter feels
-    about trailing commas.  Only ever used for flags and their values -- paths go
-    through :func:`converter.ffmpegtool.build_argv`, never through here.
-    """
-    return tuple(spec.split())
-
-
-@dataclass(frozen=True)
-class Attempt:
-    """One ffmpeg option list, with a note of anything it sacrifices."""
-
-    label: str
-    options: tuple[str, ...]
-    notes: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -1,0 +1,158 @@
+"""Declarative target-format profiles: value types plus the MP4 and WAV entries.
+
+A leaf module by design (`docs/architecture.md`): it holds no ``from converter``
+or ``import converter`` statement at all, so a target format can only ever be
+data, never new logic. That is also why ``flags()`` and ``Attempt`` live here
+instead of being imported from ``jobs.py`` -- importing them would break the
+leaf property in the other direction.
+
+See ``docs/design/degradation-ladder.md`` for how the engine in ``jobs.py``
+turns one profile into an ordered ladder of attempts, and
+``docs/design/stream-decision.md`` for how it decides one stream's fate
+against the profile's per-type rule.
+"""
+
+from dataclasses import dataclass
+
+
+def flags(spec: str) -> tuple[str, ...]:
+    """Split a command-line-shaped string into argv items.
+
+    Recipes then read exactly like what you would type after ``ffmpeg -i in.mkv``,
+    and flag/value pairs stay on one line regardless of how the formatter feels
+    about trailing commas.  Only ever used for flags and their values -- paths go
+    through :func:`converter.ffmpegtool.build_argv`, never through here.
+    """
+    return tuple(spec.split())
+
+
+@dataclass(frozen=True)
+class Attempt:
+    """One ffmpeg option list, with a note of anything it sacrifices."""
+
+    label: str
+    options: tuple[str, ...]
+    notes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class StreamRule:
+    """How one stream type is handled: accept, re-encode, or drop.
+
+    ``accept_options`` and ``fallback_options`` may carry the literal ``{n}``
+    placeholder, which the engine replaces with the stream's position among
+    output streams of its type. A rule whose ``stream_limit`` is 1 can only
+    ever produce one output stream of its type, so it writes the bare
+    specifier instead and leaves the placeholder out.
+    """
+
+    copy_mask: frozenset[str]
+    accept_options: tuple[str, ...]
+    fallback_options: tuple[str, ...] | None = None
+    fallback_name: str | None = None
+    stream_limit: int | None = None
+    #: Why a stream is dropped when the copy mask misses and no fallback is
+    #: declared -- irrelevant, and left ``None``, for a rule that always has one.
+    drop_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class Profile:
+    """One target format, declared entirely as data.
+
+    ``explicit_streams`` says whether ``cheap_attempt`` already selects streams
+    by index (WAV's ``-map 0:a:0``) rather than blindly by type (MP4's
+    ``-map 0:v?``) -- the one fact the engine cannot derive without parsing
+    ffmpeg's own option syntax, per ``docs/design/degradation-ladder.md``.
+    """
+
+    label: str
+    target_suffix: str
+    container_options: tuple[str, ...]
+    cheap_attempt: Attempt
+    explicit_streams: bool
+    rules: dict[str, StreamRule]
+    last_resort: Attempt | None = None
+
+
+#: Move the MP4 index to the front so the file plays before it is fully read.
+FASTSTART = flags("-movflags +faststart")
+
+#: Codecs a standard MP4 container accepts, so they can be stream-copied.
+MP4_VIDEO_CODECS = frozenset({"h264", "hevc", "av1", "vp9", "mpeg4", "mpeg2video", "mjpeg"})
+MP4_AUDIO_CODECS = frozenset({"aac", "mp3", "ac3", "eac3", "alac", "opus", "flac"})
+#: Subtitle codecs that convert cleanly into MP4's own ``mov_text``.
+TEXT_SUBTITLE_CODECS = frozenset({"subrip", "srt", "ass", "ssa", "mov_text", "webvtt", "text"})
+
+MP4 = Profile(
+    label="MP4",
+    target_suffix=".mp4",
+    container_options=FASTSTART,
+    # Deliberately not "-map 0": that also selects MKV attachments (font files
+    # for ASS subtitles) and data streams, which MP4 cannot hold, so an
+    # otherwise perfectly remuxable file would fail. The trailing "?" makes
+    # each selector optional instead of fatal.
+    cheap_attempt=Attempt(
+        label="remux",
+        options=flags("-map 0:v? -map 0:a? -map 0:s? -c copy -c:s mov_text"),
+    ),
+    explicit_streams=False,
+    rules={
+        "video": StreamRule(
+            copy_mask=MP4_VIDEO_CODECS,
+            accept_options=flags("-c:v:{n} copy"),
+            fallback_options=flags("-c:v:{n} libx264 -crf:v:{n} 18"),
+            fallback_name="h264",
+        ),
+        "audio": StreamRule(
+            copy_mask=MP4_AUDIO_CODECS,
+            accept_options=flags("-c:a:{n} copy"),
+            fallback_options=flags("-c:a:{n} aac -b:a:{n} 192k"),
+            fallback_name="aac",
+        ),
+        "subtitle": StreamRule(
+            copy_mask=TEXT_SUBTITLE_CODECS,
+            # A cheap in-kind transcode, not a literal copy: MP4 only holds
+            # text subtitles as its own mov_text.
+            accept_options=flags("-c:s:{n} mov_text"),
+            drop_reason="bitmap subtitles cannot be stored in MP4",
+        ),
+    },
+    last_resort=Attempt(
+        label="re-encode",
+        options=flags(
+            "-map 0:v:0? -map 0:a? "
+            "-c:v libx264 -crf 18 -preset medium -pix_fmt yuv420p "
+            "-c:a aac -b:a 192k"
+        ),
+        notes=(
+            "re-encoded to h264/aac (lossy); subtitles and extra video streams dropped",
+            "10-bit or HDR sources are reduced to 8-bit yuv420p for player compatibility",
+        ),
+    ),
+)
+
+WAV = Profile(
+    label="WAV",
+    target_suffix=".wav",
+    container_options=(),
+    # The stream is selected explicitly rather than left to ffmpeg's implicit
+    # "best stream" heuristic, so a file with several audio streams converts
+    # predictably instead of quietly depending on which one ffmpeg prefers.
+    cheap_attempt=Attempt(label="pcm_s16le", options=flags("-map 0:a:0 -c:a pcm_s16le")),
+    explicit_streams=True,
+    rules={
+        "audio": StreamRule(
+            # Empty by construction: WAV holds nothing as-is, only PCM.
+            copy_mask=frozenset(),
+            # Never emitted -- the empty copy mask means the accept branch of
+            # stream-decision.md can never be reached -- so it carries no
+            # placeholder either, same as the fallback below.
+            accept_options=(),
+            fallback_options=flags("-c:a pcm_s16le"),
+            # No fallback_name: decoding to PCM is the definition of WAV, not
+            # a loss, so the re-encode carries no note.
+            stream_limit=1,
+        ),
+    },
+)

--- a/docs/specs/spec-profile-registry.md
+++ b/docs/specs/spec-profile-registry.md
@@ -279,3 +279,20 @@ why both audio fixtures use that suffix.
   phase does not build (a mandatory last rung, copy-only acceptance, two drop
   reasons). Amended here rather than left to drift, since architecture is the
   living doc this phase alters.
+- 2026-08-25 (issue #5): `StreamRule.drop_reason` is typed `str | None`, not the
+  bare `str` its prose ("the reason a stream is dropped when there is no
+  fallback") might suggest, because MP4's video and audio rules always declare a
+  fallback encoder — the D3 branch that would read `drop_reason` is unreachable
+  for them, and giving it a real value there would read as a lie about what the
+  rule does. `None` marks "not applicable"; only MP4's subtitle rule sets it.
+- 2026-08-25 (issue #5): WAV's audio rule declares `accept_options=()` rather
+  than a placeholder copy template, because its copy mask is empty by
+  construction — the accept branch of `stream-decision.md` can never be reached
+  for it, so there is no real template to write.
+- 2026-08-25 (issue #5): `jobs.py` keeps `MP4_VIDEO_CODECS`, `MP4_AUDIO_CODECS`,
+  `TEXT_SUBTITLE_CODECS` and `FASTSTART` as its own module-level constants,
+  duplicating the values now also held by `profiles.MP4`'s rules and container
+  options. Issue #5's contract is "no ladder rewrite" — only `flags()` and
+  `Attempt` move — so `jobs.py`'s recipe functions still reference their own
+  copies. The duplication is temporary: issue #6 rewires `jobs.py` onto the
+  profile and removes it.

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,145 @@
+"""Tests for the leaf module and the two profiles it declares."""
+
+import ast
+import dataclasses
+import inspect
+
+import pytest
+
+from converter import profiles
+from converter.profiles import MP4, WAV, Attempt, Profile, StreamRule, flags
+
+
+class TestLeafModule:
+    def test_imports_nothing_from_converter(self):
+        """The leaf property is checked, not trusted: parse the actual import
+        statements (not the prose that happens to mention them) and assert none
+        names ``converter``."""
+        tree = ast.parse(inspect.getsource(profiles))
+        imported_modules = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported_modules += [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom) and node.module is not None:
+                imported_modules.append(node.module)
+
+        assert not any(
+            name == "converter" or name.startswith("converter.") for name in imported_modules
+        )
+
+
+class TestFlags:
+    def test_splits_a_command_line_shaped_string(self):
+        assert flags("-c:v copy -c:a aac") == ("-c:v", "copy", "-c:a", "aac")
+
+    def test_empty_spec_is_the_empty_tuple(self):
+        assert flags("") == ()
+
+
+class TestMp4Profile:
+    def test_label_and_suffix(self):
+        assert MP4.label == "MP4"
+        assert MP4.target_suffix == ".mp4"
+
+    def test_container_options_carry_faststart_once(self):
+        assert MP4.container_options == ("-movflags", "+faststart")
+
+    def test_cheap_attempt_excludes_container_options(self):
+        """The engine appends container options once; the declared attempt must
+        not repeat them (Prior decisions, spec-profile-registry)."""
+        assert MP4.cheap_attempt.label == "remux"
+        assert "-movflags" not in MP4.cheap_attempt.options
+        assert "+faststart" not in MP4.cheap_attempt.options
+
+    def test_cheap_attempt_selects_streams_blindly(self):
+        assert MP4.explicit_streams is False
+
+    def test_last_resort_excludes_container_options_too(self):
+        assert MP4.last_resort is not None
+        assert MP4.last_resort.label == "re-encode"
+        assert "-movflags" not in MP4.last_resort.options
+
+    def test_has_exactly_the_three_stream_rules(self):
+        assert set(MP4.rules) == {"video", "audio", "subtitle"}
+
+    def test_video_and_audio_rules_carry_the_position_placeholder(self):
+        for stream_type in ("video", "audio"):
+            rule = MP4.rules[stream_type]
+            assert "{n}" in " ".join(rule.accept_options)
+            assert rule.fallback_options is not None
+            assert "{n}" in " ".join(rule.fallback_options)
+
+    def test_subtitle_rule_transcodes_to_mov_text_and_has_no_fallback(self):
+        rule = MP4.rules["subtitle"]
+
+        assert rule.accept_options == ("-c:s:{n}", "mov_text")
+        assert rule.fallback_options is None
+        assert rule.drop_reason == "bitmap subtitles cannot be stored in MP4"
+
+
+class TestWavProfile:
+    def test_label_and_suffix(self):
+        assert WAV.label == "WAV"
+        assert WAV.target_suffix == ".wav"
+
+    def test_no_container_options(self):
+        assert WAV.container_options == ()
+
+    def test_cheap_attempt_selects_streams_explicitly(self):
+        assert WAV.explicit_streams is True
+        assert WAV.cheap_attempt.options == ("-map", "0:a:0", "-c:a", "pcm_s16le")
+
+    def test_declares_no_last_resort(self):
+        assert WAV.last_resort is None
+
+    def test_declares_only_an_audio_rule(self):
+        assert set(WAV.rules) == {"audio"}
+
+    def test_audio_rule_has_an_empty_copy_mask(self):
+        assert WAV.rules["audio"].copy_mask == frozenset()
+
+    def test_audio_rule_fallback_is_placeholder_free(self):
+        rule = WAV.rules["audio"]
+
+        assert rule.fallback_options == ("-c:a", "pcm_s16le")
+        assert "{n}" not in " ".join(rule.fallback_options)
+        assert "{n}" not in " ".join(rule.accept_options)
+
+    def test_audio_rule_fallback_carries_no_re_encode_note(self):
+        """Decoding to PCM is the point of WAV, not a loss."""
+        assert WAV.rules["audio"].fallback_name is None
+
+    def test_audio_rule_stream_limit_is_one(self):
+        assert WAV.rules["audio"].stream_limit == 1
+
+
+class TestValueTypesAreFrozen:
+    def test_attempt_is_frozen(self):
+        attempt = Attempt(label="x", options=())
+
+        with pytest.raises(AttributeError):
+            attempt.label = "y"
+
+    def test_stream_rule_is_frozen(self):
+        rule = StreamRule(copy_mask=frozenset(), accept_options=())
+
+        with pytest.raises(AttributeError):
+            rule.copy_mask = frozenset({"x"})
+
+    def test_profile_is_frozen(self):
+        with pytest.raises(AttributeError):
+            MP4.label = "changed"
+
+    def test_profile_dataclass_shape(self):
+        """Sanity check the type itself, not just the two instances."""
+        fields = {f.name for f in dataclasses.fields(Profile)}
+
+        assert fields == {
+            "label",
+            "target_suffix",
+            "container_options",
+            "cheap_attempt",
+            "explicit_streams",
+            "rules",
+            "last_resort",
+        }


### PR DESCRIPTION
## Summary

Creates `converter/profiles.py` as a leaf module (`docs/architecture.md`) — no `from converter` / `import converter` statement anywhere in it — holding `Attempt`, `StreamRule` and `Profile` as frozen dataclasses, plus `flags()` moved out of `jobs.py`. Declares the two profile entries this phase needs, `MP4` and `WAV`, shaped per `docs/specs/spec-profile-registry.md`'s Prior-decisions rows:

- **MP4**: video/audio/subtitle rules carrying the `{n}` output-position placeholder; `+faststart` declared once as a container option and excluded from the declared `remux` and `re-encode` attempts.
- **WAV**: empty copy mask, placeholder-free `pcm_s16le` fallback with no re-encode note (decoding to PCM is the point of WAV, not a loss), stream limit 1, no rule for any other stream type.

`jobs.py`'s ladder itself is untouched — the only change there is importing `Attempt`/`flags` from their new home instead of defining them locally. Rewriting the engine onto the profile (`docs/design/degradation-ladder.md`, `docs/design/stream-decision.md`) is issue #6.

Decisions made during implementation (drop_reason typed `Optional`, WAV's empty accept template, the temporary duplication of MP4's codec sets/`FASTSTART` in `jobs.py` until issue #6) are recorded in the spec's Decision log.

## Verification

- `.\.venv\Scripts\python.exe scripts\verify.py` — ruff check, ruff format --check, pytest: all green (165 passed).
- New test `tests/test_profiles.py::TestLeafModule::test_imports_nothing_from_converter` parses the module's AST and asserts no import names `converter` — the leaf rule checked, not trusted.
- `git diff main -- converter/cli.py converter/batch.py converter/paths.py` is empty.

Closes #5