### PR TITLE
test(profiles): pin the argv and every degradation note

### DIFF
--- a/docs/specs/spec-profile-registry.md
+++ b/docs/specs/spec-profile-registry.md
@@ -319,3 +319,12 @@ why both audio fixtures use that suffix.
   that rung's argv through real ffmpeg succeeds and produces a valid file. The
   same direct check was run for `attached.mkv` (delta 1) and `two-tone.opus`
   (delta 2/3), all matching the design.
+- 2026-08-25 (issue #7): several notes already asserted by issue #6's tests
+  used substring checks (`"pcm_s16le" in note and "aac" in note`) rather than
+  pinning the exact string, which does not satisfy Verification's "names the
+  stream index, that stream's codec, and what was given up" for the video- and
+  audio-reencode and bitmap-subtitle-drop branches, nor pin the last-resort
+  attempt's own two notes. Left the existing (weaker) tests untouched per the
+  no-rewrite rule on the safety net and added new tests next to them
+  (`TestMp4DegradationNotes` in `tests/test_argv.py`) asserting exact equality
+  instead. No engine or profile code changed — this issue is test-only.

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -129,6 +129,18 @@ class TestWavJob:
         assert OPUS_TO_WAV.suffixes == (".opus",)
         assert OPUS_TO_WAV.target_suffix == ".wav"
 
+    def test_pcm_reencode_of_the_kept_stream_carries_no_note(self):
+        """Decoding to PCM is WAV's own definition, not a loss (Verification,
+        spec-profile-registry): the kept stream takes the fallback branch --
+        WAV's copy mask is empty by construction -- yet contributes no note.
+        Only the surplus stream's drop is reported."""
+        streams = [Stream(0, "audio", "opus"), Stream(1, "audio", "opus")]
+
+        attempts = OPUS_TO_WAV.retries(streams)
+
+        assert len(attempts[0].notes) == 1
+        assert not any("stream 0" in note for note in attempts[0].notes)
+
 
 class TestMp4Remux:
     def test_stream_copies_and_converts_text_subtitles(self):
@@ -258,6 +270,50 @@ class TestMp4Retries:
         assert "aac" in reencode.options
         assert reencode.notes
         assert any("lossy" in note for note in reencode.notes)
+
+
+class TestMp4DegradationNotes:
+    """Verification (spec-profile-registry): one test per degradation branch,
+    each pinning the exact note -- stream index, that stream's codec, and what
+    was given up (docs/design/stream-decision.md)."""
+
+    def test_video_reencode_note_is_exact(self):
+        streams = [Stream(0, "video", "vp8"), Stream(1, "audio", "aac")]
+
+        selective = MKV_TO_MP4.retries(streams)[0]
+
+        assert selective.notes == ("video stream 0 (vp8) re-encoded to h264",)
+
+    def test_audio_reencode_note_is_exact(self):
+        streams = [Stream(0, "video", "h264"), Stream(1, "audio", "pcm_s16le")]
+
+        selective = MKV_TO_MP4.retries(streams)[0]
+
+        assert selective.notes == ("audio stream 1 (pcm_s16le) re-encoded to aac",)
+
+    def test_bitmap_subtitle_drop_note_is_exact(self):
+        streams = [
+            Stream(0, "video", "h264"),
+            Stream(1, "audio", "aac"),
+            Stream(2, "subtitle", "hdmv_pgs_subtitle"),
+        ]
+
+        selective = MKV_TO_MP4.retries(streams)[0]
+
+        assert selective.notes == (
+            "subtitle stream 2 (hdmv_pgs_subtitle) dropped: "
+            "bitmap subtitles cannot be stored in MP4",
+        )
+
+    def test_last_resort_notes_are_pinned(self):
+        """The two notes are the last-resort attempt's own data (Verification:
+        'lossy re-encode; 10-bit/HDR reduced to 8-bit'), not engine wording."""
+        reencode = MKV_TO_MP4.retries([])[-1]
+
+        assert reencode.notes == (
+            "re-encoded to h264/aac (lossy); subtitles and extra video streams dropped",
+            "10-bit or HDR sources are reduced to 8-bit yuv420p for player compatibility",
+        )
 
 
 class TestProfileArgvPinning:


### PR DESCRIPTION
## Summary

Pins the engine's degradation-note output with the tests
`docs/specs/spec-profile-registry.md`'s Verification section requires, so a
later target format cannot silently change an argv or drop a degradation
note. Issue #6 already carried most of the argv-pinning tests
(`TestProfileArgvPinning`) and several note checks, but a handful of those
note checks used substring matching (`"pcm_s16le" in note and "aac" in
note`) rather than pinning the exact string, which does not satisfy
Verification's "names the stream index, that stream's codec, and what was
given up."

Adds, in `tests/test_argv.py`:
- `TestMp4DegradationNotes`: exact-equality tests for the video-reencode,
  audio-reencode and bitmap-subtitle-drop notes, and the last-resort
  attempt's own two notes (pinned verbatim against `docs/design/stream-decision.md`
  and the profile's declared data).
- `TestWavJob.test_pcm_reencode_of_the_kept_stream_carries_no_note`: asserts
  WAV's PCM re-encode of the kept stream emits no note (decoding to PCM is
  WAV's own definition, not a loss), leaving only the surplus stream's drop
  note.

The existing (weaker) note assertions were left untouched rather than
rewritten, per the no-rewrite rule on the refactor's safety net — new tests
sit alongside them. No `converter/*.py` change: this issue is test-only.
The decision is recorded in the spec's Decision log.

## Verification

- `./.venv/Scripts/python.exe scripts/verify.py` — ruff check, ruff format
  --check, pytest all green (175 tests, up from 170).
- `git diff main -- converter/cli.py converter/batch.py converter/paths.py`
  is empty.
- Already-satisfied Verification items reused from issue #6, confirmed
  still present: full MP4 argv pinned (copyable h264+aac, non-copyable
  vp8+pcm_s16le), full WAV argv pinned (single- and two-audio), attachment
  drop / surplus-audio-drop / non-audio-dropped-by-WAV notes exact, the
  `selective` label for WAV's engine-built rung, and the WAV+non-audio-stream
  single-rung delta.

Closes #7