### PR TITLE
docs(spec): audio target profiles (roadmap phase 3)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,7 +13,7 @@
 |---|---|---|---|
 | 1 | profile-registry | [spec-profile-registry.md](specs/spec-profile-registry.md) | [#1](https://github.com/bhemsen/converter/milestone/1) |
 | 2 | target-driven-cli | [spec-target-driven-cli.md](specs/spec-target-driven-cli.md) | [#2](https://github.com/bhemsen/converter/milestone/2) |
-| 3 | audio-formats | — | — |
+| 3 | audio-formats | [spec-audio-formats.md](specs/spec-audio-formats.md) | [#3](https://github.com/bhemsen/converter/milestone/3) |
 | 4 | video-formats | — | — |
 | 5 | image-formats | — | — |
 

--- a/docs/specs/spec-audio-formats.md
+++ b/docs/specs/spec-audio-formats.md
@@ -130,7 +130,8 @@ reader should re-verify rather than trust the table.
 | **On the happy path the muxer is the authority, not the copy mask.** A stream copy that ffmpeg's muxer accepts ships, whether or not the mask lists that codec; the mask governs the *failure* path, where the engine builds the selective rung | Measured, not assumed: `--to opus` from a Vorbis `.ogg` under a blind `-c:a copy` exits 0 and writes a `.opus` file containing Vorbis. Nothing short of a probe can prevent that, and a probe on the happy path is forbidden. The per-profile cheap attempts below are chosen so that where the muxer is looser than the format's identity, the profile does not rely on a copy at all | 2026-08-25 |
 | The `cheap_attempt`, `explicit_streams` and `last_resort` of each of the **five new** profiles are fixed by the table below; `wav` is untouched and keeps phase 2's shape exactly | A blanket rule does not survive contact with the muxers: they differ in whether they enforce the target's codec, whether they hold several audio streams, and whether they reject a picture stream. Each of those differences changes what an honest cheap attempt looks like | 2026-08-25 |
 | `stream_limit=1` for `mp3` and `flac` only. `m4a`, `ogg` and `opus` declare **no** audio stream limit | Measured: the `mp3` and `flac` muxers both enforce exactly one audio stream, so the limit is real and a multi-stream source fails into the ladder, which names the stream it drops. `m4a`, `ogg` and `opus` accept several, so declaring a limit would mean mapping one stream and silently discarding the rest — a loss the tool could not name. Carrying every stream the container holds drops nothing at all, which is the better answer | 2026-08-25 |
-| OPEN — does `opus` copy or always encode? | resolved at the spec-acceptance gate, together with the standing-note decision; see the note below | — |
+| **`opus` copies**: its cheap attempt is `flags("-map 0:a? -c copy")` like the other four, `explicit_streams=False`, and it maps no video | Resolved at the gate on 2026-08-26. Generation loss on every already-Opus file was judged the worse price: it is inflicted on the common case, while the mislabel it would prevent is reachable only by pointing `--to opus` at a `.ogg`/`.oga` source. Consequence: no target maps video, so all five new profiles fall under the standing-note decision | 2026-08-26 |
+| Each of the five new profiles carries a **standing note** on its cheap attempt: non-audio streams, cover art included, are not carried into the target. `wav` does **not** get one | Resolved at the gate on 2026-08-26. Always true, never silent, and it needs no amendment to `docs/constitution.md` -- the price is that it prints on every file, including the many with nothing to lose. `wav` is excluded to keep this phase's "wav unchanged" promise and its phase-1 note assertion intact; its hole is named in this spec for a later phase to close | 2026-08-26 |
 | **Only `opus` maps video** in its cheap attempt. `mp3`, `m4a`, `flac` and `ogg` map audio only | Mapping video is worth it exactly where it turns a quiet loss into a *failure* the ladder can name. Measured, that is true only for `opus`: its cheap attempt carries no `-c:v`, so ffmpeg cannot select a video encoder and errors out, the ladder runs, and the picture stream is named. Every other target has a measured way to swallow video quietly — `m4a` copies a full h264 track through, `ogg` copies theora through (theora is the ogg muxer's own video codec, so a theora source arrives as a whole video file renamed `.ogg`), `flac` discards real video at exit 0 with only a stderr warning, and `mp3` writes a real video as a single frame. For those four, mapping video buys a silent wrong result instead of a note | 2026-08-25 |
 | `opus`'s `accept_options` is `flags("-c:a copy")`: the cheap attempt never copies, but the **selective rung does**, on a mask hit | "`opus` does not copy" is a statement about the cheap attempt alone. Following WAV's `accept_options=()` precedent here would emit a map with no codec option and produce an undeclared re-encode | 2026-08-25 |
 | The happy-path muxer-authority row is a problem only for a **codec-defined** target, where the extension names the codec. `.opus`, `.mp3` and `.flac` are codec-defined; `.m4a` and `.ogg` are container-defined, so an `.m4a` holding `ac3` (measured: it copies through, outside the declared mask) is unusual but not a lie | This is the criterion that exempts `m4a` and `ogg` from the treatment `opus` gets, and it stops `{aac, alac}` from being read later as a guarantee | 2026-08-25 |
@@ -140,7 +141,6 @@ reader should re-verify rather than trust the table.
 | `flac` and `wav` declare **`fallback_name=None`**, so an encode into them emits no note; the other four declare theirs, so a re-encode emits the engine's existing per-stream note naming the source codec and the target codec | Decoding into a container's own lossless codec gives up nothing. This is the rule phase 1 established for WAV, expressed with the one lever `jobs.py` has | 2026-08-25 |
 | **No generation-loss note** (a "your FLAC came from a 128 kbit/s MP3" warning) in this phase | It would need a lossy-codec set plus a new branch in `jobs.py`, and `Stream` carries no such notion — an engine change, which this phase's headline outcome forbids. Recorded below as a roadmap candidate rather than smuggled in | 2026-08-25 |
 | No audio profile declares a **video rule**, so any video stream — cover art included — is dropped by the selective rung with the engine's existing "not supported by TARGET" note | Keeping cover art needs the `attached_pic` disposition, which `probe_streams` does not request and `Stream` does not carry, so the engine cannot tell a picture from a real video stream. The muxer table shows what happens if you guess: `m4a` hard-fails on a real MJPEG while succeeding on a picture, and `mp3` silently truncates it to one frame | 2026-08-25 |
-| OPEN — what a conversion says when the cheap attempt **succeeds** and cover art is lost along the way | resolved at the spec-acceptance gate; see the note below | — |
 
 ### The five new profiles, fixed
 
@@ -152,7 +152,7 @@ reader should re-verify rather than trust the table.
 | `flac` | `-map 0:a? -c:a copy` | False | 1 | `-map 0:a:0 -c:a flac` |
 | `m4a` | `-map 0:a? -c:a copy` | False | none | `-map 0:a:0 -c:a aac -b:a 192k` |
 | `ogg` | `-map 0:a? -c copy` | False | none | `-map 0:a:0 -c:a libvorbis -q:a 5` |
-| `opus` | per the second open decision | False | none | `-map 0:a:0 -c:a libopus -b:a 128k` |
+| `opus` | `-map 0:a? -c copy` | False | none | `-map 0:a:0 -c:a libopus -b:a 128k` |
 
 `explicit_streams` is `False` throughout: every cheap attempt above selects by
 type rather than by index, so the selective rung is never suppressed.
@@ -175,7 +175,7 @@ are not silently lost; seeding them as roadmap phases is `/loopkit:roadmap`'s jo
 2. **Source-lossiness awareness** — a lossy-codec set the engine can consult, so a
    re-encode into a lossless target can warn that the source was already lossy.
 
-### The one open decision, in full
+### The cover-art decision, in full (resolved at the gate)
 
 `ffprobe` never runs on the happy path (`docs/constitution.md`), so a conversion
 the cheap attempt completes has **no stream list** — the engine cannot name what
@@ -233,10 +233,12 @@ gate picks:
    rather than approved as a quiet violation. Phases 1 and 2 both set the
    precedent of amending a foundation doc in the spec's own PR.
 
-Option 1 is the safer reading; option 2 is the quieter tool and costs an
-amendment. Either way the loss is real and the phase records it.
+**Resolved at the gate on 2026-08-26: option 1, the standing note, and not extended
+to `wav`.** The noise was judged the smaller cost against a silent loss, and
+touching `wav` would have changed a phase-1 note assertion this phase promised to
+leave alone. `wav`'s hole stays open and is now written down.
 
-### The second open decision: does `opus` copy?
+### The opus decision, in full (resolved at the gate)
 
 Decided with the first, because both are the same question — how much may the
 happy path lose in exchange for not probing — and because option 1 above already
@@ -263,8 +265,8 @@ common case, to prevent a mislabel only reachable by pointing `--to opus` at a
    including a plain `.mp4` someone wants ripped: a mapped video stream always
    fails encoder selection, so the ladder always runs. Intended, but priced here.
 
-Picking 1 also removes `opus` from the video-mapping group, so no target maps
-video and all six join the first decision's group. Picking 2 keeps `opus` as the
+**Resolved at the gate on 2026-08-26: option 1, `opus` copies.** No target maps
+video, so all five new profiles carry the standing note. Picking 2 keeps `opus` as the
 one target whose cover-art loss is named properly.
 
 ## Tracking
@@ -407,3 +409,10 @@ New-Item -ItemType Directory -Force art
   since phase 1, so the wav muxer's rejection never fires. Named here for the
   first time, and put to the gate as a sub-question, since closing it changes what
   `wav` reports and this phase promised `wav` unchanged.
+- 2026-08-26: Gate resolved both decisions. `opus` copies — a generation loss on
+  every already-Opus file was judged worse than a mislabel reachable only by
+  pointing `--to opus` at an Ogg source. Consequently no target maps video, and
+  all five new profiles carry a standing note that non-audio streams are not
+  carried. `wav` was deliberately left out: closing its hole would have changed a
+  phase-1 note assertion this phase promised to leave alone, so the hole stays,
+  named, for a later phase.

--- a/docs/specs/spec-audio-formats.md
+++ b/docs/specs/spec-audio-formats.md
@@ -274,7 +274,7 @@ one target whose cover-art loss is named properly.
 The decomposition into steps lives as GitHub issues, not in this file — one
 issue per step, grouped under a milestone.
 
-- Milestone: audio-formats (created at the spec-acceptance gate)
+- Milestone: [audio-formats](https://github.com/bhemsen/converter/milestone/3) (#3)
 - Issues: created from this spec once it is merged (one per implementable step)
 
 ## Verification

--- a/docs/specs/spec-audio-formats.md
+++ b/docs/specs/spec-audio-formats.md
@@ -181,7 +181,7 @@ are not silently lost; seeding them as roadmap phases is `/loopkit:roadmap`'s jo
 the cheap attempt completes has **no stream list** — the engine cannot name what
 it dropped, because it does not know.
 
-**This affects five of the seven targets, and six if `opus` copies.** A target is
+**This affects five of the six audio targets, and six if `opus` copies.** A target is
 affected whenever its cheap attempt maps audio only: it then succeeds, the
 artwork is gone, and there is nothing to build a note from. That is `mp3`, `m4a`,
 `flac`, `ogg` — and `wav`, whose cheap attempt
@@ -195,6 +195,11 @@ video is what makes a cover-art source fail into the ladder, which then names th
 picture stream and its codec properly. If `opus` copies instead, no target maps
 video at all and all six are affected.
 
+Weigh `ogg` at its real frequency, though: an `.ogg` file **cannot** hold cover
+art as a picture stream at all, so `ogg`'s silent loss is only reachable from a
+non-Ogg source that carries Vorbis plus artwork — measured, but rarer than "`ogg`
+loses your album art" would suggest.
+
 **`wav` raises a sub-question the gate should see.** It is not in this phase's
 profile table, and the Outcome promises it "behaves exactly as it does after
 phase 2". Extending the standing note to it is a `converter/profiles.py` diff —
@@ -202,6 +207,12 @@ which the file list allows — but it changes what `wav` reports, so that Outcom
 bullet would have to be relaxed to "`wav`'s argv is unchanged; its notes gain the
 standing line". The alternative is that `wav` keeps the hole, now that this spec
 has at least named it.
+
+It is not only an Outcome bullet: `tests/test_argv.py::TestWavJob::test_first_attempt_is_pcm`
+asserts `attempt.notes == ()` on WAV's cheap attempt, and `spec-profile-registry.md`
+protects that suite as its refactor's safety net. Extending the note to `wav` is a
+deliberate change to a phase-1 assertion that phase 2's test migration carried
+forward — cheap to do, but it should be chosen, not stumbled into.
 
 Every degraded conversion the *ladder* reaches still names the stream index, its
 codec and what was given up, exactly as `docs/vision.md` requires. The gap is the
@@ -253,7 +264,7 @@ common case, to prevent a mislabel only reachable by pointing `--to opus` at a
    fails encoder selection, so the ladder always runs. Intended, but priced here.
 
 Picking 1 also removes `opus` from the video-mapping group, so no target maps
-video and all five join the first decision's group. Picking 2 keeps `opus` as the
+video and all six join the first decision's group. Picking 2 keeps `opus` as the
 one target whose cover-art loss is named properly.
 
 ## Tracking
@@ -308,17 +319,17 @@ New-Item -ItemType Directory -Force in
 & $FF -y -f lavfi -i sine=duration=3 -c:a libvorbis  in/tone.ogg
 & $FF -y -f lavfi -i sine=duration=3 -c:a pcm_s16le  in/tone.wav
 & $FF -y -f lavfi -i testsrc=size=320x240:rate=10:duration=3 -f lavfi -i sine=duration=3 -c:v libx264 -c:a aac in/clip.mp4
-& $FF -y -f lavfi -i color=c=red:size=200x200:d=1 -frames:v 1 in/cover.png
-& $FF -y -i in/tone.mp3 -i in/cover.png -map 0:a -map 1:v -c copy -disposition:v:0 attached_pic in/art.mp3
-& $FF -y -i in/tone.ogg -i in/cover.png -map 0:a -map 1:v -c copy -disposition:v:0 attached_pic in/artv.ogg
+New-Item -ItemType Directory -Force art
+& $FF -y -f lavfi -i color=c=red:size=200x200:d=1 -frames:v 1 art/cover.png
+& $FF -y -i in/tone.mp3 -i art/cover.png -map 0:a -map 1:v -c copy -disposition:v:0 attached_pic art/art.mp3
+& $FF -y -i in/tone.ogg -i art/cover.png -map 0:a -map 1:v -c copy -disposition:v:0 attached_pic art/artv.mkv
 ```
 
 - [ ] Each of the six targets converts a real source and the result plays.
-- [ ] `--to mp3 in out` converts the seven conversion sources (the six tones and
-      `clip.mp4`), names every re-encode it performed, and exits 0. `art.mp3` is a
-      conversion source too and is covered by its own item below; `cover.png` is
-      not a source at all -- keep it outside `in/`, or expect the image phase to
-      claim it later.
+- [ ] `--to mp3 in out` converts the seven sources in `in/` — the six tones and
+      `clip.mp4` — names every re-encode it performed, and exits 0. The artwork
+      fixtures live in `art/` so this count stays put; they have their own items
+      below.
 - [ ] A stream copy really is a copy: `--to mp3` from `tone.mp3` finishes
       near-instantly and the audio stream is packet-identical --
       `& $FF -i out/tone.mp3 -map 0:a -c copy -f md5 -` matches the same command
@@ -332,11 +343,11 @@ New-Item -ItemType Directory -Force in
 - [ ] `art.mp3` under `--to mp3`: `ffprobe` the output and confirm the picture
       stream is gone, and that the run says what the gate's first decision says
       it says.
-- [ ] `artv.ogg` (vorbis audio plus artwork — the fixture block builds it) under
+- [ ] `artv.mkv` (vorbis audio plus artwork — the fixture block builds it) under
       `--to ogg`: same check. This is the case that exposes `ogg`'s silent loss;
       pointing `art.mp3` at `--to ogg` proves nothing about cover art, because the
       ogg muxer rejects the *mp3 audio* first and the picture is never mapped.
-- [ ] Only if the gate has `opus` encode: `artv.ogg` under `--to opus` fails the
+- [ ] Only if the gate has `opus` encode: `artv.mkv` under `--to opus` fails the
       cheap attempt, reaches the ladder, and names the picture stream and its
       codec — the one target where the loss is reported properly.
 - [ ] `--to mp3` on `clip.mp4` rips the audio and names the dropped video stream.

--- a/docs/specs/spec-audio-formats.md
+++ b/docs/specs/spec-audio-formats.md
@@ -29,7 +29,8 @@ merged.** Everything this phase builds on — the `PROFILES` registry, `name` an
       accept. `README.md` is in the list because `docs/roadmap.md` gives each
       coverage phase its own format list to maintain.
 - [ ] Every new profile has a test pinning the exact argv it builds, for a
-      copyable and for a non-copyable input.
+      copyable and for a non-copyable input — with the `opus` carve-out
+      Verification records, if the gate has it always encode.
 - [ ] Every degradation branch a new profile introduces has a test asserting the
       note it emits.
 - [ ] The curated source-suffix set covers the audio *and* video containers people
@@ -46,7 +47,9 @@ merged.** Everything this phase builds on — the `PROFILES` registry, `name` an
   (`.aac`, `.m4b`, `.wma`, `.aiff`, `.aif`, `.ape`, `.wv`, `.caf`) and the video
   containers a "rip the audio" run needs (`.mp4`, `.mov`, `.avi`, `.webm`,
   `.m4v`, `.wmv`, `.flv`), on top of what phase 2's set already holds.
-- `README.md`'s format list.
+- `README.md`'s format list, including a line saying that `m4a`, `ogg` and `opus`
+  carry every audio stream the source has and that most players offer only the
+  first -- nothing is dropped, but it is not obvious either.
 - The tests those profiles require, per the constitution's two gates.
 
 ### Out of scope
@@ -68,7 +71,8 @@ merged.** Everything this phase builds on — the `PROFILES` registry, `name` an
   `docs/architecture.md`): `converter/profiles.py` stays a leaf, and this phase's
   diff proves the rule rather than asserting it.
 - `ffprobe` never runs on the happy path. This is what bounds how precise a note
-  can be for a conversion the cheap attempt completes — see the open decision.
+  can be for a conversion the cheap attempt completes — see the two open
+  decisions.
 - No second external dependency, and no second backend.
 - Never report success for a conversion that silently dropped something.
 - The test suite keeps passing with no ffmpeg installed.
@@ -177,13 +181,27 @@ are not silently lost; seeding them as roadmap phases is `/loopkit:roadmap`'s jo
 the cheap attempt completes has **no stream list** — the engine cannot name what
 it dropped, because it does not know.
 
-**This affects three targets, not six.** `ogg` and `opus` map video precisely so
-that a cover-art source fails into the ladder, which then names the picture
-stream and its codec properly; `wav` rejects video the same way. That leaves
-`mp3`, `m4a` and `flac` — the muxers that *accept* a picture — where the cheap
-attempt maps audio only, succeeds, and the artwork is gone with nothing to build
-a note from. (If the flac measurement above comes back showing it rejects real
-video, this narrows again, to `mp3` and `m4a`.)
+**This affects five of the seven targets, and six if `opus` copies.** A target is
+affected whenever its cheap attempt maps audio only: it then succeeds, the
+artwork is gone, and there is nothing to build a note from. That is `mp3`, `m4a`,
+`flac`, `ogg` — and `wav`, whose cheap attempt
+`flags("-map 0:a:0 -c:a pcm_s16le")` has mapped no video since phase 1, so the
+wav muxer's rejection of video never fires. Measured: an mp3-plus-`attached_pic`
+source through it exits 0 with a lone PCM stream. This spec is the first place
+that hole is written down.
+
+`opus` is the exception, and only under the second decision's option 2: mapping
+video is what makes a cover-art source fail into the ladder, which then names the
+picture stream and its codec properly. If `opus` copies instead, no target maps
+video at all and all six are affected.
+
+**`wav` raises a sub-question the gate should see.** It is not in this phase's
+profile table, and the Outcome promises it "behaves exactly as it does after
+phase 2". Extending the standing note to it is a `converter/profiles.py` diff —
+which the file list allows — but it changes what `wav` reports, so that Outcome
+bullet would have to be relaxed to "`wav`'s argv is unchanged; its notes gain the
+standing line". The alternative is that `wav` keeps the hole, now that this spec
+has at least named it.
 
 Every degraded conversion the *ladder* reaches still names the stream index, its
 codec and what was given up, exactly as `docs/vision.md` requires. The gap is the
@@ -229,6 +247,10 @@ common case, to prevent a mislabel only reachable by pointing `--to opus` at a
    the mapped video is what makes a cover-art source fail into the ladder and get
    a real note — the only target where that works. Every already-Opus file pays a
    transcode.
+
+   It also costs a wasted ffmpeg spawn plus a probe on every video-bearing source,
+   including a plain `.mp4` someone wants ripped: a mapped video stream always
+   fails encoder selection, so the ladder always runs. Intended, but priced here.
 
 Picking 1 also removes `opus` from the video-mapping group, so no target maps
 video and all five join the first decision's group. Picking 2 keeps `opus` as the
@@ -288,6 +310,7 @@ New-Item -ItemType Directory -Force in
 & $FF -y -f lavfi -i testsrc=size=320x240:rate=10:duration=3 -f lavfi -i sine=duration=3 -c:v libx264 -c:a aac in/clip.mp4
 & $FF -y -f lavfi -i color=c=red:size=200x200:d=1 -frames:v 1 in/cover.png
 & $FF -y -i in/tone.mp3 -i in/cover.png -map 0:a -map 1:v -c copy -disposition:v:0 attached_pic in/art.mp3
+& $FF -y -i in/tone.ogg -i in/cover.png -map 0:a -map 1:v -c copy -disposition:v:0 attached_pic in/artv.ogg
 ```
 
 - [ ] Each of the six targets converts a real source and the result plays.
@@ -307,9 +330,15 @@ New-Item -ItemType Directory -Force in
       verified against the real engine.
 - [ ] A second run over any converted tree reports `0 converted`, exit 0.
 - [ ] `art.mp3` under `--to mp3`: `ffprobe` the output and confirm the picture
-      stream is gone, and that the run says what the gate's decision says it
-      says. Repeat for `--to ogg`, where the muxer rejects the picture and the
-      ladder is reached instead.
+      stream is gone, and that the run says what the gate's first decision says
+      it says.
+- [ ] `artv.ogg` (vorbis audio plus artwork — the fixture block builds it) under
+      `--to ogg`: same check. This is the case that exposes `ogg`'s silent loss;
+      pointing `art.mp3` at `--to ogg` proves nothing about cover art, because the
+      ogg muxer rejects the *mp3 audio* first and the picture is never mapped.
+- [ ] Only if the gate has `opus` encode: `artv.ogg` under `--to opus` fails the
+      cheap attempt, reaches the ladder, and names the picture stream and its
+      codec — the one target where the loss is reported properly.
 - [ ] `--to mp3` on `clip.mp4` rips the audio and names the dropped video stream.
 
 ## Risks and mitigations
@@ -347,7 +376,8 @@ New-Item -ItemType Directory -Force in
 - 2026-08-25: Spec review measured that a blind `-c:a copy` lets the muxer, not
   the copy mask, decide the happy path — `--to opus` from a Vorbis source shipped
   a `.opus` file containing Vorbis at exit 0. The cheap attempts are now per
-  profile, and `opus` forces its encoder rather than copying.
+  profile, and `opus` forces its encoder rather than copying. That last part was
+  reopened two rounds later -- see the final entry below.
 - 2026-08-25: Spec review measured that mapping video into `ogg` passes a theora
   source straight through at exit 0 — a whole video file renamed `.ogg`, the same
   defect that rules `m4a` out. `ogg` no longer maps video, which leaves `opus` as
@@ -361,3 +391,8 @@ New-Item -ItemType Directory -Force in
   row into the gate, next to the standing-note decision. Settling it in a row
   traded a generation loss on the common case for a mislabel on a rare one, and
   presented the loss as a warning the source "deserved" — the tool inflicts it.
+- 2026-08-25: Spec review found that `wav` has the same happy-path cover-art hole
+  as the four new audio-only targets — its cheap attempt has mapped no video
+  since phase 1, so the wav muxer's rejection never fires. Named here for the
+  first time, and put to the gate as a sub-question, since closing it changes what
+  `wav` reports and this phase promised `wav` unchanged.

--- a/docs/specs/spec-audio-formats.md
+++ b/docs/specs/spec-audio-formats.md
@@ -4,42 +4,50 @@
 
 Add the five remaining audio target profiles — `mp3`, `m4a`, `flac`, `opus`,
 `ogg` — to the registry, alongside the `wav` profile that already exists, and
-prove that adding a format really does cost nothing but a profile entry and its
-test. This spec carries no lifecycle state — acceptance is the spec merged on the
-default branch with a milestone and issues, and all progress lives in the GitHub
-issues and milestone. A completed spec is moved to `docs/specs/archive/`.
+prove that adding a format really does cost nothing but a profile entry, its
+README line and its test. This spec carries no lifecycle state — acceptance is
+the spec merged on the default branch with a milestone and issues, and all
+progress lives in the GitHub issues and milestone. A completed spec is moved to
+`docs/specs/archive/`.
+
+**Depends on milestone #2 (target-driven-cli), which is planned but not yet
+merged.** Everything this phase builds on — the `PROFILES` registry, `name` and
+`description` on the profile, the curated source-suffix set, `--to`,
+`--list-formats` — is phase-2 code. Do not start against `main` until #2 closes.
 
 ## Outcome
 
 - [ ] `converter --to <fmt>` works for `mp3`, `m4a`, `flac`, `opus` and `ogg`,
       and `wav` still behaves exactly as it does after phase 2.
-- [ ] `--list-formats` prints six audio targets.
-- [ ] **The diff of this phase touches `converter/profiles.py` and the tests, and
-      nothing else.** This is the constitution's "a target format is data, not
-      code" claim being cashed in for the first time; a diff in `cli.py`,
-      `batch.py`, `paths.py` or `jobs.py` means the profile model is wrong and
-      that is the bug to fix, not the diff to accept.
+- [ ] `--list-formats` prints seven lines, one per registry entry, including the
+      five new audio names.
+- [ ] **The diff of every PR in this milestone touches only
+      `converter/profiles.py`, `README.md` and files under `tests/`.** This is the
+      constitution's "a target format is data, not code" claim being cashed in for
+      the first time; a diff in `cli.py`, `batch.py`, `paths.py` or `jobs.py`
+      means the profile model is wrong and that is the bug to fix, not the diff to
+      accept. `README.md` is in the list because `docs/roadmap.md` gives each
+      coverage phase its own format list to maintain.
 - [ ] Every new profile has a test pinning the exact argv it builds, for a
       copyable and for a non-copyable input.
 - [ ] Every degradation branch a new profile introduces has a test asserting the
       note it emits.
-- [ ] Whatever a source carries that the target cannot hold is named in a note —
-      never dropped in silence.
-- [ ] The curated source-suffix set covers the audio formats people actually
-      have, so `--to mp3` over a real music tree finds them.
+- [ ] The curated source-suffix set covers the audio *and* video containers people
+      actually have, so `--to mp3` over a real tree finds them.
 
 ## Scope
 
 ### In scope
 
-- Five new `Profile` entries in `converter/profiles.py` with their stream rules,
-  copy masks, fallback encoders and container options, plus their registry
-  entries.
-- Extending the curated source-suffix set with the audio suffixes a source tree
-  realistically holds (`.aac`, `.m4b`, `.wma`, `.aiff`, `.alac`, `.ape`, `.wv`
-  and the six targets' own suffixes).
+- Five new `Profile` entries in `converter/profiles.py` — including each one's
+  `cheap_attempt`, `explicit_streams` and `last_resort`, which the Prior
+  decisions fix — plus their registry entries.
+- Extending the curated source-suffix set: audio containers
+  (`.aac`, `.m4b`, `.wma`, `.aiff`, `.aif`, `.ape`, `.wv`, `.caf`) and the video
+  containers a "rip the audio" run needs (`.mp4`, `.mov`, `.avi`, `.webm`,
+  `.m4v`, `.wmv`, `.flv`), on top of what phase 2's set already holds.
+- `README.md`'s format list.
 - The tests those profiles require, per the constitution's two gates.
-- Cover-art handling, per the decision resolved at the acceptance gate.
 
 ### Out of scope
 
@@ -47,32 +55,32 @@ issues and milestone. A completed spec is moved to `docs/specs/archive/`.
   not on this one.
 - Any encoder-tuning surface. Bitrates and quality settings are chosen once, as
   defaults, and are not exposed (`docs/vision.md` non-goal).
-- Loudness normalisation, resampling, channel remapping, tag editing. A
-  conversion is a conversion.
-- Changing the engine or the ladder. If a profile needs an engine change, that is
-  a finding to escalate, not to absorb quietly — see the Risks table.
+- Loudness normalisation, resampling, channel remapping, tag editing.
+- **Any engine change.** If a profile needs one, that is a finding to escalate as
+  `needs:planning`, not to absorb by editing `jobs.py` — the phase's headline
+  outcome is precisely that no such diff appears.
+- **Keeping cover art as a picture stream.** It is not expressible as data and is
+  recorded below as its own roadmap candidate.
 
 ## Constraints
 
 - A target format is data, not code (`docs/constitution.md`,
   `docs/architecture.md`): `converter/profiles.py` stays a leaf, and this phase's
   diff proves the rule rather than asserting it.
-- No second external dependency, and no second backend — every format here has a
-  working ffmpeg muxer or it does not ship (`docs/vision.md` non-goals).
+- `ffprobe` never runs on the happy path. This is what bounds how precise a note
+  can be for a conversion the cheap attempt completes — see the open decision.
+- No second external dependency, and no second backend.
 - Never report success for a conversion that silently dropped something.
-- Every degraded conversion names the stream index, that stream's codec, and what
-  was given up.
-- The test suite keeps passing with no ffmpeg installed; the subprocess boundary
-  stays stubbed.
+- The test suite keeps passing with no ffmpeg installed.
 
 ## Prior art
 
 - [Python wrapper structure around the ffmpeg CLI (Phase 3, Phase 4)](../prior-art.md#python-wrapper-structure-around-the-ffmpeg-cli-phase-3-phase-4)
   — the concern tagged for this phase. Its ADOPT is confirmation rather than code:
   `ffmpeg-normalize`'s split into per-stream-type handling plus a command builder
-  is the shape this codebase already has. Its AVOID is the live one here — never
-  scrape ffmpeg's stderr to decide a second pass; a profile that "needs" stderr to
-  choose an encoder is a profile modelled wrong.
+  is the shape this codebase already has. Its AVOID is the live one — never scrape
+  ffmpeg's stderr to decide a second pass; a profile that "needs" stderr to choose
+  an encoder is a profile modelled wrong.
 - [Container/codec capability modelling (Phase 1)](../prior-art.md#containercodec-capability-modelling-phase-1)
   — still governing: HandBrake's copy-mask plus encoder-fallback vocabulary is what
   each new profile is written in, and the ffmpeg-CLI entry is why every mask below
@@ -81,57 +89,85 @@ issues and milestone. A completed spec is moved to `docs/specs/archive/`.
 ## Design
 
 No new design artifact. This phase makes no new decision about the ladder or the
-per-stream branch — it fills in data for decisions `docs/design/degradation-ladder.md`
-and `docs/design/stream-decision.md` already settled. Implement against those two.
+per-stream branch — it supplies data for decisions
+`docs/design/degradation-ladder.md` and `docs/design/stream-decision.md` already
+settled. Implement against those two.
 
 ## Human prerequisites
 
-- none. No secret, no dependency, no external provisioning. The QA gate needs the
-  ffmpeg already installed on this machine, and one real music file per source
-  codec, which the gate synthesises.
+- none. No secret, no dependency, no external provisioning.
 
 ## Prior decisions
 
+### The muxer facts these profiles rest on
+
+Verified against the installed ffmpeg 9.0 during planning, not assumed. A later
+reader should re-verify rather than trust the table.
+
+| Fact | Consequence |
+|---|---|
+| `.m4a` auto-selects the **`ipod`** muxer, not `mp4`, and ipod's accept set is *narrower*: `mp3`, `opus` and `flac` stream copies are all rejected | The `m4a` mask is `{aac, alac}` and must **not** reuse `profiles.MP4_AUDIO_CODECS`, which is much wider |
+| The `ogg` muxer accepts `vorbis`, `opus` and `flac` as-is; it rejects `mp3` and `aac` | The `ogg` mask is `{vorbis, opus, flac}` |
+| The `mp3` muxer enforces "exactly one MP3 audio stream" | `stream_limit=1` there is a muxer constraint, not only a product judgement |
+| The `ogg` and `opus` muxers **reject** a picture stream outright (`Unsupported codec id in stream 1`), and the `wav` muxer rejects any video stream | Not "awkward support" — a hard failure, which is why a blind cheap attempt that mapped video would fail for these targets |
+| `mp3`, `m4a` (ipod) and `flac` **accept** a picture stream, and an `mp3` target given a genuine 20-frame MJPEG video silently writes a single-frame `attached_pic` | Mapping video blindly into an audio target is a silent data loss the constitution forbids — so no audio profile maps video at all |
+| `-q:a 2` (libmp3lame) and `-q:a 5` (libvorbis) are valid | The fallback defaults below are real |
+
+### Decisions
+
 | Decision | Rationale | Date |
 |---|---|---|
-| Each audio target declares a stream limit of 1 for audio, like WAV | These containers hold one audio stream in any player anyone will use; a second stream is dropped with a note naming it, which is the honest outcome rather than a file that plays unpredictably | 2026-08-25 |
-| Copy masks: `mp3` -> `{mp3}`; `m4a` -> `{aac, alac}`; `flac` -> `{flac}`; `opus` -> `{opus}`; `ogg` -> `{vorbis, opus, flac}` | Each is what the muxer accepts as-is, curated by hand per the prior-art AVOID. A copy mask this narrow is the point: a re-encode that the mask predicts is named in a note, and a stream copy that the mask allows costs nothing | 2026-08-25 |
-| Fallback encoders and their defaults: `mp3` -> `libmp3lame -q:a 2` (VBR ~190 kbit/s); `m4a` -> `aac -b:a 192k`; `flac` -> `flac` (lossless); `opus` -> `libopus -b:a 128k`; `ogg` -> `libvorbis -q:a 5` (~160 kbit/s) | Quality-based VBR where the encoder has a good one, bitrate where it does not, all at "transparent enough that nobody notices" rather than "smallest". They are defaults, not a surface: `docs/vision.md` rules out an encoder-tuning surface, so these are chosen once and pinned by the argv tests | 2026-08-25 |
-| Re-encoding a lossy source into another lossy format emits a note naming both codecs; re-encoding **into** `flac` from a lossy source also emits one, saying the result is lossless but the source was not | Generation loss is exactly the kind of thing the free tools stay silent about (`docs/vision.md`), and a 40 MB FLAC made from a 128 kbit/s MP3 is a result the user should be told about rather than discover | 2026-08-25 |
-| Converting into `wav` or `flac` from any source emits **no** note for the encode itself | Decoding to the container's own lossless codec gives up nothing; a note per file would be noise. This is the rule phase 1 already established for WAV's PCM rule | 2026-08-25 |
-| A source's video streams that are not cover art are dropped with a note naming the stream and its codec | `--to mp3` pointed at a video file is a legitimate "rip the audio" request; failing it would be unhelpful, and dropping the video without a word is what the constitution forbids | 2026-08-25 |
-| OPEN — cover art: which audio targets keep an embedded picture stream, and which drop it with a note | resolved at the spec-acceptance gate; see the note below | — |
+| Every audio profile's `cheap_attempt` is a **blind audio-only stream copy**, `flags("-map 0:a? -c:a copy")`, with `explicit_streams=False` | Blind, so the copy masks are live on the happy path and "a stream copy really is a copy" holds. Audio-only, because mapping video blindly is the silent single-frame loss the muxer table records. `explicit_streams=False` because the attempt is blind, which also means the selective rung is never suppressed | 2026-08-25 |
+| Every audio profile declares a `last_resort`: the format's fallback encoder over the first audio stream only, e.g. `flags("-map 0:a:0 -c:a libmp3lame -q:a 2")` | Without it a ladder that reaches the end lands as `failed`. Concretely: `--to flac` from a `.wav` source fails the cheap copy, and its selective rung carries no note (encoding into a container's own lossless codec is not a loss), so the rung alone is not a safety net | 2026-08-25 |
+| Each audio target declares `stream_limit=1` for audio | A muxer constraint for `mp3`; for the rest, these containers hold one audio stream in any player anyone will use. A second stream is dropped with a note naming it | 2026-08-25 |
+| Copy masks: `mp3` -> `{mp3}`; `m4a` -> `{aac, alac}`; `flac` -> `{flac}`; `opus` -> `{opus}`; `ogg` -> `{vorbis, opus, flac}` | Each is what the muxer accepts as-is, per the verified table above and curated by hand per the prior-art AVOID | 2026-08-25 |
+| Fallback encoders and their defaults: `mp3` -> `libmp3lame -q:a 2` (VBR ~190 kbit/s); `m4a` -> `aac -b:a 192k`; `flac` -> `flac`; `opus` -> `libopus -b:a 128k`; `ogg` -> `libvorbis -q:a 5` (~160 kbit/s) | Quality-based VBR where the encoder has a good one, bitrate where it does not, all at "transparent enough that nobody notices" rather than "smallest". Defaults, not a surface: pinned by the argv tests, so changing one is an argued diff | 2026-08-25 |
+| `flac` and `wav` declare **`fallback_name=None`**, so an encode into them emits no note; the other four declare theirs, so a re-encode emits the engine's existing per-stream note naming the source codec and the target codec | Decoding into a container's own lossless codec gives up nothing. This is the rule phase 1 established for WAV, expressed with the one lever `jobs.py` has | 2026-08-25 |
+| **No generation-loss note** (a "your FLAC came from a 128 kbit/s MP3" warning) in this phase | It would need a lossy-codec set plus a new branch in `jobs.py`, and `Stream` carries no such notion — an engine change, which this phase's headline outcome forbids. Recorded below as a roadmap candidate rather than smuggled in | 2026-08-25 |
+| No audio profile declares a **video rule**, so any video stream — cover art included — is dropped by the selective rung with the engine's existing "not supported by TARGET" note | Keeping cover art needs the `attached_pic` disposition, which `probe_streams` does not request and `Stream` does not carry, so the engine cannot tell a picture from a real video stream. The muxer table shows what happens if you guess: `m4a` hard-fails on a real MJPEG while succeeding on a picture, and `mp3` silently truncates it to one frame | 2026-08-25 |
+| OPEN — what a conversion says when the cheap attempt **succeeds** and cover art is lost along the way | resolved at the spec-acceptance gate; see the note below | — |
+
+### Two roadmap candidates this phase deliberately does not take
+
+Both need an engine change, so neither is a profile entry. Recorded here so they
+are not silently lost; seeding them as roadmap phases is `/loopkit:roadmap`'s job.
+
+1. **Stream-disposition awareness** — a `disposition` field on `Stream`, the
+   matching `-show_entries` field in `ffmpegtool.py`, and a disposition branch in
+   `jobs.py`. It is what keeping cover art actually costs, and it would let
+   `mp3`, `m4a` and `flac` carry artwork through.
+2. **Source-lossiness awareness** — a lossy-codec set the engine can consult, so a
+   re-encode into a lossless target can warn that the source was already lossy.
 
 ### The one open decision, in full
 
-Music files carry cover art as a video stream with the `attached_pic`
-disposition — usually `mjpeg` or `png`. It is not metadata, so `docs/vision.md`'s
-EXIF/ICC non-goal does not settle it, and nothing in the prior art does either.
+`ffprobe` never runs on the happy path (`docs/constitution.md`), so a conversion
+the cheap attempt completes has **no stream list** — the engine cannot name what
+it dropped, because it does not know. Concretely: an `.mp3` with cover art, under
+`--to mp3`, is copied by `flags("-map 0:a? -c:a copy")`, the artwork does not
+come along, and there is nothing to build a per-stream note from.
 
-Keeping it costs a video rule per profile (`-c:v:{n} copy` plus
-`-disposition:v:{n} attached_pic`) and a real risk: ffmpeg's support for attached
-pictures differs per muxer, and it is *known* to be awkward for Ogg and Opus,
-where the picture goes into a `METADATA_BLOCK_PICTURE` tag rather than a stream.
-Dropping it is one line per profile and always works — and loses the album art
-off every file someone converts.
+Every degraded conversion the *ladder* reaches still names the stream index, its
+codec and what was given up, exactly as `docs/vision.md` requires. The gap is only
+the happy path, and it is structural rather than an oversight. The gate picks:
 
-The gate picks one of:
+1. **A standing note on the cheap attempt** — a fixed line on the `Attempt`, e.g.
+   `non-audio streams (including cover art) are not carried into MP3`. Always
+   truthful, never silent, and free. The cost is noise: it prints for every file,
+   including the vast majority that had nothing to lose.
+2. **Say nothing when the cheap attempt succeeds.** No noise, and a file that had
+   cover art loses it without a word — a real tension with "never report success
+   for a conversion that silently dropped something", confined to the one path
+   where the constitution also forbids the probe that would resolve it.
 
-1. **Keep cover art where the muxer holds it as a stream (`mp3`, `m4a`, `flac`),
-   drop it with a note for `wav`, `opus` and `ogg`.** Honest and per-format, and
-   the note tells the user which of their files lost artwork. Costs a QA item
-   proving each of the three really does keep it with the installed ffmpeg 9.
-2. **Drop cover art everywhere, always with a note.** One rule, no per-muxer
-   surprises, no risk of a profile that works on one ffmpeg build and not another.
-   Every converted music file loses its artwork, and is told so.
-
-Whichever is picked, the drop is never silent.
+Option 1 is the safer reading of the constitution; option 2 is the quieter tool.
+Whichever is picked, this phase records the tension in the spec rather than
+leaving it for someone to discover.
 
 ## Tracking
 
 The decomposition into steps lives as GitHub issues, not in this file — one
-issue per step, grouped under a milestone. This spec owns the design; the issues
-own progress.
+issue per step, grouped under a milestone.
 
 - Milestone: audio-formats (created at the spec-acceptance gate)
 - Issues: created from this spec once it is merged (one per implementable step)
@@ -141,51 +177,82 @@ own progress.
 Machine checks:
 
 - [ ] Verify passes (ruff check, ruff format --check, pytest) on the merge commit.
-- [ ] `git diff <phase-2-merge>..HEAD --stat` for this milestone lists only
-      `converter/profiles.py` and files under `tests/`. This is the phase's
-      headline outcome and it is checked, not asserted.
+- [ ] For **every PR in this milestone**, `git diff main...<pr-head> --name-only`
+      lists only `converter/profiles.py`, `README.md` and paths under `tests/`.
+      Per-PR and merge-base-scoped on purpose: phases 3, 4 and 5 may run as
+      parallel orchestrators, so a two-dot range against `main` would sweep in
+      another milestone's commits.
 - [ ] Per new profile, a test pinning the full argv for a copyable input and for
       a non-copyable one — ten tests, five profiles, both cases each.
-- [ ] Per new degradation branch, a test asserting the note: the lossy-to-lossy
-      re-encode, the lossy-source-into-flac note, a second audio stream dropped,
-      a non-cover-art video stream dropped, and whatever the cover-art decision
-      adds.
+- [ ] Per new degradation branch, a test asserting the note: a re-encode naming
+      both codecs, a second audio stream dropped, a video stream dropped, and
+      whatever the cover-art decision adds.
+- [ ] A test that converting into `flac` or `wav` emits no note for the encode.
 - [ ] A test that `wav`'s argv is byte-for-byte what it was before this phase.
-- [ ] A test that every registry entry has a `name`, a `description`, a target
-      suffix that appears in the curated source-suffix set, and at least one
-      stream rule — a structural check that catches a half-written profile.
-- [ ] A test that converting into `flac` or `wav` emits no note for the encode
-      itself.
+- [ ] A structural test over the whole registry: every entry has a `name`, a
+      `description`, a target suffix present in the curated source-suffix set,
+      and at least one stream rule — this catches a half-written profile, and it
+      keeps working for phases 4 and 5.
+- [ ] A test that `--to flac` from a PCM source reaches the `last_resort` rather
+      than landing as `failed`.
 
 Human milestone-QA gate — the machine checks stub the subprocess boundary, so
-only this proves a real conversion. Synthesise one source per codec first with
-the absolute ffmpeg path from *This machine* (`libmp3lame`, `aac`, `flac`,
-`libopus`, `libvorbis`, plus one `.mkv` with an audio track):
+only this proves a real conversion. `$FF` is the absolute ffmpeg path from *This
+machine*; PowerShell, one command per line:
+
+```text
+New-Item -ItemType Directory -Force in
+& $FF -f lavfi -i sine=duration=3 -c:a libmp3lame in/tone.mp3
+& $FF -f lavfi -i sine=duration=3 -c:a aac        in/tone.m4a
+& $FF -f lavfi -i sine=duration=3 -c:a flac       in/tone.flac
+& $FF -f lavfi -i sine=duration=3 -c:a libopus    in/tone.opus
+& $FF -f lavfi -i sine=duration=3 -c:a libvorbis  in/tone.ogg
+& $FF -f lavfi -i sine=duration=3 -c:a pcm_s16le  in/tone.wav
+& $FF -f lavfi -i testsrc=size=320x240:rate=10:duration=3 -f lavfi -i sine=duration=3 -c:v libx264 -c:a aac in/clip.mp4
+& $FF -f lavfi -i color=c=red:size=200x200:d=1 -frames:v 1 in/cover.png
+& $FF -i in/tone.mp3 -i in/cover.png -map 0:a -map 1:v -c copy -disposition:v:0 attached_pic in/art.mp3
+```
 
 - [ ] Each of the six targets converts a real source and the result plays.
-- [ ] `--to mp3` over a directory holding all six source kinds converts every one
-      of them, reports the re-encodes it performed by name, and exits 0.
-- [ ] A stream copy really is a copy: `--to opus` from an `.opus` source finishes
-      near-instantly and the output is bit-identical in its audio stream.
-- [ ] `--to flac` from a 128 kbit/s MP3 prints the generation-loss note.
+- [ ] `--to mp3 in out` converts all seven sources, names every re-encode it
+      performed, and exits 0.
+- [ ] A stream copy really is a copy: `--to opus` from `tone.opus` finishes
+      near-instantly and the audio stream is packet-identical —
+      `& $FF -i out/tone.opus -map 0:a -c copy -f md5 -` matches the same command
+      on the source. Compare the stream, not the file: a remux re-pages the
+      container.
+- [ ] `--to flac in out` over `tone.wav` produces a playable FLAC via the
+      `last_resort`, not a failure.
 - [ ] A second run over any converted tree reports `0 converted`, exit 0.
-- [ ] Cover art behaves exactly as the gate's decision says, verified per target
-      with `ffprobe` rather than by looking at a player.
-- [ ] `--to mp3` on a video file rips the audio and names the dropped video
-      stream.
+- [ ] `art.mp3` under `--to mp3`: `ffprobe` the output and confirm the picture
+      stream is gone, and that the run says what the gate's decision says it
+      says. Repeat for `--to ogg`, where the muxer rejects the picture and the
+      ladder is reached instead.
+- [ ] `--to mp3` on `clip.mp4` rips the audio and names the dropped video stream.
 
 ## Risks and mitigations
 
 | Risk | Mitigation |
 |---|---|
-| A profile turns out to need an engine change, quietly breaking the phase's headline outcome | The diff check is a Verification item. A profile that cannot be expressed as data is escalated as `needs:planning`, not absorbed by editing `jobs.py` |
-| A copy mask is wrong and a stream copy produces a file that does not play | The QA gate plays one output per target, and the copy-vs-re-encode path is the one thing the machine checks cannot prove |
-| The fallback defaults age badly, or someone treats them as a tuning surface | They are pinned by the argv tests, so changing one is a visible, argued diff rather than a drive-by |
-| Cover art works on this machine's ffmpeg 9 and not on an older build | The QA gate verifies with `ffprobe` per target; the decision note records that muxer support is the risk, so a later bug report has somewhere to land |
-| The curated suffix set misses a format people actually have, so `--to mp3` silently finds nothing | The suffix list is enumerated in Scope rather than left to taste, and the QA gate points the tool at a directory holding all six source kinds |
+| A profile turns out to need an engine change, quietly breaking the phase's headline outcome | The per-PR diff check is a Verification item. A profile that cannot be expressed as data is escalated as `needs:planning` |
+| A copy mask is wrong and a stream copy produces a file that does not play | The masks are verified against ffmpeg 9 in the table above, and the QA gate plays one output per target |
+| The muxer facts are re-derived wrongly by a later reader | They are written down as a table with the consequence beside each, and the QA gate re-exercises them |
+| The fallback defaults age badly, or someone treats them as a tuning surface | Pinned by the argv tests, so changing one is a visible, argued diff |
+| The two deferred candidates (disposition, lossiness) are forgotten | Named in the spec with what each actually costs, so a roadmap cycle can pick them up |
+| The curated suffix set misses a format people actually have | Enumerated in Scope rather than left to taste, and the QA gate points the tool at a directory holding all seven source kinds |
 
 ## Decision log
 
 - 2026-08-25: No design artifact for this phase. The ladder and the per-stream
-  branch are already drawn; phases 3-5 supply data for them, and a fourth diagram
-  restating that would be the drift `docs/design.md` warns about.
+  branch are already drawn; a fourth diagram restating them would be the drift
+  `docs/design.md` warns about.
+- 2026-08-25: Spec review ran the installed ffmpeg against every proposed mask.
+  Three of the planned decisions were wrong: `m4a` uses the `ipod` muxer with a
+  narrower accept set than MP4's, `ogg`/`opus` reject a picture stream outright
+  rather than handling it awkwardly, and a blind video map into `mp3` silently
+  truncates a real video to one frame. The masks and the cheap attempt were
+  rewritten around the measured behaviour.
+- 2026-08-25: Cover art and generation-loss notes were both dropped from the
+  phase once the review showed neither is expressible in the implemented value
+  types. They are recorded as roadmap candidates with their real cost — an engine
+  change — rather than being smuggled in as "just a profile field".

--- a/docs/specs/spec-audio-formats.md
+++ b/docs/specs/spec-audio-formats.md
@@ -109,11 +109,14 @@ reader should re-verify rather than trust the table.
 | `.m4a` auto-selects the **`ipod`** muxer, not `mp4`, and ipod's accept set is *narrower*: `mp3`, `opus` and `flac` stream copies are all rejected | The `m4a` mask is `{aac, alac}` and must **not** reuse `profiles.MP4_AUDIO_CODECS`, which is much wider |
 | The `ogg` muxer accepts `vorbis`, `opus` and `flac` as-is; it rejects `mp3` and `aac` | The `ogg` mask is `{vorbis, opus, flac}` |
 | The `mp3` muxer enforces "exactly one MP3 audio stream" | `stream_limit=1` there is a muxer constraint, not only a product judgement |
-| The `ogg` and `opus` muxers **reject** a picture stream outright (`Unsupported codec id in stream 1`), and the `wav` muxer rejects any video stream | Not "awkward support" — a hard failure, which is why a blind cheap attempt that mapped video would fail for these targets |
+| The `ogg` and `opus` muxers **reject** a picture stream outright (`Unsupported codec id in stream 1`), and the `wav` muxer rejects any video stream | Not "awkward support" — a hard failure. It is not enough on its own to justify mapping video, though: see the theora row below for why `ogg` still cannot |
 | `mp3`, `m4a` (ipod) and `flac` **accept** a picture stream that already carries the `attached_pic` disposition. A **bare** mjpeg is a different case: `m4a` rejects it, `mp3` silently writes it as a single frame | These three cannot map video safely, so they map audio only |
 | `m4a` (ipod) copies a **full h264 track** through without complaint: `clip.mkv` under `-map 0:a? -map 0:v? -c copy` exits 0 with `0\|aac 1\|h264` | The decisive reason `m4a` maps no video: the user asked for audio and would get a video file |
-| The `opus` muxer accepts a **Vorbis** stream | A blind copy into `.opus` can ship a file whose extension lies about its contents; `opus` forces its encoder instead |
+| The `opus` muxer accepts a **Vorbis** stream | A blind copy into `.opus` can ship a file whose extension lies about its contents -- the second open decision below |
 | The `flac` muxer enforces exactly one FLAC audio stream, like `mp3` | `stream_limit=1` is a muxer constraint there too |
+| The `flac` muxer accepts an `attached_pic` picture but **silently discards a real video stream at exit 0**, warning only on stderr | Worse than a rejection: there is no failure to fall into the ladder, so `flac` maps audio only and stays in the open decision |
+| The `ogg` muxer's own video codec is **theora**, so a theora+vorbis source copies straight through: exit 0, output byte-identical in size to the input | `ogg` cannot map video either -- it would hand the user a video file they asked to have as audio, the same defect that rules `m4a` out |
+| The `opus` muxer holds **several** audio streams, by copy and by encode | `opus` declares no `stream_limit` |
 | `-q:a 2` (libmp3lame) and `-q:a 5` (libvorbis) are valid | The fallback defaults below are real |
 
 ### Decisions
@@ -123,8 +126,10 @@ reader should re-verify rather than trust the table.
 | **On the happy path the muxer is the authority, not the copy mask.** A stream copy that ffmpeg's muxer accepts ships, whether or not the mask lists that codec; the mask governs the *failure* path, where the engine builds the selective rung | Measured, not assumed: `--to opus` from a Vorbis `.ogg` under a blind `-c:a copy` exits 0 and writes a `.opus` file containing Vorbis. Nothing short of a probe can prevent that, and a probe on the happy path is forbidden. The per-profile cheap attempts below are chosen so that where the muxer is looser than the format's identity, the profile does not rely on a copy at all | 2026-08-25 |
 | The `cheap_attempt`, `explicit_streams` and `last_resort` of each of the **five new** profiles are fixed by the table below; `wav` is untouched and keeps phase 2's shape exactly | A blanket rule does not survive contact with the muxers: they differ in whether they enforce the target's codec, whether they hold several audio streams, and whether they reject a picture stream. Each of those differences changes what an honest cheap attempt looks like | 2026-08-25 |
 | `stream_limit=1` for `mp3` and `flac` only. `m4a`, `ogg` and `opus` declare **no** audio stream limit | Measured: the `mp3` and `flac` muxers both enforce exactly one audio stream, so the limit is real and a multi-stream source fails into the ladder, which names the stream it drops. `m4a`, `ogg` and `opus` accept several, so declaring a limit would mean mapping one stream and silently discarding the rest — a loss the tool could not name. Carrying every stream the container holds drops nothing at all, which is the better answer | 2026-08-25 |
-| `opus` **does not copy**: its cheap attempt forces `libopus`, and carries a standing note saying the audio was re-encoded to Opus | The `opus` muxer accepts a Vorbis stream (measured), and `.opus` is a codec-defined format, so a copy can ship a file whose name lies about its contents. Forcing the encoder is the only way the label stays true without a probe. The standing note is accurate for every input, including an already-Opus source, where it is the generation-loss warning that source deserves | 2026-08-25 |
-| `ogg` and `opus` **map video** in their cheap attempt; `mp3`, `m4a` and `flac` do not | Measured: the `ogg` and `opus` muxers reject a picture stream outright, so mapping video makes a cover-art source *fail* into the ladder, which then emits the real per-stream note. That costs one extra ffmpeg spawn for sources that carry artwork and nothing otherwise. The other three accept a picture — and `m4a` will happily copy a full h264 track into a file the user asked for as audio (measured) — so for them mapping video buys a silent wrong result instead of a note | 2026-08-25 |
+| OPEN — does `opus` copy or always encode? | resolved at the spec-acceptance gate, together with the standing-note decision; see the note below | — |
+| **Only `opus` maps video** in its cheap attempt. `mp3`, `m4a`, `flac` and `ogg` map audio only | Mapping video is worth it exactly where it turns a quiet loss into a *failure* the ladder can name. Measured, that is true only for `opus`: its cheap attempt carries no `-c:v`, so ffmpeg cannot select a video encoder and errors out, the ladder runs, and the picture stream is named. Every other target has a measured way to swallow video quietly — `m4a` copies a full h264 track through, `ogg` copies theora through (theora is the ogg muxer's own video codec, so a theora source arrives as a whole video file renamed `.ogg`), `flac` discards real video at exit 0 with only a stderr warning, and `mp3` writes a real video as a single frame. For those four, mapping video buys a silent wrong result instead of a note | 2026-08-25 |
+| `opus`'s `accept_options` is `flags("-c:a copy")`: the cheap attempt never copies, but the **selective rung does**, on a mask hit | "`opus` does not copy" is a statement about the cheap attempt alone. Following WAV's `accept_options=()` precedent here would emit a map with no codec option and produce an undeclared re-encode | 2026-08-25 |
+| The happy-path muxer-authority row is a problem only for a **codec-defined** target, where the extension names the codec. `.opus`, `.mp3` and `.flac` are codec-defined; `.m4a` and `.ogg` are container-defined, so an `.m4a` holding `ac3` (measured: it copies through, outside the declared mask) is unusual but not a lie | This is the criterion that exempts `m4a` and `ogg` from the treatment `opus` gets, and it stops `{aac, alac}` from being read later as a guarantee | 2026-08-25 |
 | Every new profile declares a `last_resort`: the format's fallback encoder over the first audio stream, e.g. `flags("-map 0:a:0 -c:a libmp3lame -q:a 2")` | Not for the FLAC-from-WAV case, which the selective rung already handles. It is for the case the selective rung cannot: the rung may choose `-c:a copy` on a mask hit for a bitstream the muxer then refuses, and only a forced re-encode rescues that file | 2026-08-25 |
 | Copy masks: `mp3` -> `{mp3}`; `m4a` -> `{aac, alac}`; `flac` -> `{flac}`; `opus` -> `{opus}`; `ogg` -> `{vorbis, opus, flac}` | Each is what the muxer accepts as-is, per the verified table above and curated by hand per the prior-art AVOID | 2026-08-25 |
 | Fallback encoders and their defaults: `mp3` -> `libmp3lame -q:a 2` (VBR ~190 kbit/s); `m4a` -> `aac -b:a 192k`; `flac` -> `flac`; `opus` -> `libopus -b:a 128k`; `ogg` -> `libvorbis -q:a 5` (~160 kbit/s) | Quality-based VBR where the encoder has a good one, bitrate where it does not, all at "transparent enough that nobody notices" rather than "smallest". Defaults, not a surface: pinned by the argv tests, so changing one is an argued diff | 2026-08-25 |
@@ -142,20 +147,17 @@ reader should re-verify rather than trust the table.
 | `mp3` | `-map 0:a? -c:a copy` | False | 1 | `-map 0:a:0 -c:a libmp3lame -q:a 2` |
 | `flac` | `-map 0:a? -c:a copy` | False | 1 | `-map 0:a:0 -c:a flac` |
 | `m4a` | `-map 0:a? -c:a copy` | False | none | `-map 0:a:0 -c:a aac -b:a 192k` |
-| `ogg` | `-map 0:a? -map 0:v? -c copy` | False | none | `-map 0:a:0 -c:a libvorbis -q:a 5` |
-| `opus` | `-map 0:a? -map 0:v? -c:a libopus -b:a 128k`, with the standing re-encode note | False | none | `-map 0:a:0 -c:a libopus -b:a 128k` |
+| `ogg` | `-map 0:a? -c copy` | False | none | `-map 0:a:0 -c:a libvorbis -q:a 5` |
+| `opus` | per the second open decision | False | none | `-map 0:a:0 -c:a libopus -b:a 128k` |
 
 `explicit_streams` is `False` throughout: every cheap attempt above selects by
 type rather than by index, so the selective rung is never suppressed.
 
-**To be measured before the issues are written**, and recorded here once they
-are — the review closes these rather than the implementer discovering them:
-
-- Does the `flac` muxer reject a *real* video stream while accepting a picture?
-  If it does, `flac` belongs in the video-mapping group with `ogg` and `opus`,
-  and its share of the open decision disappears.
-- Does the `opus` muxer accept more than one audio stream? If it enforces one,
-  `opus` gains `stream_limit=1` for the same reason `mp3` has it.
+Both questions this table originally left open were measured during review and
+are now rows in the muxer table above: `flac` does **not** reject real video — it
+discards it at exit 0 — so `flac` maps audio only and stays in the open decision;
+and `opus` does hold several audio streams, so it declares no `stream_limit`.
+Nothing here is left for the implementer to determine.
 
 ### Two roadmap candidates this phase deliberately does not take
 
@@ -205,6 +207,33 @@ gate picks:
 Option 1 is the safer reading; option 2 is the quieter tool and costs an
 amendment. Either way the loss is real and the phase records it.
 
+### The second open decision: does `opus` copy?
+
+Decided with the first, because both are the same question — how much may the
+happy path lose in exchange for not probing — and because option 1 above already
+accepts a standing note as a mechanism.
+
+The `opus` muxer accepts a Vorbis stream (measured), and `.opus` is a
+codec-defined format, so a plain copy can ship a file whose extension lies about
+its contents. Forcing `libopus` fixes that and costs a re-encode of every source
+that was *already* Opus: measured, `tone.opus` grows 18 445 -> 37 356 bytes and
+its packets change. That is a real generation loss the tool inflicted, on the
+common case, to prevent a mislabel only reachable by pointing `--to opus` at a
+`.ogg`/`.oga` file.
+
+1. **`opus` copies** (`-map 0:a? -c copy`). No generation loss, fast, and the
+   mask governs the selective rung as everywhere else. A Vorbis source is copied
+   into a file called `.opus`, reported as converted — the tool's only mislabel.
+2. **`opus` always encodes** (`-map 0:a? -map 0:v? -c:a libopus -b:a 128k`) with a
+   standing note saying the audio was re-encoded. The extension never lies, and
+   the mapped video is what makes a cover-art source fail into the ladder and get
+   a real note — the only target where that works. Every already-Opus file pays a
+   transcode.
+
+Picking 1 also removes `opus` from the video-mapping group, so no target maps
+video and all five join the first decision's group. Picking 2 keeps `opus` as the
+one target whose cover-art loss is named properly.
+
 ## Tracking
 
 The decomposition into steps lives as GitHub issues, not in this file — one
@@ -224,7 +253,10 @@ Machine checks:
       parallel orchestrators, so a two-dot range against `main` would sweep in
       another milestone's commits.
 - [ ] Per new profile, a test pinning the full argv for a copyable input and for
-      a non-copyable one — ten tests, five profiles, both cases each.
+      a non-copyable one. Nine or ten tests depending on the `opus` decision: if
+      `opus` always encodes it has no happy-path copyable case, the same exception
+      `spec-profile-registry.md` recorded for WAV's empty mask, and its copy is
+      reachable only on the selective rung.
 - [ ] Per new degradation branch, a test asserting the note: a re-encode naming
       both codecs, a second audio stream dropped **for `mp3` and `flac`, whose
       muxers enforce one** (the other three carry every stream, so there is no
@@ -264,13 +296,15 @@ New-Item -ItemType Directory -Force in
       conversion source too and is covered by its own item below; `cover.png` is
       not a source at all -- keep it outside `in/`, or expect the image phase to
       claim it later.
-- [ ] A stream copy really is a copy: `--to opus` from `tone.opus` finishes
-      near-instantly and the audio stream is packet-identical —
-      `& $FF -i out/tone.opus -map 0:a -c copy -f md5 -` matches the same command
+- [ ] A stream copy really is a copy: `--to mp3` from `tone.mp3` finishes
+      near-instantly and the audio stream is packet-identical --
+      `& $FF -i out/tone.mp3 -map 0:a -c copy -f md5 -` matches the same command
       on the source. Compare the stream, not the file: a remux re-pages the
-      container.
+      container. Aimed at `mp3` rather than `opus`, since whether `opus` copies at
+      all is one of the gate decisions.
 - [ ] `--to flac in out` over `tone.wav` produces a playable FLAC via the
-      `last_resort`, not a failure.
+      **selective** rung, not a failure -- the same rung the machine check names,
+      verified against the real engine.
 - [ ] A second run over any converted tree reports `0 converted`, exit 0.
 - [ ] `art.mp3` under `--to mp3`: `ffprobe` the output and confirm the picture
       stream is gone, and that the run says what the gate's decision says it
@@ -314,3 +348,16 @@ New-Item -ItemType Directory -Force in
   the copy mask, decide the happy path — `--to opus` from a Vorbis source shipped
   a `.opus` file containing Vorbis at exit 0. The cheap attempts are now per
   profile, and `opus` forces its encoder rather than copying.
+- 2026-08-25: Spec review measured that mapping video into `ogg` passes a theora
+  source straight through at exit 0 — a whole video file renamed `.ogg`, the same
+  defect that rules `m4a` out. `ogg` no longer maps video, which leaves `opus` as
+  the only target where a cover-art loss can be named, and only if the gate has
+  it encode rather than copy.
+- 2026-08-25: Spec review measured that `flac` does not reject a real video
+  stream — it discards it at exit 0 with only a stderr warning, which the
+  constitution forbids parsing. Silent discard is worse than rejection, so `flac`
+  maps audio only.
+- 2026-08-25: The `opus` copy-or-encode question was promoted out of a decision
+  row into the gate, next to the standing-note decision. Settling it in a row
+  traded a generation loss on the common case for a mislabel on a rare one, and
+  presented the loss as a warning the source "deserved" — the tool inflicts it.

--- a/docs/specs/spec-audio-formats.md
+++ b/docs/specs/spec-audio-formats.md
@@ -110,22 +110,52 @@ reader should re-verify rather than trust the table.
 | The `ogg` muxer accepts `vorbis`, `opus` and `flac` as-is; it rejects `mp3` and `aac` | The `ogg` mask is `{vorbis, opus, flac}` |
 | The `mp3` muxer enforces "exactly one MP3 audio stream" | `stream_limit=1` there is a muxer constraint, not only a product judgement |
 | The `ogg` and `opus` muxers **reject** a picture stream outright (`Unsupported codec id in stream 1`), and the `wav` muxer rejects any video stream | Not "awkward support" — a hard failure, which is why a blind cheap attempt that mapped video would fail for these targets |
-| `mp3`, `m4a` (ipod) and `flac` **accept** a picture stream, and an `mp3` target given a genuine 20-frame MJPEG video silently writes a single-frame `attached_pic` | Mapping video blindly into an audio target is a silent data loss the constitution forbids — so no audio profile maps video at all |
+| `mp3`, `m4a` (ipod) and `flac` **accept** a picture stream that already carries the `attached_pic` disposition. A **bare** mjpeg is a different case: `m4a` rejects it, `mp3` silently writes it as a single frame | These three cannot map video safely, so they map audio only |
+| `m4a` (ipod) copies a **full h264 track** through without complaint: `clip.mkv` under `-map 0:a? -map 0:v? -c copy` exits 0 with `0\|aac 1\|h264` | The decisive reason `m4a` maps no video: the user asked for audio and would get a video file |
+| The `opus` muxer accepts a **Vorbis** stream | A blind copy into `.opus` can ship a file whose extension lies about its contents; `opus` forces its encoder instead |
+| The `flac` muxer enforces exactly one FLAC audio stream, like `mp3` | `stream_limit=1` is a muxer constraint there too |
 | `-q:a 2` (libmp3lame) and `-q:a 5` (libvorbis) are valid | The fallback defaults below are real |
 
 ### Decisions
 
 | Decision | Rationale | Date |
 |---|---|---|
-| Every audio profile's `cheap_attempt` is a **blind audio-only stream copy**, `flags("-map 0:a? -c:a copy")`, with `explicit_streams=False` | Blind, so the copy masks are live on the happy path and "a stream copy really is a copy" holds. Audio-only, because mapping video blindly is the silent single-frame loss the muxer table records. `explicit_streams=False` because the attempt is blind, which also means the selective rung is never suppressed | 2026-08-25 |
-| Every audio profile declares a `last_resort`: the format's fallback encoder over the first audio stream only, e.g. `flags("-map 0:a:0 -c:a libmp3lame -q:a 2")` | Without it a ladder that reaches the end lands as `failed`. Concretely: `--to flac` from a `.wav` source fails the cheap copy, and its selective rung carries no note (encoding into a container's own lossless codec is not a loss), so the rung alone is not a safety net | 2026-08-25 |
-| Each audio target declares `stream_limit=1` for audio | A muxer constraint for `mp3`; for the rest, these containers hold one audio stream in any player anyone will use. A second stream is dropped with a note naming it | 2026-08-25 |
+| **On the happy path the muxer is the authority, not the copy mask.** A stream copy that ffmpeg's muxer accepts ships, whether or not the mask lists that codec; the mask governs the *failure* path, where the engine builds the selective rung | Measured, not assumed: `--to opus` from a Vorbis `.ogg` under a blind `-c:a copy` exits 0 and writes a `.opus` file containing Vorbis. Nothing short of a probe can prevent that, and a probe on the happy path is forbidden. The per-profile cheap attempts below are chosen so that where the muxer is looser than the format's identity, the profile does not rely on a copy at all | 2026-08-25 |
+| The `cheap_attempt`, `explicit_streams` and `last_resort` of each of the **five new** profiles are fixed by the table below; `wav` is untouched and keeps phase 2's shape exactly | A blanket rule does not survive contact with the muxers: they differ in whether they enforce the target's codec, whether they hold several audio streams, and whether they reject a picture stream. Each of those differences changes what an honest cheap attempt looks like | 2026-08-25 |
+| `stream_limit=1` for `mp3` and `flac` only. `m4a`, `ogg` and `opus` declare **no** audio stream limit | Measured: the `mp3` and `flac` muxers both enforce exactly one audio stream, so the limit is real and a multi-stream source fails into the ladder, which names the stream it drops. `m4a`, `ogg` and `opus` accept several, so declaring a limit would mean mapping one stream and silently discarding the rest — a loss the tool could not name. Carrying every stream the container holds drops nothing at all, which is the better answer | 2026-08-25 |
+| `opus` **does not copy**: its cheap attempt forces `libopus`, and carries a standing note saying the audio was re-encoded to Opus | The `opus` muxer accepts a Vorbis stream (measured), and `.opus` is a codec-defined format, so a copy can ship a file whose name lies about its contents. Forcing the encoder is the only way the label stays true without a probe. The standing note is accurate for every input, including an already-Opus source, where it is the generation-loss warning that source deserves | 2026-08-25 |
+| `ogg` and `opus` **map video** in their cheap attempt; `mp3`, `m4a` and `flac` do not | Measured: the `ogg` and `opus` muxers reject a picture stream outright, so mapping video makes a cover-art source *fail* into the ladder, which then emits the real per-stream note. That costs one extra ffmpeg spawn for sources that carry artwork and nothing otherwise. The other three accept a picture — and `m4a` will happily copy a full h264 track into a file the user asked for as audio (measured) — so for them mapping video buys a silent wrong result instead of a note | 2026-08-25 |
+| Every new profile declares a `last_resort`: the format's fallback encoder over the first audio stream, e.g. `flags("-map 0:a:0 -c:a libmp3lame -q:a 2")` | Not for the FLAC-from-WAV case, which the selective rung already handles. It is for the case the selective rung cannot: the rung may choose `-c:a copy` on a mask hit for a bitstream the muxer then refuses, and only a forced re-encode rescues that file | 2026-08-25 |
 | Copy masks: `mp3` -> `{mp3}`; `m4a` -> `{aac, alac}`; `flac` -> `{flac}`; `opus` -> `{opus}`; `ogg` -> `{vorbis, opus, flac}` | Each is what the muxer accepts as-is, per the verified table above and curated by hand per the prior-art AVOID | 2026-08-25 |
 | Fallback encoders and their defaults: `mp3` -> `libmp3lame -q:a 2` (VBR ~190 kbit/s); `m4a` -> `aac -b:a 192k`; `flac` -> `flac`; `opus` -> `libopus -b:a 128k`; `ogg` -> `libvorbis -q:a 5` (~160 kbit/s) | Quality-based VBR where the encoder has a good one, bitrate where it does not, all at "transparent enough that nobody notices" rather than "smallest". Defaults, not a surface: pinned by the argv tests, so changing one is an argued diff | 2026-08-25 |
 | `flac` and `wav` declare **`fallback_name=None`**, so an encode into them emits no note; the other four declare theirs, so a re-encode emits the engine's existing per-stream note naming the source codec and the target codec | Decoding into a container's own lossless codec gives up nothing. This is the rule phase 1 established for WAV, expressed with the one lever `jobs.py` has | 2026-08-25 |
 | **No generation-loss note** (a "your FLAC came from a 128 kbit/s MP3" warning) in this phase | It would need a lossy-codec set plus a new branch in `jobs.py`, and `Stream` carries no such notion — an engine change, which this phase's headline outcome forbids. Recorded below as a roadmap candidate rather than smuggled in | 2026-08-25 |
 | No audio profile declares a **video rule**, so any video stream — cover art included — is dropped by the selective rung with the engine's existing "not supported by TARGET" note | Keeping cover art needs the `attached_pic` disposition, which `probe_streams` does not request and `Stream` does not carry, so the engine cannot tell a picture from a real video stream. The muxer table shows what happens if you guess: `m4a` hard-fails on a real MJPEG while succeeding on a picture, and `mp3` silently truncates it to one frame | 2026-08-25 |
 | OPEN — what a conversion says when the cheap attempt **succeeds** and cover art is lost along the way | resolved at the spec-acceptance gate; see the note below | — |
+
+### The five new profiles, fixed
+
+`wav` is not in this table: it keeps phase 2's shape unchanged.
+
+| Target | `cheap_attempt` | `explicit_streams` | `stream_limit` (audio) | `last_resort` |
+|---|---|---|---|---|
+| `mp3` | `-map 0:a? -c:a copy` | False | 1 | `-map 0:a:0 -c:a libmp3lame -q:a 2` |
+| `flac` | `-map 0:a? -c:a copy` | False | 1 | `-map 0:a:0 -c:a flac` |
+| `m4a` | `-map 0:a? -c:a copy` | False | none | `-map 0:a:0 -c:a aac -b:a 192k` |
+| `ogg` | `-map 0:a? -map 0:v? -c copy` | False | none | `-map 0:a:0 -c:a libvorbis -q:a 5` |
+| `opus` | `-map 0:a? -map 0:v? -c:a libopus -b:a 128k`, with the standing re-encode note | False | none | `-map 0:a:0 -c:a libopus -b:a 128k` |
+
+`explicit_streams` is `False` throughout: every cheap attempt above selects by
+type rather than by index, so the selective rung is never suppressed.
+
+**To be measured before the issues are written**, and recorded here once they
+are — the review closes these rather than the implementer discovering them:
+
+- Does the `flac` muxer reject a *real* video stream while accepting a picture?
+  If it does, `flac` belongs in the video-mapping group with `ogg` and `opus`,
+  and its share of the open decision disappears.
+- Does the `opus` muxer accept more than one audio stream? If it enforces one,
+  `opus` gains `stream_limit=1` for the same reason `mp3` has it.
 
 ### Two roadmap candidates this phase deliberately does not take
 
@@ -143,26 +173,37 @@ are not silently lost; seeding them as roadmap phases is `/loopkit:roadmap`'s jo
 
 `ffprobe` never runs on the happy path (`docs/constitution.md`), so a conversion
 the cheap attempt completes has **no stream list** — the engine cannot name what
-it dropped, because it does not know. Concretely: an `.mp3` with cover art, under
-`--to mp3`, is copied by `flags("-map 0:a? -c:a copy")`, the artwork does not
-come along, and there is nothing to build a per-stream note from.
+it dropped, because it does not know.
+
+**This affects three targets, not six.** `ogg` and `opus` map video precisely so
+that a cover-art source fails into the ladder, which then names the picture
+stream and its codec properly; `wav` rejects video the same way. That leaves
+`mp3`, `m4a` and `flac` — the muxers that *accept* a picture — where the cheap
+attempt maps audio only, succeeds, and the artwork is gone with nothing to build
+a note from. (If the flac measurement above comes back showing it rejects real
+video, this narrows again, to `mp3` and `m4a`.)
 
 Every degraded conversion the *ladder* reaches still names the stream index, its
-codec and what was given up, exactly as `docs/vision.md` requires. The gap is only
-the happy path, and it is structural rather than an oversight. The gate picks:
+codec and what was given up, exactly as `docs/vision.md` requires. The gap is the
+happy path for those targets, and it is structural rather than an oversight. The
+gate picks:
 
-1. **A standing note on the cheap attempt** — a fixed line on the `Attempt`, e.g.
-   `non-audio streams (including cover art) are not carried into MP3`. Always
-   truthful, never silent, and free. The cost is noise: it prints for every file,
-   including the vast majority that had nothing to lose.
-2. **Say nothing when the cheap attempt succeeds.** No noise, and a file that had
-   cover art loses it without a word — a real tension with "never report success
-   for a conversion that silently dropped something", confined to the one path
-   where the constitution also forbids the probe that would resolve it.
+1. **A standing note on those profiles' cheap attempts** — a fixed line on the
+   `Attempt`, e.g. `non-audio streams, including cover art, are not carried into
+   MP3`. Always truthful, never silent, free, and it needs no amendment to any
+   foundation doc. The cost is noise: it prints for every file, including the
+   majority that had nothing to lose.
+2. **Say nothing when the cheap attempt succeeds.** The quieter tool, and a file
+   that had cover art loses it without a word. **Picking this requires amending
+   `docs/constitution.md` in this PR** — its "never report success for a
+   conversion that silently dropped something" is normative and this spec's own
+   Constraints repeat it, so the exception has to be written down (scoped to the
+   happy path, where the same document forbids the probe that would resolve it)
+   rather than approved as a quiet violation. Phases 1 and 2 both set the
+   precedent of amending a foundation doc in the spec's own PR.
 
-Option 1 is the safer reading of the constitution; option 2 is the quieter tool.
-Whichever is picked, this phase records the tension in the spec rather than
-leaving it for someone to discover.
+Option 1 is the safer reading; option 2 is the quieter tool and costs an
+amendment. Either way the loss is real and the phase records it.
 
 ## Tracking
 
@@ -185,16 +226,20 @@ Machine checks:
 - [ ] Per new profile, a test pinning the full argv for a copyable input and for
       a non-copyable one — ten tests, five profiles, both cases each.
 - [ ] Per new degradation branch, a test asserting the note: a re-encode naming
-      both codecs, a second audio stream dropped, a video stream dropped, and
-      whatever the cover-art decision adds.
+      both codecs, a second audio stream dropped **for `mp3` and `flac`, whose
+      muxers enforce one** (the other three carry every stream, so there is no
+      drop to name), a video stream dropped, and whatever the cover-art decision
+      adds.
 - [ ] A test that converting into `flac` or `wav` emits no note for the encode.
 - [ ] A test that `wav`'s argv is byte-for-byte what it was before this phase.
 - [ ] A structural test over the whole registry: every entry has a `name`, a
       `description`, a target suffix present in the curated source-suffix set,
       and at least one stream rule — this catches a half-written profile, and it
       keeps working for phases 4 and 5.
-- [ ] A test that `--to flac` from a PCM source reaches the `last_resort` rather
-      than landing as `failed`.
+- [ ] A test that `--to flac` from a PCM source reaches the **selective** rung
+      -- verified against the real engine during review, which returns
+      `selective` then `re-encode` for a `pcm_s16le` stream -- rather than
+      landing as `failed`.
 
 Human milestone-QA gate — the machine checks stub the subprocess boundary, so
 only this proves a real conversion. `$FF` is the absolute ffmpeg path from *This
@@ -202,20 +247,23 @@ machine*; PowerShell, one command per line:
 
 ```text
 New-Item -ItemType Directory -Force in
-& $FF -f lavfi -i sine=duration=3 -c:a libmp3lame in/tone.mp3
-& $FF -f lavfi -i sine=duration=3 -c:a aac        in/tone.m4a
-& $FF -f lavfi -i sine=duration=3 -c:a flac       in/tone.flac
-& $FF -f lavfi -i sine=duration=3 -c:a libopus    in/tone.opus
-& $FF -f lavfi -i sine=duration=3 -c:a libvorbis  in/tone.ogg
-& $FF -f lavfi -i sine=duration=3 -c:a pcm_s16le  in/tone.wav
-& $FF -f lavfi -i testsrc=size=320x240:rate=10:duration=3 -f lavfi -i sine=duration=3 -c:v libx264 -c:a aac in/clip.mp4
-& $FF -f lavfi -i color=c=red:size=200x200:d=1 -frames:v 1 in/cover.png
-& $FF -i in/tone.mp3 -i in/cover.png -map 0:a -map 1:v -c copy -disposition:v:0 attached_pic in/art.mp3
+& $FF -y -f lavfi -i sine=duration=3 -c:a libmp3lame in/tone.mp3
+& $FF -y -f lavfi -i sine=duration=3 -c:a aac        in/tone.m4a
+& $FF -y -f lavfi -i sine=duration=3 -c:a flac       in/tone.flac
+& $FF -y -f lavfi -i sine=duration=3 -c:a libopus    in/tone.opus
+& $FF -y -f lavfi -i sine=duration=3 -c:a libvorbis  in/tone.ogg
+& $FF -y -f lavfi -i sine=duration=3 -c:a pcm_s16le  in/tone.wav
+& $FF -y -f lavfi -i testsrc=size=320x240:rate=10:duration=3 -f lavfi -i sine=duration=3 -c:v libx264 -c:a aac in/clip.mp4
+& $FF -y -f lavfi -i color=c=red:size=200x200:d=1 -frames:v 1 in/cover.png
+& $FF -y -i in/tone.mp3 -i in/cover.png -map 0:a -map 1:v -c copy -disposition:v:0 attached_pic in/art.mp3
 ```
 
 - [ ] Each of the six targets converts a real source and the result plays.
-- [ ] `--to mp3 in out` converts all seven sources, names every re-encode it
-      performed, and exits 0.
+- [ ] `--to mp3 in out` converts the seven conversion sources (the six tones and
+      `clip.mp4`), names every re-encode it performed, and exits 0. `art.mp3` is a
+      conversion source too and is covered by its own item below; `cover.png` is
+      not a source at all -- keep it outside `in/`, or expect the image phase to
+      claim it later.
 - [ ] A stream copy really is a copy: `--to opus` from `tone.opus` finishes
       near-instantly and the audio stream is packet-identical —
       `& $FF -i out/tone.opus -map 0:a -c copy -f md5 -` matches the same command
@@ -256,3 +304,13 @@ New-Item -ItemType Directory -Force in
   phase once the review showed neither is expressible in the implemented value
   types. They are recorded as roadmap candidates with their real cost — an engine
   change — rather than being smuggled in as "just a profile field".
+- 2026-08-25: Spec review built the proposed FLAC profile against the real engine
+  and ran it: a PCM stream yields `selective` then `re-encode`, so the selective
+  rung is what rescues `--to flac` from a WAV source, not the `last_resort`. The
+  `last_resort` is kept for the case the rung cannot cover — a mask hit whose
+  bitstream the muxer then refuses — and the Verification item was corrected to
+  assert the rung the engine actually reaches.
+- 2026-08-25: Spec review measured that a blind `-c:a copy` lets the muxer, not
+  the copy mask, decide the happy path — `--to opus` from a Vorbis source shipped
+  a `.opus` file containing Vorbis at exit 0. The cheap attempts are now per
+  profile, and `opus` forces its encoder rather than copying.

--- a/docs/specs/spec-audio-formats.md
+++ b/docs/specs/spec-audio-formats.md
@@ -1,0 +1,191 @@
+# Spec: audio-formats (roadmap phase 3)
+
+> Created: 2026-08-25
+
+Add the five remaining audio target profiles — `mp3`, `m4a`, `flac`, `opus`,
+`ogg` — to the registry, alongside the `wav` profile that already exists, and
+prove that adding a format really does cost nothing but a profile entry and its
+test. This spec carries no lifecycle state — acceptance is the spec merged on the
+default branch with a milestone and issues, and all progress lives in the GitHub
+issues and milestone. A completed spec is moved to `docs/specs/archive/`.
+
+## Outcome
+
+- [ ] `converter --to <fmt>` works for `mp3`, `m4a`, `flac`, `opus` and `ogg`,
+      and `wav` still behaves exactly as it does after phase 2.
+- [ ] `--list-formats` prints six audio targets.
+- [ ] **The diff of this phase touches `converter/profiles.py` and the tests, and
+      nothing else.** This is the constitution's "a target format is data, not
+      code" claim being cashed in for the first time; a diff in `cli.py`,
+      `batch.py`, `paths.py` or `jobs.py` means the profile model is wrong and
+      that is the bug to fix, not the diff to accept.
+- [ ] Every new profile has a test pinning the exact argv it builds, for a
+      copyable and for a non-copyable input.
+- [ ] Every degradation branch a new profile introduces has a test asserting the
+      note it emits.
+- [ ] Whatever a source carries that the target cannot hold is named in a note —
+      never dropped in silence.
+- [ ] The curated source-suffix set covers the audio formats people actually
+      have, so `--to mp3` over a real music tree finds them.
+
+## Scope
+
+### In scope
+
+- Five new `Profile` entries in `converter/profiles.py` with their stream rules,
+  copy masks, fallback encoders and container options, plus their registry
+  entries.
+- Extending the curated source-suffix set with the audio suffixes a source tree
+  realistically holds (`.aac`, `.m4b`, `.wma`, `.aiff`, `.alac`, `.ape`, `.wv`
+  and the six targets' own suffixes).
+- The tests those profiles require, per the constitution's two gates.
+- Cover-art handling, per the decision resolved at the acceptance gate.
+
+### Out of scope
+
+- Video and image targets — phases 4 and 5, which depend on the same phase 2 and
+  not on this one.
+- Any encoder-tuning surface. Bitrates and quality settings are chosen once, as
+  defaults, and are not exposed (`docs/vision.md` non-goal).
+- Loudness normalisation, resampling, channel remapping, tag editing. A
+  conversion is a conversion.
+- Changing the engine or the ladder. If a profile needs an engine change, that is
+  a finding to escalate, not to absorb quietly — see the Risks table.
+
+## Constraints
+
+- A target format is data, not code (`docs/constitution.md`,
+  `docs/architecture.md`): `converter/profiles.py` stays a leaf, and this phase's
+  diff proves the rule rather than asserting it.
+- No second external dependency, and no second backend — every format here has a
+  working ffmpeg muxer or it does not ship (`docs/vision.md` non-goals).
+- Never report success for a conversion that silently dropped something.
+- Every degraded conversion names the stream index, that stream's codec, and what
+  was given up.
+- The test suite keeps passing with no ffmpeg installed; the subprocess boundary
+  stays stubbed.
+
+## Prior art
+
+- [Python wrapper structure around the ffmpeg CLI (Phase 3, Phase 4)](../prior-art.md#python-wrapper-structure-around-the-ffmpeg-cli-phase-3-phase-4)
+  — the concern tagged for this phase. Its ADOPT is confirmation rather than code:
+  `ffmpeg-normalize`'s split into per-stream-type handling plus a command builder
+  is the shape this codebase already has. Its AVOID is the live one here — never
+  scrape ffmpeg's stderr to decide a second pass; a profile that "needs" stderr to
+  choose an encoder is a profile modelled wrong.
+- [Container/codec capability modelling (Phase 1)](../prior-art.md#containercodec-capability-modelling-phase-1)
+  — still governing: HandBrake's copy-mask plus encoder-fallback vocabulary is what
+  each new profile is written in, and the ffmpeg-CLI entry is why every mask below
+  is curated by hand rather than discovered from `ffmpeg -codecs`.
+
+## Design
+
+No new design artifact. This phase makes no new decision about the ladder or the
+per-stream branch — it fills in data for decisions `docs/design/degradation-ladder.md`
+and `docs/design/stream-decision.md` already settled. Implement against those two.
+
+## Human prerequisites
+
+- none. No secret, no dependency, no external provisioning. The QA gate needs the
+  ffmpeg already installed on this machine, and one real music file per source
+  codec, which the gate synthesises.
+
+## Prior decisions
+
+| Decision | Rationale | Date |
+|---|---|---|
+| Each audio target declares a stream limit of 1 for audio, like WAV | These containers hold one audio stream in any player anyone will use; a second stream is dropped with a note naming it, which is the honest outcome rather than a file that plays unpredictably | 2026-08-25 |
+| Copy masks: `mp3` -> `{mp3}`; `m4a` -> `{aac, alac}`; `flac` -> `{flac}`; `opus` -> `{opus}`; `ogg` -> `{vorbis, opus, flac}` | Each is what the muxer accepts as-is, curated by hand per the prior-art AVOID. A copy mask this narrow is the point: a re-encode that the mask predicts is named in a note, and a stream copy that the mask allows costs nothing | 2026-08-25 |
+| Fallback encoders and their defaults: `mp3` -> `libmp3lame -q:a 2` (VBR ~190 kbit/s); `m4a` -> `aac -b:a 192k`; `flac` -> `flac` (lossless); `opus` -> `libopus -b:a 128k`; `ogg` -> `libvorbis -q:a 5` (~160 kbit/s) | Quality-based VBR where the encoder has a good one, bitrate where it does not, all at "transparent enough that nobody notices" rather than "smallest". They are defaults, not a surface: `docs/vision.md` rules out an encoder-tuning surface, so these are chosen once and pinned by the argv tests | 2026-08-25 |
+| Re-encoding a lossy source into another lossy format emits a note naming both codecs; re-encoding **into** `flac` from a lossy source also emits one, saying the result is lossless but the source was not | Generation loss is exactly the kind of thing the free tools stay silent about (`docs/vision.md`), and a 40 MB FLAC made from a 128 kbit/s MP3 is a result the user should be told about rather than discover | 2026-08-25 |
+| Converting into `wav` or `flac` from any source emits **no** note for the encode itself | Decoding to the container's own lossless codec gives up nothing; a note per file would be noise. This is the rule phase 1 already established for WAV's PCM rule | 2026-08-25 |
+| A source's video streams that are not cover art are dropped with a note naming the stream and its codec | `--to mp3` pointed at a video file is a legitimate "rip the audio" request; failing it would be unhelpful, and dropping the video without a word is what the constitution forbids | 2026-08-25 |
+| OPEN — cover art: which audio targets keep an embedded picture stream, and which drop it with a note | resolved at the spec-acceptance gate; see the note below | — |
+
+### The one open decision, in full
+
+Music files carry cover art as a video stream with the `attached_pic`
+disposition — usually `mjpeg` or `png`. It is not metadata, so `docs/vision.md`'s
+EXIF/ICC non-goal does not settle it, and nothing in the prior art does either.
+
+Keeping it costs a video rule per profile (`-c:v:{n} copy` plus
+`-disposition:v:{n} attached_pic`) and a real risk: ffmpeg's support for attached
+pictures differs per muxer, and it is *known* to be awkward for Ogg and Opus,
+where the picture goes into a `METADATA_BLOCK_PICTURE` tag rather than a stream.
+Dropping it is one line per profile and always works — and loses the album art
+off every file someone converts.
+
+The gate picks one of:
+
+1. **Keep cover art where the muxer holds it as a stream (`mp3`, `m4a`, `flac`),
+   drop it with a note for `wav`, `opus` and `ogg`.** Honest and per-format, and
+   the note tells the user which of their files lost artwork. Costs a QA item
+   proving each of the three really does keep it with the installed ffmpeg 9.
+2. **Drop cover art everywhere, always with a note.** One rule, no per-muxer
+   surprises, no risk of a profile that works on one ffmpeg build and not another.
+   Every converted music file loses its artwork, and is told so.
+
+Whichever is picked, the drop is never silent.
+
+## Tracking
+
+The decomposition into steps lives as GitHub issues, not in this file — one
+issue per step, grouped under a milestone. This spec owns the design; the issues
+own progress.
+
+- Milestone: audio-formats (created at the spec-acceptance gate)
+- Issues: created from this spec once it is merged (one per implementable step)
+
+## Verification
+
+Machine checks:
+
+- [ ] Verify passes (ruff check, ruff format --check, pytest) on the merge commit.
+- [ ] `git diff <phase-2-merge>..HEAD --stat` for this milestone lists only
+      `converter/profiles.py` and files under `tests/`. This is the phase's
+      headline outcome and it is checked, not asserted.
+- [ ] Per new profile, a test pinning the full argv for a copyable input and for
+      a non-copyable one — ten tests, five profiles, both cases each.
+- [ ] Per new degradation branch, a test asserting the note: the lossy-to-lossy
+      re-encode, the lossy-source-into-flac note, a second audio stream dropped,
+      a non-cover-art video stream dropped, and whatever the cover-art decision
+      adds.
+- [ ] A test that `wav`'s argv is byte-for-byte what it was before this phase.
+- [ ] A test that every registry entry has a `name`, a `description`, a target
+      suffix that appears in the curated source-suffix set, and at least one
+      stream rule — a structural check that catches a half-written profile.
+- [ ] A test that converting into `flac` or `wav` emits no note for the encode
+      itself.
+
+Human milestone-QA gate — the machine checks stub the subprocess boundary, so
+only this proves a real conversion. Synthesise one source per codec first with
+the absolute ffmpeg path from *This machine* (`libmp3lame`, `aac`, `flac`,
+`libopus`, `libvorbis`, plus one `.mkv` with an audio track):
+
+- [ ] Each of the six targets converts a real source and the result plays.
+- [ ] `--to mp3` over a directory holding all six source kinds converts every one
+      of them, reports the re-encodes it performed by name, and exits 0.
+- [ ] A stream copy really is a copy: `--to opus` from an `.opus` source finishes
+      near-instantly and the output is bit-identical in its audio stream.
+- [ ] `--to flac` from a 128 kbit/s MP3 prints the generation-loss note.
+- [ ] A second run over any converted tree reports `0 converted`, exit 0.
+- [ ] Cover art behaves exactly as the gate's decision says, verified per target
+      with `ffprobe` rather than by looking at a player.
+- [ ] `--to mp3` on a video file rips the audio and names the dropped video
+      stream.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| A profile turns out to need an engine change, quietly breaking the phase's headline outcome | The diff check is a Verification item. A profile that cannot be expressed as data is escalated as `needs:planning`, not absorbed by editing `jobs.py` |
+| A copy mask is wrong and a stream copy produces a file that does not play | The QA gate plays one output per target, and the copy-vs-re-encode path is the one thing the machine checks cannot prove |
+| The fallback defaults age badly, or someone treats them as a tuning surface | They are pinned by the argv tests, so changing one is a visible, argued diff rather than a drive-by |
+| Cover art works on this machine's ffmpeg 9 and not on an older build | The QA gate verifies with `ffprobe` per target; the decision note records that muxer support is the risk, so a later bug report has somewhere to land |
+| The curated suffix set misses a format people actually have, so `--to mp3` silently finds nothing | The suffix list is enumerated in Scope rather than left to taste, and the QA gate points the tool at a directory holding all six source kinds |
+
+## Decision log
+
+- 2026-08-25: No design artifact for this phase. The ladder and the per-stream
+  branch are already drawn; phases 3-5 supply data for them, and a fourth diagram
+  restating that would be the drift `docs/design.md` warns about.


### PR DESCRIPTION
Roadmap phase 3 — the planning package for `audio-formats`.

Adds `mp3`, `m4a`, `flac`, `opus` and `ogg` beside the existing `wav` profile. No new design artifact: the ladder and the per-stream branch are already drawn, and this phase supplies data for them.

The headline outcome is the diff itself — if a target format is really data, this phase touches `converter/profiles.py` and the tests and nothing else. That is a Verification item, not a claim.

Depends on milestone #2 (target-driven-cli): there is no `--to` to reach a new profile without it. Independent of phases 4 and 5.

One decision is left open for the acceptance gate: which audio targets keep embedded cover art.
