### PR TITLE
refactor(jobs): drive the attempt ladder from a profile

### DIFF
--- a/converter/jobs.py
+++ b/converter/jobs.py
@@ -1,24 +1,25 @@
-"""The conversion recipes, expressed as ffmpeg option lists.
+"""The generic conversion engine: profile plus probed streams -> attempt ladder.
 
-Each job is a cheap first attempt plus an optional ladder of fallbacks that is
-only consulted -- and only pays for an ffprobe round-trip -- once the first
-attempt has actually failed.
+The engine holds no format-specific fact -- no codec name, no container option,
+no degradation-note wording. Every such fact lives in the ``Profile`` it is
+handed (``converter/profiles.py``) and is read out of that data, never written
+here. The two exceptions are ``Job`` -- the public shape ``cli.py`` and
+``batch.py`` already depend on -- and ``JOB_BINDINGS`` below it, which is CLI
+wiring (source suffixes, sub-command name, progress-bar label) rather than
+target-format knowledge, and is marked as phase-2 scaffolding: it disappears
+once ``--to`` replaces the ``video``/``audio`` sub-commands
+(``docs/specs/spec-profile-registry.md``).
+
+See ``docs/design/degradation-ladder.md`` for the order of attempts this module
+builds, and ``docs/design/stream-decision.md`` for how one stream's fate is
+decided inside the engine-built rung.
 """
 
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 from converter.ffmpegtool import Stream
-from converter.profiles import Attempt, flags
-
-#: Codecs a standard MP4 container accepts, so they can be stream-copied.
-MP4_VIDEO_CODECS = frozenset({"h264", "hevc", "av1", "vp9", "mpeg4", "mpeg2video", "mjpeg"})
-MP4_AUDIO_CODECS = frozenset({"aac", "mp3", "ac3", "eac3", "alac", "opus", "flac"})
-#: Subtitle codecs that convert cleanly into MP4's own ``mov_text``.
-TEXT_SUBTITLE_CODECS = frozenset({"subrip", "srt", "ass", "ssa", "mov_text", "webvtt", "text"})
-
-#: Move the MP4 index to the front so the file plays before it is fully read.
-FASTSTART = ("-movflags", "+faststart")
+from converter.profiles import MP4, WAV, Attempt, Profile
 
 
 @dataclass(frozen=True)
@@ -33,143 +34,166 @@ class Job:
     retries: Callable[[Sequence[Stream]], list[Attempt]] = field(repr=False)
 
 
-def mp4_remux() -> Attempt:
-    """Stream-copy everything a viewer cares about: lossless and near-instant."""
-    # Deliberately not "-map 0": that also selects MKV attachments (font files
-    # for ASS subtitles) and data streams, which MP4 cannot hold, so an
-    # otherwise perfectly remuxable file would fail.  The trailing "?" makes
-    # each selector optional instead of fatal.
-    return Attempt(
-        label="remux",
-        options=flags("-map 0:v? -map 0:a? -map 0:s? -c copy -c:s mov_text") + FASTSTART,
-    )
+def _with_container_options(attempt: Attempt, profile: Profile) -> Attempt:
+    """Append the profile's container-wide options once, at the end of *attempt*.
+
+    Declared attempts exclude them by convention (Prior decisions,
+    spec-profile-registry) so a profile states ``+faststart`` once rather than
+    repeating it in every attempt it declares.
+    """
+    return replace(attempt, options=(*attempt.options, *profile.container_options))
 
 
-def _mp4_selective(streams: Sequence[Stream]) -> Attempt | None:
-    """Copy what MP4 accepts, re-encode what it does not, drop what it cannot hold.
+def _substitute_position(template: tuple[str, ...], position: int) -> tuple[str, ...]:
+    """Replace the optional literal ``{n}`` placeholder with an output position."""
+    return tuple(item.replace("{n}", str(position)) for item in template)
 
-    Output stream specifiers such as ``-c:a:1`` count per type in mapping order,
-    which is exactly what the per-type counters below track.
+
+def _drop_note(stream: Stream, reason: str) -> str:
+    """D1/D2/D3 of stream-decision.md: a drop always names index, codec, reason."""
+    kind = stream.codec_type or "unknown"
+    codec = stream.codec_name or "unknown"
+    return f"{kind} stream {stream.index} ({codec}) dropped: {reason}"
+
+
+def _reencode_note(stream: Stream, target_codec: str) -> str:
+    """The note a re-encode carries when the rule declares one worth naming."""
+    kind = stream.codec_type or "unknown"
+    codec = stream.codec_name or "unknown"
+    return f"{kind} stream {stream.index} ({codec}) re-encoded to {target_codec}"
+
+
+def _room_reason(profile: Profile, stream_type: str, limit: int) -> str:
+    """D2's reason: the noun agrees in number with the rule's stream limit."""
+    noun = "stream" if limit == 1 else "streams"
+    return f"{profile.label} holds {limit} {stream_type} {noun}"
+
+
+def _decide_stream(
+    profile: Profile, stream: Stream, counts: dict[str, int]
+) -> tuple[list[str], list[str], str | None]:
+    """One pass through stream-decision.md's flowchart for a single stream.
+
+    Returns the maps and codec options *stream* contributes and the note it
+    produces (or ``None``). ``counts`` is mutated so later streams see how many
+    output streams of their type already exist.
+    """
+    rule = profile.rules.get(stream.codec_type)
+    if rule is None:
+        return [], [], _drop_note(stream, f"not supported by {profile.label}")
+
+    position = counts.get(stream.codec_type, 0)
+    if rule.stream_limit is not None and position >= rule.stream_limit:
+        reason = _room_reason(profile, stream.codec_type, rule.stream_limit)
+        return [], [], _drop_note(stream, reason)
+
+    maps = ["-map", f"0:{stream.index}"]
+    if stream.codec_name in rule.copy_mask:
+        codecs = list(_substitute_position(rule.accept_options, position))
+        note = None
+    elif rule.fallback_options is not None:
+        codecs = list(_substitute_position(rule.fallback_options, position))
+        note = _reencode_note(stream, rule.fallback_name) if rule.fallback_name else None
+    else:
+        reason = rule.drop_reason or f"not supported by {profile.label}"
+        return [], [], _drop_note(stream, reason)
+
+    counts[stream.codec_type] = position + 1
+    return maps, codecs, note
+
+
+def _build_selective(profile: Profile, streams: Sequence[Stream]) -> Attempt | None:
+    """The engine-built rung: the PLAN and SEL nodes of degradation-ladder.md.
+
+    Returns ``None`` when the rung would add nothing over the cheap attempt --
+    either no stream survives at all, or the cheap attempt already selects
+    streams explicitly and this plan gives up nothing worth naming.
     """
     maps: list[str] = []
     codecs: list[str] = []
     notes: list[str] = []
-    seen = {"video": 0, "audio": 0, "subtitle": 0}
+    counts: dict[str, int] = {}
 
     for stream in streams:
-        codec = stream.codec_name or "unknown"
-        if stream.codec_type == "video":
-            position = seen["video"]
-            maps += ["-map", f"0:{stream.index}"]
-            if stream.codec_name in MP4_VIDEO_CODECS:
-                codecs += [f"-c:v:{position}", "copy"]
-            else:
-                codecs += [f"-c:v:{position}", "libx264", f"-crf:v:{position}", "18"]
-                notes.append(f"video stream {stream.index} ({codec}) re-encoded to h264")
-            seen["video"] += 1
-        elif stream.codec_type == "audio":
-            position = seen["audio"]
-            maps += ["-map", f"0:{stream.index}"]
-            if stream.codec_name in MP4_AUDIO_CODECS:
-                codecs += [f"-c:a:{position}", "copy"]
-            else:
-                codecs += [f"-c:a:{position}", "aac", f"-b:a:{position}", "192k"]
-                notes.append(f"audio stream {stream.index} ({codec}) re-encoded to aac")
-            seen["audio"] += 1
-        elif stream.codec_type == "subtitle":
-            if stream.codec_name in TEXT_SUBTITLE_CODECS:
-                position = seen["subtitle"]
-                maps += ["-map", f"0:{stream.index}"]
-                codecs += [f"-c:s:{position}", "mov_text"]
-                seen["subtitle"] += 1
-            else:
-                notes.append(
-                    f"subtitle stream {stream.index} ({codec}) dropped: "
-                    "bitmap subtitles cannot be stored in MP4"
-                )
-        else:
-            notes.append(
-                f"{stream.codec_type or 'unknown'} stream {stream.index} dropped: "
-                "not supported by MP4"
-            )
+        stream_maps, stream_codecs, note = _decide_stream(profile, stream, counts)
+        maps += stream_maps
+        codecs += stream_codecs
+        if note is not None:
+            notes.append(note)
 
     if not maps:
         return None
-    return Attempt("selective", (*maps, *codecs, *FASTSTART), tuple(notes))
+    if profile.explicit_streams and not notes:
+        return None
+    return Attempt("selective", (*maps, *codecs), tuple(notes))
 
 
-def mp4_reencode() -> Attempt:
-    """Last resort: one video and all audio streams, re-encoded for compatibility."""
-    return Attempt(
-        label="re-encode",
-        options=flags(
-            "-map 0:v:0? -map 0:a? "
-            "-c:v libx264 -crf 18 -preset medium -pix_fmt yuv420p "
-            "-c:a aac -b:a 192k"
-        )
-        + FASTSTART,
-        notes=(
-            "re-encoded to h264/aac (lossy); subtitles and extra video streams dropped",
-            "10-bit or HDR sources are reduced to 8-bit yuv420p for player compatibility",
-        ),
+def make_attempts(
+    profile: Profile,
+) -> tuple[Callable[[], Attempt], Callable[[Sequence[Stream]], list[Attempt]]]:
+    """Build the ``(first_attempt, retries)`` pair degradation-ladder.md needs."""
+
+    def first_attempt() -> Attempt:
+        return _with_container_options(profile.cheap_attempt, profile)
+
+    def retries(streams: Sequence[Stream]) -> list[Attempt]:
+        attempts: list[Attempt] = []
+        selective = _build_selective(profile, streams)
+        if selective is not None:
+            attempts.append(_with_container_options(selective, profile))
+        if profile.last_resort is not None:
+            attempts.append(_with_container_options(profile.last_resort, profile))
+        return attempts
+
+    return first_attempt, retries
+
+
+@dataclass(frozen=True)
+class _Binding:
+    """A source-pair binding: CLI-visible name plus which suffixes feed which
+    profile. This is CLI wiring, not target-format knowledge -- the exemption
+    the module docstring describes -- and is phase-2 scaffolding, removed once
+    ``--to`` replaces the ``video``/``audio`` sub-commands.
+    """
+
+    name: str
+    description: str
+    suffixes: tuple[str, ...]
+    profile: Profile
+
+
+#: Phase-2 scaffolding (see the module docstring and ``_Binding``).
+JOB_BINDINGS: dict[str, _Binding] = {
+    "video": _Binding(
+        name="mkv-to-mp4",
+        description="Convert .mkv files to .mp4 (stream copy where possible)",
+        suffixes=(".mkv",),
+        profile=MP4,
+    ),
+    "audio": _Binding(
+        name="opus-to-wav",
+        description="Convert .opus files to uncompressed .wav",
+        suffixes=(".opus",),
+        profile=WAV,
+    ),
+}
+
+
+def _job_from_binding(binding: _Binding) -> Job:
+    """The factory the issue asks for: wire the generic engine to one profile."""
+    first_attempt, retries = make_attempts(binding.profile)
+    return Job(
+        name=binding.name,
+        description=binding.description,
+        suffixes=binding.suffixes,
+        target_suffix=binding.profile.target_suffix,
+        first_attempt=first_attempt,
+        retries=retries,
     )
 
 
-def mp4_retries(streams: Sequence[Stream]) -> list[Attempt]:
-    """The fallback ladder for MKV -> MP4, most conservative first."""
-    attempts = []
-    selective = _mp4_selective(streams)
-    if selective is not None:
-        attempts.append(selective)
-    attempts.append(mp4_reencode())
-    return attempts
-
-
-def wav_pcm() -> Attempt:
-    """Decode the first audio stream to signed 16-bit PCM.
-
-    The stream is selected explicitly rather than left to ffmpeg's implicit
-    "best stream" heuristic, so a file with several audio streams converts
-    predictably instead of quietly depending on which one ffmpeg prefers.
-    Mapping audio only also drops any embedded cover art, which WAV cannot hold.
-    """
-    return Attempt(label="pcm_s16le", options=flags("-map 0:a:0 -c:a pcm_s16le"))
-
-
-def wav_retries(streams: Sequence[Stream]) -> list[Attempt]:
-    """WAV holds a single audio stream, so fall back to keeping just the first."""
-    audio = [stream for stream in streams if stream.codec_type == "audio"]
-    if len(audio) <= 1:
-        return []
-    return [
-        Attempt(
-            label="first-audio-stream",
-            options=("-map", f"0:{audio[0].index}", "-c:a", "pcm_s16le"),
-            notes=(
-                f"{len(audio)} audio streams present; kept stream {audio[0].index} "
-                "only (WAV holds one)",
-            ),
-        )
-    ]
-
-
-MKV_TO_MP4 = Job(
-    name="mkv-to-mp4",
-    description="Convert .mkv files to .mp4 (stream copy where possible)",
-    suffixes=(".mkv",),
-    target_suffix=".mp4",
-    first_attempt=mp4_remux,
-    retries=mp4_retries,
-)
-
-OPUS_TO_WAV = Job(
-    name="opus-to-wav",
-    description="Convert .opus files to uncompressed .wav",
-    suffixes=(".opus",),
-    target_suffix=".wav",
-    first_attempt=wav_pcm,
-    retries=wav_retries,
-)
+MKV_TO_MP4 = _job_from_binding(JOB_BINDINGS["video"])
+OPUS_TO_WAV = _job_from_binding(JOB_BINDINGS["audio"])
 
 #: Sub-command name -> job.
 JOBS: dict[str, Job] = {"video": MKV_TO_MP4, "audio": OPUS_TO_WAV}

--- a/docs/constitution.md
+++ b/docs/constitution.md
@@ -71,6 +71,5 @@
 | Deviation | Where | Plan |
 | --------- | ----- | ---- |
 | `convert_command` is 54 lines, over the 50-line limit | `converter/cli.py` | Phase 2 rewrites it target-format-driven; split it there |
-| `_mp4_selective` is 51 lines, over the 50-line limit | `converter/jobs.py` | Phase 1 replaces it with profile-driven logic |
 | Ruff `D` (pydocstyle) rules are not enabled, so the docstring convention rests on review | `pyproject.toml` | Enable pydocstyle once the noise is acceptable |
 | The README names `develop` as the pull-request target | `README.md` | The base branch is `main`; correct it with the next docs change |

--- a/docs/specs/spec-profile-registry.md
+++ b/docs/specs/spec-profile-registry.md
@@ -296,3 +296,26 @@ why both audio fixtures use that suffix.
   `Attempt` move — so `jobs.py`'s recipe functions still reference their own
   copies. The duplication is temporary: issue #6 rewires `jobs.py` onto the
   profile and removes it.
+- 2026-08-25 (issue #6): the per-stream decision is drawn as a single helper,
+  `_decide_stream`, that returns `(maps, codecs, note)` for one stream and
+  mutates a shared `counts` dict rather than the caller threading a returned
+  counter back in. A pure "return the incremented count too" shape was
+  rejected: `_build_selective`'s loop would then have to unpack and re-store
+  `counts[stream.codec_type]` itself, duplicating the bookkeeping
+  `_decide_stream` already has all the information to do once.
+- 2026-08-25 (issue #6): `JOB_BINDINGS` is keyed by the same strings as `JOBS`
+  (`"video"`, `"audio"`) and holds a small frozen `_Binding` (name,
+  description, suffixes, profile) rather than a bare tuple, so the phase-2
+  removal this table is scaffolding for can delete one dataclass and one dict
+  without hunting through positional-tuple indexing elsewhere.
+- 2026-08-25 (issue #6): confirmed on this machine's ffmpeg (9.0, gyan.dev
+  build) that the milestone-QA `lossless.mkv` fixture's cheap remux attempt
+  (`-c copy` into MP4) exits 0 even though the source is `ffv1`, so the ladder
+  is not forced by that fixture in practice here — this is unchanged from
+  `main` (the cheap-attempt argv is byte-identical), not a regression. The
+  ladder logic was verified directly instead: probing the fixture with real
+  ffprobe and calling `MKV_TO_MP4.retries()` on the result produces the
+  expected selective rung (video re-encoded to h264, noting `ffv1`), and running
+  that rung's argv through real ffmpeg succeeds and produces a valid file. The
+  same direct check was run for `attached.mkv` (delta 1) and `two-tone.opus`
+  (delta 2/3), all matching the design.

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -6,14 +6,7 @@ import pytest
 
 from converter import ffmpegtool
 from converter.ffmpegtool import Stream, build_argv, cli_path
-from converter.jobs import (
-    MKV_TO_MP4,
-    OPUS_TO_WAV,
-    mp4_remux,
-    mp4_retries,
-    wav_pcm,
-    wav_retries,
-)
+from converter.jobs import MKV_TO_MP4, OPUS_TO_WAV
 
 
 def options_of(argv: list[str], src: str, dst: str) -> list[str]:
@@ -97,7 +90,7 @@ class TestRunIsShellFree:
 
 class TestWavJob:
     def test_first_attempt_is_pcm(self):
-        attempt = wav_pcm()
+        attempt = OPUS_TO_WAV.first_attempt()
 
         assert attempt.options == ("-map", "0:a:0", "-c:a", "pcm_s16le")
         assert attempt.notes == ()
@@ -105,16 +98,32 @@ class TestWavJob:
     def test_single_audio_stream_needs_no_fallback(self):
         streams = [Stream(0, "audio", "opus")]
 
-        assert wav_retries(streams) == []
+        assert OPUS_TO_WAV.retries(streams) == []
 
-    def test_multiple_audio_streams_fall_back_to_the_first(self):
+    def test_multiple_audio_streams_fall_back_to_a_selective_rung(self):
+        """Deltas 2 and 3: the note names the dropped stream and its codec, and
+        the engine-built rung is labelled 'selective' rather than
+        'first-audio-stream'. The argv is unchanged."""
         streams = [Stream(0, "audio", "opus"), Stream(1, "audio", "opus")]
 
-        attempts = wav_retries(streams)
+        attempts = OPUS_TO_WAV.retries(streams)
 
         assert len(attempts) == 1
+        assert attempts[0].label == "selective"
         assert attempts[0].options == ("-map", "0:0", "-c:a", "pcm_s16le")
-        assert "kept stream 0" in attempts[0].notes[0]
+        assert attempts[0].notes == ("audio stream 1 (opus) dropped: WAV holds 1 audio stream",)
+
+    def test_non_audio_stream_gains_a_selective_rung_on_the_failure_path(self):
+        """Delta 4: an embedded cover-art stream used to produce no retry at
+        all; it now reaches a selective rung that drops it with a note."""
+        streams = [Stream(0, "audio", "opus"), Stream(1, "video", "mjpeg")]
+
+        attempts = OPUS_TO_WAV.retries(streams)
+
+        assert len(attempts) == 1
+        assert attempts[0].label == "selective"
+        assert attempts[0].options == ("-map", "0:0", "-c:a", "pcm_s16le")
+        assert attempts[0].notes == ("video stream 1 (mjpeg) dropped: not supported by WAV",)
 
     def test_job_metadata(self):
         assert OPUS_TO_WAV.suffixes == (".opus",)
@@ -123,7 +132,7 @@ class TestWavJob:
 
 class TestMp4Remux:
     def test_stream_copies_and_converts_text_subtitles(self):
-        options = mp4_remux().options
+        options = MKV_TO_MP4.first_attempt().options
 
         assert "-c" in options
         assert options[options.index("-c") + 1] == "copy"
@@ -133,7 +142,7 @@ class TestMp4Remux:
     def test_does_not_use_bare_map_zero(self):
         """'-map 0' also selects MKV attachments and data streams, which MP4
         cannot hold, so a remuxable file would fail for no good reason."""
-        options = list(mp4_remux().options)
+        options = list(MKV_TO_MP4.first_attempt().options)
         mapped = [options[i + 1] for i, flag in enumerate(options) if flag == "-map"]
 
         assert "0" not in mapped
@@ -142,19 +151,32 @@ class TestMp4Remux:
     def test_job_metadata(self):
         assert MKV_TO_MP4.suffixes == (".mkv",)
         assert MKV_TO_MP4.target_suffix == ".mp4"
-        assert MKV_TO_MP4.first_attempt() == mp4_remux()
+        assert MKV_TO_MP4.first_attempt().options == (
+            "-map",
+            "0:v?",
+            "-map",
+            "0:a?",
+            "-map",
+            "0:s?",
+            "-c",
+            "copy",
+            "-c:s",
+            "mov_text",
+            "-movflags",
+            "+faststart",
+        )
 
 
 class TestMp4Retries:
     def test_ladder_ends_with_a_full_reencode(self):
-        attempts = mp4_retries([Stream(0, "video", "h264")])
+        attempts = MKV_TO_MP4.retries([Stream(0, "video", "h264")])
 
         assert [a.label for a in attempts] == ["selective", "re-encode"]
 
     def test_selective_copies_compatible_streams(self):
         streams = [Stream(0, "video", "h264"), Stream(1, "audio", "aac")]
 
-        selective = mp4_retries(streams)[0]
+        selective = MKV_TO_MP4.retries(streams)[0]
 
         assert selective.options[:8] == (
             "-map",
@@ -171,7 +193,7 @@ class TestMp4Retries:
     def test_selective_reencodes_audio_mp4_cannot_hold(self):
         streams = [Stream(0, "video", "h264"), Stream(1, "audio", "pcm_s16le")]
 
-        selective = mp4_retries(streams)[0]
+        selective = MKV_TO_MP4.retries(streams)[0]
 
         assert "-c:a:0" in selective.options
         assert selective.options[selective.options.index("-c:a:0") + 1] == "aac"
@@ -184,7 +206,7 @@ class TestMp4Retries:
             Stream(2, "subtitle", "hdmv_pgs_subtitle"),
         ]
 
-        selective = mp4_retries(streams)[0]
+        selective = MKV_TO_MP4.retries(streams)[0]
 
         assert "-map" in selective.options
         assert "0:2" not in selective.options
@@ -193,18 +215,19 @@ class TestMp4Retries:
     def test_selective_keeps_text_subtitles_as_mov_text(self):
         streams = [Stream(0, "video", "h264"), Stream(1, "subtitle", "subrip")]
 
-        selective = mp4_retries(streams)[0]
+        selective = MKV_TO_MP4.retries(streams)[0]
 
         assert "-c:s:0" in selective.options
         assert selective.options[selective.options.index("-c:s:0") + 1] == "mov_text"
 
     def test_selective_drops_attachments_with_a_note(self):
+        """Delta 1: the note now names the codec too."""
         streams = [Stream(0, "video", "h264"), Stream(1, "attachment", "ttf")]
 
-        selective = mp4_retries(streams)[0]
+        selective = MKV_TO_MP4.retries(streams)[0]
 
         assert "0:1" not in selective.options
-        assert any("attachment" in note for note in selective.notes)
+        assert selective.notes == ("attachment stream 1 (ttf) dropped: not supported by MP4",)
 
     def test_output_specifiers_count_per_type_in_map_order(self):
         """Interleaved streams must still yield -c:a:0 and -c:a:1, not -c:a:1/-c:a:3."""
@@ -215,7 +238,7 @@ class TestMp4Retries:
             Stream(3, "audio", "flac"),
         ]
 
-        selective = mp4_retries(streams)[0]
+        selective = MKV_TO_MP4.retries(streams)[0]
 
         assert "-c:a:0" in selective.options
         assert "-c:a:1" in selective.options
@@ -224,12 +247,12 @@ class TestMp4Retries:
         assert "-c:s:0" in selective.options
 
     def test_no_mappable_stream_skips_straight_to_reencode(self):
-        attempts = mp4_retries([Stream(0, "attachment", "ttf")])
+        attempts = MKV_TO_MP4.retries([Stream(0, "attachment", "ttf")])
 
         assert [a.label for a in attempts] == ["re-encode"]
 
     def test_reencode_states_what_it_sacrifices(self):
-        reencode = mp4_retries([])[-1]
+        reencode = MKV_TO_MP4.retries([])[-1]
 
         assert "libx264" in reencode.options
         assert "aac" in reencode.options
@@ -237,7 +260,116 @@ class TestMp4Retries:
         assert any("lossy" in note for note in reencode.notes)
 
 
-@pytest.mark.parametrize("attempt", [mp4_remux(), *mp4_retries([Stream(0, "video", "h264")])])
+class TestProfileArgvPinning:
+    """Verification: the full argv each profile builds, pinned byte-for-byte
+    (docs/specs/spec-profile-registry.md)."""
+
+    def test_mp4_copyable_source(self):
+        streams = [Stream(0, "video", "h264"), Stream(1, "audio", "aac")]
+        selective = MKV_TO_MP4.retries(streams)[0]
+
+        argv = build_argv("ffmpeg", "in.mkv", selective.options, "out.mp4")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:0",
+            "-map",
+            "0:1",
+            "-c:v:0",
+            "copy",
+            "-c:a:0",
+            "copy",
+            "-movflags",
+            "+faststart",
+            "out.mp4",
+        ]
+
+    def test_mp4_non_copyable_source(self):
+        streams = [Stream(0, "video", "vp8"), Stream(1, "audio", "pcm_s16le")]
+        selective = MKV_TO_MP4.retries(streams)[0]
+
+        argv = build_argv("ffmpeg", "in.mkv", selective.options, "out.mp4")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:0",
+            "-map",
+            "0:1",
+            "-c:v:0",
+            "libx264",
+            "-crf:v:0",
+            "18",
+            "-c:a:0",
+            "aac",
+            "-b:a:0",
+            "192k",
+            "-movflags",
+            "+faststart",
+            "out.mp4",
+        ]
+
+    def test_wav_single_audio_source(self):
+        argv = build_argv("ffmpeg", "in.opus", OPUS_TO_WAV.first_attempt().options, "out.wav")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.opus",
+            "-map",
+            "0:a:0",
+            "-c:a",
+            "pcm_s16le",
+            "out.wav",
+        ]
+
+    def test_wav_two_audio_source(self):
+        streams = [Stream(0, "audio", "opus"), Stream(1, "audio", "opus")]
+        selective = OPUS_TO_WAV.retries(streams)[0]
+
+        argv = build_argv("ffmpeg", "in.opus", selective.options, "out.wav")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.opus",
+            "-map",
+            "0:0",
+            "-c:a",
+            "pcm_s16le",
+            "out.wav",
+        ]
+
+
+@pytest.mark.parametrize(
+    "attempt",
+    [MKV_TO_MP4.first_attempt(), *MKV_TO_MP4.retries([Stream(0, "video", "h264")])],
+)
 def test_every_attempt_produces_a_wellformed_command(attempt):
     argv = build_argv("ffmpeg", "in.mkv", attempt.options, "out.mp4")
 


### PR DESCRIPTION
## Summary

Replaces the two hand-written MP4/WAV recipes in `converter/jobs.py` with one
generic engine that turns a target profile (`converter/profiles.py`, from
#5/#9) plus a probed stream list into an ordered ladder of attempts, per
`docs/design/degradation-ladder.md` and `docs/design/stream-decision.md`.

- `jobs.py` holds no codec name, container option or degradation-note wording
  of its own. The one exemption, `JOB_BINDINGS`, is CLI wiring (source
  suffixes, sub-command name, progress-bar label) and is marked in the module
  as phase-2 scaffolding.
- `Job` keeps its public shape and `JOBS` its keys; `MKV_TO_MP4` and
  `OPUS_TO_WAV` are now built from `profiles.MP4` / `profiles.WAV` by a
  factory (`_job_from_binding`).
- `converter/cli.py`, `converter/batch.py` and `converter/paths.py` have an
  empty diff (checked explicitly with `git diff main -- ...`).
- Every argv assertion in `tests/test_argv.py` and `tests/test_batch.py` is
  preserved verbatim. Note-text assertions changed only for the four
  *Accepted behaviour deltas* the spec closes: the attachment/unknown-stream
  note now names the codec, the surplus-audio-stream note is per-stream
  instead of per-file, WAV's fallback rung is labelled `selective` instead of
  `first-audio-stream`, and a WAV source carrying a non-audio stream now
  reaches a rung on the failure path.
- New `TestProfileArgvPinning` tests pin the full argv MP4 builds for a
  copyable (h264+aac) and non-copyable (vp8+pcm_s16le) source, and WAV builds
  for a single- and two-audio-stream source.
- Removed the `_mp4_selective` row from the tech-debt table in
  `docs/constitution.md` now that the 51-line function it flagged is gone.
- Recorded three decisions on `docs/specs/spec-profile-registry.md`'s
  Decision log: the shared-mutable-`counts` shape for `_decide_stream`, the
  `_Binding` dataclass for `JOB_BINDINGS`, and an ffmpeg-version note (this
  machine's ffmpeg 9.0 happens to remux `ffv1` into MP4 without failing, so
  the milestone-QA `lossless.mkv` fixture doesn't force the ladder here --
  unchanged from `main` since the cheap-attempt argv is byte-identical; the
  ladder logic was verified directly against real ffprobe output instead).

## Verification

- `.\.venv\Scripts\python.exe scripts\verify.py` -- ruff check, ruff format
  --check, pytest: all green (170 passed).
- `.\.venv\Scripts\python.exe -m pytest` -- 170 passed.
- `.\.venv\Scripts\python.exe -m pip wheel . --no-deps -w <tmpdir>` -- builds
  cleanly.
- `git diff main -- converter/cli.py converter/batch.py converter/paths.py`
  -- empty.
- No function in `jobs.py` or `profiles.py` exceeds 50 lines (checked via
  `ast`).
- Real ffmpeg/ffprobe smoke test: `converter video`/`converter audio`
  convert the milestone-QA fixtures and a second run reports 0
  converted/skips the rest. The ladder was exercised directly against real
  probed streams for `lossless.mkv`, `attached.mkv` and `two-tone.opus`; each
  produced the expected selective rung, and every rung's argv ran cleanly
  through real ffmpeg.

Closes #6