### PR TITLE
docs(spec): image target profiles (roadmap phase 5)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,7 +15,7 @@
 | 2 | target-driven-cli | [spec-target-driven-cli.md](specs/spec-target-driven-cli.md) | [#2](https://github.com/bhemsen/converter/milestone/2) |
 | 3 | audio-formats | [spec-audio-formats.md](specs/spec-audio-formats.md) | [#3](https://github.com/bhemsen/converter/milestone/3) |
 | 4 | video-formats | [spec-video-formats.md](specs/spec-video-formats.md) | [#4](https://github.com/bhemsen/converter/milestone/4) |
-| 5 | image-formats | — | — |
+| 5 | image-formats | [spec-image-formats.md](specs/spec-image-formats.md) | [#5](https://github.com/bhemsen/converter/milestone/5) |
 
 A phase gets a Spec link once `/plan` drafts it, and a Milestone link once the
 spec is merged. The milestone (open/closed + issue progress) is where status

--- a/docs/specs/spec-image-formats.md
+++ b/docs/specs/spec-image-formats.md
@@ -234,7 +234,7 @@ choice; do not read them as settled before the gate.
 
 ## Tracking
 
-- Milestone: image-formats (created at the spec-acceptance gate)
+- Milestone: [image-formats](https://github.com/bhemsen/converter/milestone/5) (#5)
 - Issues: created from this spec once it is merged (one per implementable step)
 
 ## Verification

--- a/docs/specs/spec-image-formats.md
+++ b/docs/specs/spec-image-formats.md
@@ -106,6 +106,8 @@ codes taken from ffmpeg itself.
 |---|---|
 | **The image2 muxer accepts any video codec under `-c copy`.** `flat.jpg -map 0:v? -c copy out.png` exits 0 and writes a JPEG named `.png`; `alpha.png -> out.jpg` writes a PNG named `.jpg` | `png`, `jpg`, `tiff` and `bmp` must **force their encoder** in the cheap attempt. A copy there mislabels the file on the default path, for the two commonest image conversions there are |
 | **`webp`, `avif` and `gif` self-police**: a non-matching codec copy exits 127 ("webp muxer supports only codec webp", "gif muxer supports only codec gif", "Could not find tag for codec png") | Those three can keep `-c copy` safely; the price is one wasted spawn plus one probe per non-matching source |
+| **GIF is a 256-colour palette format, not a lossless one**: a photograph through `-c:v gif` keeps 182 of 36 485 distinct colours at exit 0 | `gif` must declare a `fallback_name`, or the quantisation is reported nowhere |
+| **Forcing `jpg`'s encoder re-encodes an already-JPEG source**: 44 893 B -> 51 865 B (+15.5%), PSNR 53.5 dB, where `-c copy` is byte-identical | The price of not shipping a mislabelled file. `png`, `tiff` and `bmp` re-encode losslessly and pay nothing |
 | **A multi-frame source into an image2 target fails hard** at both the cheap attempt and the selective rung: "Cannot write more than one file with the same name" | Only a rung carrying `-frames:v 1` converts a video into a `png`/`jpg`/`tiff`/`bmp` |
 | **`gif` and `webp` write every frame**: a 20-frame video becomes a 20-frame GIF and a 20-frame animated WebP, both at exit 0 on the selective rung | `webp` is an *animated* target, not a still one. Neither carries a frame limit |
 | **`avif` silently reduces a 20-frame source to one frame at exit 0** — the muxer, not the flag: dropping `-still-picture 1` still yields one frame. With an AV1-in-MP4 source the copy mask hits and this happens on the **cheap attempt** | The one silent multi-frame loss in the phase, and it needs a standing note; no rung can turn it into a failure |
@@ -119,15 +121,16 @@ codes taken from ffmpeg itself.
 | Decision | Rationale | Date |
 |---|---|---|
 | **`png`, `jpg`, `tiff`, `bmp` force their encoder in the cheap attempt**: `flags("-map 0:v? -c:v png")`, `flags("-map 0:v? -c:v mjpeg -q:v 2")`, `flags("-map 0:v? -c:v tiff")`, `flags("-map 0:v? -c:v bmp")`. `explicit_streams=False` | Measured: image2 accepts any codec on copy, so `--to png` over JPEGs would ship JPEGs named `.png`. This is phase 3's carve-out — "where the muxer is looser than the format's identity, the profile does not rely on a copy at all" — and it is the same shape as `opus`. The copy still happens on the selective rung, on a mask hit | 2026-08-26 |
-| **`gif`, `webp`, `avif` keep `flags("-map 0:v? -c copy")`**, `explicit_streams=False` | Their muxers reject a non-matching codec, so a copy cannot mislabel. The cost is one wasted ffmpeg spawn plus one ffprobe for every non-matching source — which is nearly every source, since a copy only hits when the input is already that format. Accepted deliberately: it buys a real stream copy for the same-format case, which is the one conversion where it matters | 2026-08-26 |
+| **`webp` keeps `flags("-map 0:v? -c copy")`**, `explicit_streams=False`. Whether `gif` and `avif` do is the phase's second open decision | `webp`'s muxer rejects a non-matching codec, so a copy cannot mislabel, and `webp` loses neither alpha nor frames -- it has no standing note whose reachability depends on which rung wins. `gif` and `avif` do, which is what makes their case different | 2026-08-26 |
 | Copy masks: `png` -> `{png}`; `jpg` -> `{mjpeg}`; `webp` -> `{webp}`; `avif` -> `{av1}`; `gif` -> `{gif}`; `tiff` -> `{tiff}`; `bmp` -> `{bmp}` | Measured against ffprobe's reported codec names | 2026-08-26 |
-| Fallback encoders, as full `StreamRule` templates: `png` -> `flags("-c:v:{n} png")`; `jpg` -> `flags("-c:v:{n} mjpeg -q:v:{n} 2")`; `webp` -> `flags("-c:v:{n} libwebp -quality:v:{n} 80")`; `avif` -> `flags("-c:v:{n} libaom-av1 -crf:v:{n} 30 -still-picture 1")`; `gif` -> `flags("-c:v:{n} gif")`; `tiff` -> `flags("-c:v:{n} tiff")`; `bmp` -> `flags("-c:v:{n} bmp")` | One quality default per lossy format, pinned by the argv tests. Written in full rather than as shorthand, because the `-c:v:{n}` is not optional | 2026-08-26 |
-| `png`, `tiff`, `bmp` and `gif` declare `fallback_name=None` — no note for the encode; `jpg`, `webp` and `avif` declare theirs | The phase-3 rule: encoding into a target's own lossless codec gives up nothing worth naming | 2026-08-26 |
-| **`stream_limit=1` on every image profile's video rule** | One image, one picture. A source with two video streams — cover art beside a video, an MJPEG-plus-video AVI — would otherwise map both into one output file and fail. `mp3` and `flac` got the same treatment in phase 3 for the same reason | 2026-08-26 |
+| Fallback encoders, as full `StreamRule` templates: `png` -> `flags("-c:v png")`; `jpg` -> `flags("-c:v mjpeg -q:v 2")`; `webp` -> `flags("-c:v libwebp -quality:v 80")`; `avif` -> `flags("-c:v libaom-av1 -crf:v 30 -still-picture 1")`; `gif` -> `flags("-c:v gif")`; `tiff` -> `flags("-c:v tiff")`; `bmp` -> `flags("-c:v bmp")` -- all placeholder-free, per the stream-limit row below | One quality default per lossy format, pinned by the argv tests. Written in full rather than as shorthand, because the `-c:v:{n}` is not optional | 2026-08-26 |
+| Only `png`, `tiff` and `bmp` declare `fallback_name=None`. `gif`, `jpg`, `webp` and `avif` declare theirs | The phase-3 rule -- encoding into a target's own lossless codec gives up nothing worth naming -- covers `png`, `tiff` and `bmp` only. **GIF is not lossless**: it is a 256-colour palette format, and measured, a 1280x720 photograph goes from 36 485 distinct colours to 182 (PSNR 39.4 dB against 47.0 for png and bmp). With `fallback_name=None` that loss would be reported nowhere at all | 2026-08-26 |
+| **`stream_limit=1` on every image profile's video rule**, and -- following the convention `spec-profile-registry.md` recorded -- their templates are written **without** `{n}`: `flags("-c:v png")`, `flags("-c:v mjpeg -q:v 2")` and so on | A rule limited to one stream can only ever produce output stream 0, so it writes the bare specifier and the engine substitutes nothing. That is phase 1's rule, and the argv tests pin whichever form is chosen, so it is worth choosing deliberately. One image, one picture. A source with two video streams — cover art beside a video, an MJPEG-plus-video AVI — would otherwise map both into one output file and fail. `mp3` and `flac` got the same treatment in phase 3 for the same reason | 2026-08-26 |
 | No image profile declares an audio, subtitle or attachment rule; `container_options` is `()` for all seven | An image holds one thing, and none of these muxers takes a container flag | 2026-08-26 |
-| **Standing notes**: `jpg`, `gif` and `avif` say transparency is not carried; `avif` additionally says a multi-frame source is reduced to a single frame | Measured. `avif`'s frame note is the only way that loss is ever reported — no rung can turn it into a failure, and it can strike on the cheap attempt with an AV1-in-MP4 source | 2026-08-26 |
-| `last_resort`: `gif` -> `flags("-map 0:v:0 -c:v gif")`; `webp` -> `flags("-map 0:v:0 -c:v libwebp -quality:v 80")`; `avif` -> `flags("-map 0:v:0 -c:v libaom-av1 -crf 30 -still-picture 1")`. The four image2 targets' `last_resort` is what the gate decides | Phase 4's rule: every profile needs one or a ladder that reaches the end lands as `failed`. Written without `{n}`, which is not substituted outside `StreamRule` templates | 2026-08-26 |
-| OPEN — how `png`, `jpg`, `tiff` and `bmp` handle a multi-frame source | resolved at the spec-acceptance gate; see the note below | — |
+| **Standing notes**: `jpg` says transparency is not carried **and** that the image was re-encoded. `gif` and `avif` need the same treatment for transparency, and `avif` for frame reduction -- but whether those notes are reachable depends on the second open decision | `jpg`'s cheap attempt always wins, so its note always prints. `gif`'s and `avif`'s cheap attempt is a copy that wins only for a source already in that format, so as drafted their notes print for exactly the inputs that lose nothing. That is the defect the second open decision exists to close | 2026-08-26 |
+| `last_resort`: `gif` -> `flags("-map 0:v:0 -c:v gif")`; `webp` -> `flags("-map 0:v:0 -c:v libwebp -quality:v 80")`; `avif` -> `flags("-map 0:v:0 -c:v libaom-av1 -crf 30 -still-picture 1")`. The four image2 targets' `last_resort` is what the gate decides | Phase 4's rule: every profile needs one or a ladder that reaches the end lands as `failed`. Written without `{n}`, which is not substituted outside `StreamRule` templates. Each carries the notes its rung earns: `gif` that the image was re-quantised to 256 colours, `avif` that a multi-frame source is reduced to one frame -- a last rung that converts in silence is what `mp4`'s two notes exist to prevent | 2026-08-26 |
+| OPEN — how `png`, `jpg`, `tiff` and `bmp` handle a multi-frame source | resolved at the spec-acceptance gate; see the first note below | — |
+| OPEN — do `gif` and `avif` copy, or always encode? | resolved at the spec-acceptance gate; see the second note below | — |
 
 ### The one open decision, in full
 
@@ -162,6 +165,38 @@ carries no stream of any type the profile has a rule for, and a video does match
 an image profile's video rule. Making it apply would be a `jobs.py` change, which
 this phase does not take.
 
+### The second open decision: do `gif` and `avif` copy, or always encode?
+
+A standing note lives on `cheap_attempt.notes`, and `batch._attempt_conversion`
+reports **only the winning attempt's** notes. `gif`'s and `avif`'s drafted cheap
+attempt is `-c copy`, which succeeds only when the source is already GIF or AV1 --
+the one input that loses nothing. For every other source the copy exits 127, the
+selective rung wins, and its per-stream notes are what print. Measured through the
+real engine:
+
+- `--to gif` over an alpha PNG loses the transparency at exit 0 **in complete
+  silence**.
+- `--to avif` over an h264 video loses 19 of 20 frames and says only that the
+  video was re-encoded.
+
+So the drafted notes are attached to a path they do not print on. The only lever
+this phase has is the cheap attempt:
+
+1. **Force the encoder for `gif` and `avif` too**, as `png`/`jpg`/`tiff`/`bmp`
+   now do. The cheap attempt then always wins, so both standing notes always
+   print, and the wasted spawn plus probe on every non-matching source disappears.
+   The price is that a same-format source is re-encoded rather than copied: a GIF
+   is re-quantised, and an AVIF pays a lossy re-encode plus about 7 seconds.
+2. **Keep the copy.** A same-format source is copied perfectly and cheaply. The
+   price is that a non-GIF source into `gif` loses transparency, and a video into
+   `avif` loses frames, with nothing naming either -- which `docs/constitution.md`
+   forbids in as many words, so picking this means amending it as phase 3's
+   option 2 would have.
+
+This is the same shape as phase 3's `opus` decision, with one difference worth
+weighing: there the cost of copying was a mislabelled file, here it is an unnamed
+*loss*, which the constitution addresses directly.
+
 ## Tracking
 
 - Milestone: image-formats (created at the spec-acceptance gate)
@@ -186,10 +221,12 @@ Machine checks:
 - [ ] A test that no image profile declares an audio, subtitle or attachment
       rule, so those streams are dropped with a note, and that every one declares
       `stream_limit=1`.
-- [ ] A test per standing note, pinning its exact wording: transparency for
-      `jpg`, `gif`, `avif`, and the single-frame note for `avif`.
-- [ ] A test that converting into `png`, `tiff`, `bmp` or `gif` emits no note for
-      the encode itself.
+- [ ] A test per standing note, pinning its exact wording **and** that the note
+      is on a rung that actually wins for the input it describes -- the defect the
+      second open decision exists to close.
+- [ ] A test that converting into `png`, `tiff` or `bmp` emits no note for the
+      encode itself -- and that converting into `gif` **does**, since GIF is a
+      256-colour format rather than a lossless one.
 - [ ] `--list-formats` prints one line per registry entry, including the seven
       image names. The 17-line total is a QA-gate item for whichever of the three
       coverage milestones closes last, not a machine check here — phases 3, 4 and
@@ -220,6 +257,7 @@ New-Item -ItemType Directory -Force in
 - [ ] `--to avif in out` over `clip.mp4` produces a single frame and **says so**.
 - [ ] `--to png in out` over `clip.mp4` behaves as the gate decided; a second run
       reports the same thing with exit 0 unless the gate chose option 3.
+- [ ] `--to gif in out` over a photograph names the colour quantisation.
 - [ ] Time `--to avif` over a large still and compare with `--to webp`. The
       measured gap is 17x; confirm it is tolerable on real photographs.
 - [ ] A second run over any converted tree reports `0 converted`, exit 0.
@@ -247,3 +285,11 @@ New-Item -ItemType Directory -Force in
 - 2026-08-26: `avif`'s silent frame reduction has no failure path to hang a
   per-stream note on, so it is the one loss in this phase that only a standing
   note can report — including on the cheap attempt, for an AV1-in-MP4 source.
+- 2026-08-26: Review round 2 found that `gif` and `avif`'s standing notes were
+  attached to a path they never print on — their cheap attempt is a copy that only
+  wins for a source already in that format, i.e. the one input that loses nothing.
+  Promoted to the phase's second open decision rather than settled, because the
+  fix costs a re-encode on the same-format case.
+- 2026-08-26: Review round 2 measured that GIF keeps 182 of 36 485 colours from a
+  photograph. It had been grouped with the lossless targets and would have
+  reported that loss nowhere at all.

--- a/docs/specs/spec-image-formats.md
+++ b/docs/specs/spec-image-formats.md
@@ -113,7 +113,7 @@ codes taken from ffmpeg itself.
 | **`avif` silently reduces a 20-frame source to one frame at exit 0** — the muxer, not the flag: dropping `-still-picture 1` still yields one frame. With an AV1-in-MP4 source the copy mask hits and this happens on the **cheap attempt** | The one silent multi-frame loss in the phase, and it needs a standing note; no rung can turn it into a failure |
 | **Alpha, measured by round-tripping `rgba` (α=127) through each fallback encoder:** kept by `png`, `tiff`, `bmp`, `webp`; **lost by `jpg`, `gif` and `avif`** — `gif` loses even a fully transparent source, `avif` because `libaom-av1` has no alpha pix_fmt | `jpg`, `gif` and `avif` need a transparency standing note. `bmp` does not — the question the earlier draft left open is closed |
 | ffprobe reports a still's `codec_name` as `png`, `mjpeg`, `webp`, `tiff`, `bmp`, `gif`, `av1` | The copy masks below are right |
-| Option syntax parses and takes effect in the `{n}` form: `-quality:v:0` for libwebp (not `-compression_level`), `-q:v:0` for mjpeg, `-crf:v:0` for libaom-av1 | The fallback templates below are valid |
+| Option syntax parses in the placeholder-free form the profiles use: `-c:v mjpeg -q:v 2`, `-c:v libwebp -quality:v 80` (not `-compression_level`), `-c:v libaom-av1 -crf:v 30 -still-picture 1`, and bare `-c:v png` / `gif` / `tiff` / `bmp` | The fallback templates below are valid |
 | **`libaom-av1` is 17-34x slower than the alternatives**: a 3000x2000 still takes 6.9 s at `-crf 30 -still-picture 1`, against 0.41 s for `libwebp -quality 80` and 0.20 s for `mjpeg -q:v 2` | `--to avif` over a folder of camera JPEGs is a different tool from `--to webp` over the same folder. Priced here rather than discovered |
 
 ### Decisions
@@ -123,12 +123,13 @@ codes taken from ffmpeg itself.
 | **`png`, `jpg`, `tiff`, `bmp` force their encoder in the cheap attempt**: `flags("-map 0:v? -c:v png")`, `flags("-map 0:v? -c:v mjpeg -q:v 2")`, `flags("-map 0:v? -c:v tiff")`, `flags("-map 0:v? -c:v bmp")`. `explicit_streams=False` | Measured: image2 accepts any codec on copy, so `--to png` over JPEGs would ship JPEGs named `.png`. This is phase 3's carve-out — "where the muxer is looser than the format's identity, the profile does not rely on a copy at all" — and it is the same shape as `opus`. The copy still happens on the selective rung, on a mask hit | 2026-08-26 |
 | **`webp` keeps `flags("-map 0:v? -c copy")`**, `explicit_streams=False`. Whether `gif` and `avif` do is the phase's second open decision | `webp`'s muxer rejects a non-matching codec, so a copy cannot mislabel, and `webp` loses neither alpha nor frames -- it has no standing note whose reachability depends on which rung wins. `gif` and `avif` do, which is what makes their case different | 2026-08-26 |
 | Copy masks: `png` -> `{png}`; `jpg` -> `{mjpeg}`; `webp` -> `{webp}`; `avif` -> `{av1}`; `gif` -> `{gif}`; `tiff` -> `{tiff}`; `bmp` -> `{bmp}` | Measured against ffprobe's reported codec names | 2026-08-26 |
-| Fallback encoders, as full `StreamRule` templates: `png` -> `flags("-c:v png")`; `jpg` -> `flags("-c:v mjpeg -q:v 2")`; `webp` -> `flags("-c:v libwebp -quality:v 80")`; `avif` -> `flags("-c:v libaom-av1 -crf:v 30 -still-picture 1")`; `gif` -> `flags("-c:v gif")`; `tiff` -> `flags("-c:v tiff")`; `bmp` -> `flags("-c:v bmp")` -- all placeholder-free, per the stream-limit row below | One quality default per lossy format, pinned by the argv tests. Written in full rather than as shorthand, because the `-c:v:{n}` is not optional | 2026-08-26 |
+| Fallback encoders, as full `StreamRule` templates: `png` -> `flags("-c:v png")`; `jpg` -> `flags("-c:v mjpeg -q:v 2")`; `webp` -> `flags("-c:v libwebp -quality:v 80")`; `avif` -> `flags("-c:v libaom-av1 -crf:v 30 -still-picture 1")`; `gif` -> `flags("-c:v gif")`; `tiff` -> `flags("-c:v tiff")`; `bmp` -> `flags("-c:v bmp")` -- all placeholder-free, per the stream-limit row below | One quality default per lossy format, pinned by the argv tests. Written in full rather than as shorthand, because the `-c:v` is not optional | 2026-08-26 |
 | Only `png`, `tiff` and `bmp` declare `fallback_name=None`. `gif`, `jpg`, `webp` and `avif` declare theirs | The phase-3 rule -- encoding into a target's own lossless codec gives up nothing worth naming -- covers `png`, `tiff` and `bmp` only. **GIF is not lossless**: it is a 256-colour palette format, and measured, a 1280x720 photograph goes from 36 485 distinct colours to 182 (PSNR 39.4 dB against 47.0 for png and bmp). With `fallback_name=None` that loss would be reported nowhere at all | 2026-08-26 |
+| **`accept_options=flags("-c:v copy")` on every image profile's video rule**, placeholder-free like the rest | Follow `opus`'s precedent, **not** WAV's `accept_options=()`. WAV's empty form is safe only because its mask is empty, so the accept branch is unreachable; here every mask hits, and measured, `()` emits a map with no codec option -- `-map 0:0` alone on a JPEG re-encodes it at exit 0 (44 867 B against 44 893 B, PSNR 66 dB) where `-c:v copy` is byte-identical. A silent lossy re-encode on the one path the copy mask exists to protect | 2026-08-26 |
 | **`stream_limit=1` on every image profile's video rule**, and -- following the convention `spec-profile-registry.md` recorded -- their templates are written **without** `{n}`: `flags("-c:v png")`, `flags("-c:v mjpeg -q:v 2")` and so on | A rule limited to one stream can only ever produce output stream 0, so it writes the bare specifier and the engine substitutes nothing. That is phase 1's rule, and the argv tests pin whichever form is chosen, so it is worth choosing deliberately. One image, one picture. A source with two video streams — cover art beside a video, an MJPEG-plus-video AVI — would otherwise map both into one output file and fail. `mp3` and `flac` got the same treatment in phase 3 for the same reason | 2026-08-26 |
 | No image profile declares an audio, subtitle or attachment rule; `container_options` is `()` for all seven | An image holds one thing, and none of these muxers takes a container flag | 2026-08-26 |
 | **Standing notes**: `jpg` says transparency is not carried **and** that the image was re-encoded. `gif` and `avif` need the same treatment for transparency, and `avif` for frame reduction -- but whether those notes are reachable depends on the second open decision | `jpg`'s cheap attempt always wins, so its note always prints. `gif`'s and `avif`'s cheap attempt is a copy that wins only for a source already in that format, so as drafted their notes print for exactly the inputs that lose nothing. That is the defect the second open decision exists to close | 2026-08-26 |
-| `last_resort`: `gif` -> `flags("-map 0:v:0 -c:v gif")`; `webp` -> `flags("-map 0:v:0 -c:v libwebp -quality:v 80")`; `avif` -> `flags("-map 0:v:0 -c:v libaom-av1 -crf 30 -still-picture 1")`. The four image2 targets' `last_resort` is what the gate decides | Phase 4's rule: every profile needs one or a ladder that reaches the end lands as `failed`. Written without `{n}`, which is not substituted outside `StreamRule` templates. Each carries the notes its rung earns: `gif` that the image was re-quantised to 256 colours, `avif` that a multi-frame source is reduced to one frame -- a last rung that converts in silence is what `mp4`'s two notes exist to prevent | 2026-08-26 |
+| `last_resort`: `gif` -> `flags("-map 0:v:0 -c:v gif")`; `webp` -> `flags("-map 0:v:0 -c:v libwebp -quality:v 80")`, noting the image was re-encoded; `avif` -> `flags("-map 0:v:0 -c:v libaom-av1 -crf 30 -still-picture 1")`. The four image2 targets' `last_resort` is what the gate decides | Phase 4's rule: every profile needs one or a ladder that reaches the end lands as `failed`. Written without `{n}`, which is not substituted outside `StreamRule` templates. Each carries the notes its rung earns: `gif` that the image was re-quantised to 256 colours, `avif` that a multi-frame source is reduced to one frame -- a last rung that converts in silence is what `mp4`'s two notes exist to prevent | 2026-08-26 |
 | OPEN — how `png`, `jpg`, `tiff` and `bmp` handle a multi-frame source | resolved at the spec-acceptance gate; see the first note below | — |
 | OPEN — do `gif` and `avif` copy, or always encode? | resolved at the spec-acceptance gate; see the second note below | — |
 
@@ -197,6 +198,21 @@ This is the same shape as phase 3's `opus` decision, with one difference worth
 weighing: there the cost of copying was a mislabelled file, here it is an unnamed
 *loss*, which the constitution addresses directly.
 
+**Where each note lives, per option.** This is not cosmetic: `fallback_name` and a
+standing note are reachable on opposite paths.
+
+- **Option 1 (force the encoder).** The cheap attempt always wins, so the standing
+  notes are the reporting path and must carry everything: transparency for both,
+  the 256-colour quantisation for `gif`, the frame reduction for `avif`.
+  `fallback_name` stays declared but fires only on the rarely-reached selective
+  rung.
+- **Option 2 (keep the copy).** The selective rung usually wins, so `fallback_name`
+  carries the re-encode note -- and the transparency and frame notes are
+  unreachable, which is the constitution amendment named above.
+
+The Verification and QA items that check these notes are conditioned on this
+choice; do not read them as settled before the gate.
+
 ## Tracking
 
 - Milestone: image-formats (created at the spec-acceptance gate)
@@ -210,10 +226,10 @@ Machine checks:
 - [ ] For every PR in this milestone, `git diff main...<pr-head> --name-only`
       lists only `converter/profiles.py`, `README.md` and paths under `tests/`.
 - [ ] Per new profile, a test pinning the full argv for a copyable input and for
-      a non-copyable one. `png`, `jpg`, `tiff` and `bmp` carry the same exception
-      `spec-profile-registry.md` recorded for WAV and phase 3 for `opus`: their
-      cheap attempt never copies, so the copyable case exists only on the
-      selective rung.
+      a non-copyable one. `png`, `jpg`, `tiff` and `bmp` carry the same exception phase 3
+      recorded for `opus`: their cheap attempt never copies, so the copyable case
+      exists only on the selective rung. Not WAV's exception, which is about an
+      empty mask and points at `accept_options=()` -- the wrong form here.
 - [ ] A test that `gif` and `webp` carry no frame limit anywhere, and that the
       image2 four reach one through the rung the gate chose.
 - [ ] A test that `png`, `jpg`, `tiff` and `bmp` force `-c:v` in their cheap
@@ -225,8 +241,10 @@ Machine checks:
       is on a rung that actually wins for the input it describes -- the defect the
       second open decision exists to close.
 - [ ] A test that converting into `png`, `tiff` or `bmp` emits no note for the
-      encode itself -- and that converting into `gif` **does**, since GIF is a
-      256-colour format rather than a lossless one.
+      encode itself. GIF is not in that list -- it is a 256-colour format, not a
+      lossless one -- but **which rung reports its quantisation depends on the
+      second open decision**, so this test is written against whichever the gate
+      chose.
 - [ ] `--list-formats` prints one line per registry entry, including the seven
       image names. The 17-line total is a QA-gate item for whichever of the three
       coverage milestones closes last, not a machine check here — phases 3, 4 and
@@ -249,15 +267,18 @@ New-Item -ItemType Directory -Force in
       exit 0, which is the defect this phase's cheap attempts exist to prevent.
 - [ ] `--to jpg in out` over `flat.png` produces a real JPEG, same check.
 - [ ] `--to jpg in out` over `alpha.png` prints the transparency note, and the
-      output's `pix_fmt` shows the alpha is gone. Repeat for `--to gif` and
-      `--to avif`; `--to bmp`, `--to png`, `--to tiff` and `--to webp` keep it and
-      print no such note.
+      output's `pix_fmt` shows the alpha is gone. `--to bmp`, `--to png`,
+      `--to tiff` and `--to webp` keep it and print no such note. Repeat for
+      `--to gif` and `--to avif` **only if the gate chose option 1** -- under
+      option 2 those two losses are unnamed by construction.
 - [ ] `--to gif in out` over `clip.mp4` produces an **animated** GIF, and
       `--to webp` an animated WebP: count frames with `ffprobe -count_frames`.
-- [ ] `--to avif in out` over `clip.mp4` produces a single frame and **says so**.
+- [ ] `--to avif in out` over `clip.mp4` produces a single frame, and says so if
+      the gate chose option 1.
 - [ ] `--to png in out` over `clip.mp4` behaves as the gate decided; a second run
       reports the same thing with exit 0 unless the gate chose option 3.
-- [ ] `--to gif in out` over a photograph names the colour quantisation.
+- [ ] `--to gif in out` over a photograph names the colour quantisation, on
+      whichever rung the gate's second decision puts it.
 - [ ] Time `--to avif` over a large still and compare with `--to webp`. The
       measured gap is 17x; confirm it is tolerable on real photographs.
 - [ ] A second run over any converted tree reports `0 converted`, exit 0.
@@ -267,10 +288,10 @@ New-Item -ItemType Directory -Force in
 | Risk | Mitigation |
 |---|---|
 | A stream copy ships a mislabelled file | The four image2 targets force their encoder, with a Verification item and a QA check on both directions of the commonest conversion |
-| `avif` silently drops frames | Its standing note is the only reporting path, and the QA gate checks it explicitly |
+| `avif` silently drops frames, and `gif` silently drops transparency and colours | Reportable only under the second open decision's option 1; option 2 leaves them unnamed and costs a constitution amendment. The gate is shown both prices |
 | `--to avif` over a photo library is unusably slow | Measured and priced in the muxer table; the QA gate confirms it on real photographs |
-| An alpha loss goes unnamed | Measured per target; three need the note and four do not |
-| The wasted spawn on `gif`/`webp`/`avif` is mistaken for a bug | Named in its decision row as a deliberate price for a real copy path |
+| An alpha loss goes unnamed | Measured per target: `jpg`, `gif` and `avif` lose it, `png`, `tiff`, `bmp` and `webp` keep it. `jpg`'s note always prints; `gif`'s and `avif`'s depend on the second open decision |
+| The wasted spawn is mistaken for a bug | For `webp` it is named in its decision row as a deliberate price for a real copy path. For `gif` and `avif` it disappears entirely under the second open decision's option 1 |
 | Someone reads the missing EXIF as a bug | Named as a vision non-goal with the prior-art entry that evidences it |
 
 ## Decision log
@@ -293,3 +314,11 @@ New-Item -ItemType Directory -Force in
 - 2026-08-26: Review round 2 measured that GIF keeps 182 of 36 485 colours from a
   photograph. It had been grouped with the lossless targets and would have
   reported that loss nowhere at all.
+- 2026-08-26: Review round 3 found `accept_options` undecided and the Verification
+  bullet citing WAV's precedent, which is the wrong one — WAV's `()` is safe only
+  because its mask is empty, and here it would emit a map with no codec option,
+  turning every mask hit into a silent lossy re-encode.
+- 2026-08-26: Review round 3 also found that `fallback_name`'s reachability is the
+  mirror of the standing notes' — reachable under option 2, unreachable under
+  option 1 — so the second open decision now states where each note lives per
+  option, and the checks that depend on it say they are conditional.

--- a/docs/specs/spec-image-formats.md
+++ b/docs/specs/spec-image-formats.md
@@ -121,25 +121,27 @@ codes taken from ffmpeg itself.
 | Decision | Rationale | Date |
 |---|---|---|
 | **`png`, `jpg`, `tiff`, `bmp` force their encoder in the cheap attempt**: `flags("-map 0:v? -c:v png")`, `flags("-map 0:v? -c:v mjpeg -q:v 2")`, `flags("-map 0:v? -c:v tiff")`, `flags("-map 0:v? -c:v bmp")`. `explicit_streams=False` | Measured: image2 accepts any codec on copy, so `--to png` over JPEGs would ship JPEGs named `.png`. This is phase 3's carve-out — "where the muxer is looser than the format's identity, the profile does not rely on a copy at all" — and it is the same shape as `opus`. The copy still happens on the selective rung, on a mask hit | 2026-08-26 |
-| **`webp` keeps `flags("-map 0:v? -c copy")`**, `explicit_streams=False`. Whether `gif` and `avif` do is the phase's second open decision | `webp`'s muxer rejects a non-matching codec, so a copy cannot mislabel, and `webp` loses neither alpha nor frames -- it has no standing note whose reachability depends on which rung wins. `gif` and `avif` do, which is what makes their case different | 2026-08-26 |
+| **`webp` alone keeps `flags("-map 0:v? -c copy")`**, `explicit_streams=False`. `gif` and `avif` force their encoder, per the decision above | `webp`'s muxer rejects a non-matching codec, so a copy cannot mislabel, and `webp` loses neither alpha nor frames -- it has no standing note whose reachability depends on which rung wins. `gif` and `avif` do, which is what makes their case different | 2026-08-26 |
 | Copy masks: `png` -> `{png}`; `jpg` -> `{mjpeg}`; `webp` -> `{webp}`; `avif` -> `{av1}`; `gif` -> `{gif}`; `tiff` -> `{tiff}`; `bmp` -> `{bmp}` | Measured against ffprobe's reported codec names | 2026-08-26 |
 | Fallback encoders, as full `StreamRule` templates: `png` -> `flags("-c:v png")`; `jpg` -> `flags("-c:v mjpeg -q:v 2")`; `webp` -> `flags("-c:v libwebp -quality:v 80")`; `avif` -> `flags("-c:v libaom-av1 -crf:v 30 -still-picture 1")`; `gif` -> `flags("-c:v gif")`; `tiff` -> `flags("-c:v tiff")`; `bmp` -> `flags("-c:v bmp")` -- all placeholder-free, per the stream-limit row below | One quality default per lossy format, pinned by the argv tests. Written in full rather than as shorthand, because the `-c:v` is not optional | 2026-08-26 |
 | Only `png`, `tiff` and `bmp` declare `fallback_name=None`. `gif`, `jpg`, `webp` and `avif` declare theirs | The phase-3 rule -- encoding into a target's own lossless codec gives up nothing worth naming -- covers `png`, `tiff` and `bmp` only. **GIF is not lossless**: it is a 256-colour palette format, and measured, a 1280x720 photograph goes from 36 485 distinct colours to 182 (PSNR 39.4 dB against 47.0 for png and bmp). With `fallback_name=None` that loss would be reported nowhere at all | 2026-08-26 |
 | **`accept_options=flags("-c:v copy")` on every image profile's video rule**, placeholder-free like the rest | Follow `opus`'s precedent, **not** WAV's `accept_options=()`. WAV's empty form is safe only because its mask is empty, so its accept branch is unreachable at all; every mask here is non-empty, so the branch is live. Measured, `()` emits a map with no codec option -- `-map 0:0` alone on a JPEG re-encodes it at exit 0 (44 867 B against 44 893 B, PSNR 66 dB) where `-c:v copy` is byte-identical. A silent lossy re-encode on the one path the copy mask exists to protect | 2026-08-26 |
 | **`stream_limit=1` on every image profile's video rule**, and -- following the convention `spec-profile-registry.md` recorded -- their templates are written **without** `{n}`: `flags("-c:v png")`, `flags("-c:v mjpeg -q:v 2")` and so on | A rule limited to one stream can only ever produce output stream 0, so it writes the bare specifier and the engine substitutes nothing. That is phase 1's rule, and the argv tests pin whichever form is chosen, so it is worth choosing deliberately. One image, one picture. A source with two video streams — cover art beside a video, an MJPEG-plus-video AVI — would otherwise map both into one output file and fail. `mp3` and `flac` got the same treatment in phase 3 for the same reason | 2026-08-26 |
 | No image profile declares an audio, subtitle or attachment rule; `container_options` is `()` for all seven | An image holds one thing, and none of these muxers takes a container flag | 2026-08-26 |
-| **Standing notes**: `jpg` says transparency is not carried **and** that the image was re-encoded. `gif` and `avif` need the same treatment for transparency, and `avif` for frame reduction -- but whether those notes are reachable depends on the second open decision | `jpg`'s cheap attempt always wins, so its note always prints. `gif`'s and `avif`'s cheap attempt is a copy that wins only for a source already in that format, so as drafted their notes print for exactly the inputs that lose nothing. That is the defect the second open decision exists to close | 2026-08-26 |
+| **Standing notes**, all on a cheap attempt that always wins: `jpg` -- transparency is not carried, and the image was re-encoded; `gif` -- transparency is not carried, and a photograph is reduced to 256 colours; `avif` -- transparency is not carried, and a multi-frame source is reduced to a single frame | All three cheap attempts force their encoder, so all three always win and all three notes always print. The drafted version had `gif` and `avif` copying, which meant their notes printed for exactly the inputs that lose nothing -- the defect the gate's second decision closed | 2026-08-26 |
 | `last_resort`: `gif` -> `flags("-map 0:v:0 -c:v gif")`; `webp` -> `flags("-map 0:v:0 -c:v libwebp -quality:v 80")`, noting the image was re-encoded; `avif` -> `flags("-map 0:v:0 -c:v libaom-av1 -crf 30 -still-picture 1")`. The four image2 targets' `last_resort` is what the gate decides | Phase 4's rule: every profile needs one or a ladder that reaches the end lands as `failed`. Written without `{n}`, which is not substituted outside `StreamRule` templates. Each carries the notes its rung earns: `gif` that the image was re-quantised to 256 colours, `avif` that a multi-frame source is reduced to one frame -- a last rung that converts in silence is what `mp4`'s two notes exist to prevent | 2026-08-26 |
-| OPEN — how `png`, `jpg`, `tiff` and `bmp` handle a multi-frame source | resolved at the spec-acceptance gate; see the first note below | — |
-| OPEN — do `gif` and `avif` copy, or always encode? | resolved at the spec-acceptance gate; see the second note below | — |
+| A multi-frame source into `png`, `jpg`, `tiff` or `bmp` is handled by the **`last_resort`**: `flags("-map 0:v:0 -frames:v 1 -c:v png")` and its siblings, with a note that a single frame was taken | Resolved at the gate on 2026-08-26. Keeps the overwhelmingly common case -- an actual image -- converting on the first attempt with no note at all; a video pays three ffmpeg spawns plus a probe for a thumbnail. Failing instead was rejected: the file would produce no output, so every re-run fails again and a mixed tree never reaches `0 converted, 0 failed` | 2026-08-26 |
+| **`gif` and `avif` force their encoder** too: `flags("-map 0:v? -c:v gif")` and `flags("-map 0:v? -c:v libaom-av1 -crf:v 30 -still-picture 1")`. Only `webp` keeps `-c copy` | Resolved at the gate on 2026-08-26. The cheap attempt then always wins, so both standing notes always print and the wasted spawn disappears. Measured, `gif` pays nothing for it -- a GIF source re-encodes pixel-identically. `avif` pays a real generation loss plus 7 s per already-AVIF file, accepted so its transparency and frame losses are named rather than requiring a constitution amendment to leave them silent | 2026-08-26 |
 
-### The one open decision, in full
+### The multi-frame decision, in full (resolved at the gate)
 
 **Scope: four targets, not seven.** `gif` and `webp` convert a video into an
 animation, which needs no decision. `avif` reduces it to one frame no matter what
 this decision says — whether that reduction is *reported* is the second open
 decision's business, not this one's. Only the image2 four — `png`, `jpg`, `tiff`,
 `bmp` — reach a rung where this is a choice.
+
+**Resolved at the gate on 2026-08-26: option 1, the `last_resort`.**
 
 Measured: with the encoder forced, an image source converts on the cheap attempt.
 A video source fails the cheap attempt *and* the selective rung, because neither
@@ -167,7 +169,13 @@ carries no stream of any type the profile has a rule for, and a video does match
 an image profile's video rule. Making it apply would be a `jobs.py` change, which
 this phase does not take.
 
-### The second open decision: do `gif` and `avif` copy, or always encode?
+### The gif/avif decision, in full (resolved at the gate)
+
+**Resolved at the gate on 2026-08-26: option 1, both force their encoder.** The
+notes therefore always print, and the "where each note lives" block below applies
+in its option-1 form: the standing notes carry transparency for both, the
+256-colour quantisation for `gif` and the frame reduction for `avif`, while
+`fallback_name` stays declared for the rarely-reached selective rung.
 
 A standing note lives on `cheap_attempt.notes`, and `batch._attempt_conversion`
 reports **only the winning attempt's** notes. `gif`'s and `avif`'s drafted cheap
@@ -249,13 +257,11 @@ Machine checks:
       rule, so those streams are dropped with a note, and that every one declares
       `stream_limit=1`.
 - [ ] A test per standing note, pinning its exact wording **and** that the note
-      is on a rung that actually wins for the input it describes -- the defect the
-      second open decision exists to close.
+      is on the cheap attempt, which always wins -- the defect the gate's second
+      decision closed.
 - [ ] A test that converting into `png`, `tiff` or `bmp` emits no note for the
       encode itself. GIF is not in that list -- it is a 256-colour format, not a
-      lossless one -- but **which rung reports its quantisation depends on the
-      second open decision**, so this test is written against whichever the gate
-      chose.
+      lossless one -- and its quantisation is reported by its standing note.
 - [ ] `--list-formats` prints one line per registry entry, including the seven
       image names. The 17-line total is a QA-gate item for whichever of the three
       coverage milestones closes last, not a machine check here — phases 3, 4 and
@@ -280,16 +286,13 @@ New-Item -ItemType Directory -Force in
 - [ ] `--to jpg in out` over `alpha.png` prints the transparency note, and the
       output's `pix_fmt` shows the alpha is gone. `--to bmp`, `--to png`,
       `--to tiff` and `--to webp` keep it and print no such note. Repeat for
-      `--to gif` and `--to avif` **only if the gate chose option 1** -- under
-      option 2 those two losses are unnamed by construction.
+      `--to gif` and `--to avif`, whose standing notes now always print.
 - [ ] `--to gif in out` over `clip.mp4` produces an **animated** GIF, and
       `--to webp` an animated WebP: count frames with `ffprobe -count_frames`.
-- [ ] `--to avif in out` over `clip.mp4` produces a single frame, and says so if
-      the gate chose option 1.
-- [ ] `--to png in out` over `clip.mp4` behaves as the gate decided; a second run
-      reports the same thing with exit 0 unless the gate chose option 3.
-- [ ] `--to gif in out` over a photograph names the colour quantisation, on
-      whichever rung the gate's second decision puts it.
+- [ ] `--to avif in out` over `clip.mp4` produces a single frame and says so.
+- [ ] `--to png in out` over `clip.mp4` produces a single frame via the
+      `last_resort` and names it; a second run reports the same thing, exit 0.
+- [ ] `--to gif in out` over a photograph names the colour quantisation, via its standing note.
 - [ ] Time `--to avif` over a large still and compare with `--to webp`. The
       measured gap is 17x; confirm it is tolerable on real photographs.
 - [ ] A second run over any converted tree reports `0 converted`, exit 0.
@@ -299,10 +302,10 @@ New-Item -ItemType Directory -Force in
 | Risk | Mitigation |
 |---|---|
 | A stream copy ships a mislabelled file | The four image2 targets force their encoder, with a Verification item and a QA check on both directions of the commonest conversion |
-| `avif` silently drops frames, and `gif` silently drops transparency and colours | Reportable only under the second open decision's option 1; option 2 leaves them unnamed and costs a constitution amendment. The gate is shown both prices |
+| `avif` silently drops frames, and `gif` silently drops transparency and colours | Both forced their encoder at the gate, so their standing notes are on the rung that always wins and the losses are always named |
 | `--to avif` over a photo library is unusably slow | Measured and priced in the muxer table; the QA gate confirms it on real photographs |
-| An alpha loss goes unnamed | Measured per target: `jpg`, `gif` and `avif` lose it, `png`, `tiff`, `bmp` and `webp` keep it. `jpg`'s note always prints; `gif`'s and `avif`'s depend on the second open decision |
-| The wasted spawn is mistaken for a bug | For `webp` it is named in its decision row as a deliberate price for a real copy path. For `gif` and `avif` it disappears entirely under the second open decision's option 1 |
+| An alpha loss goes unnamed | Measured per target: `jpg`, `gif` and `avif` lose it, `png`, `tiff`, `bmp` and `webp` keep it. All three notes print on a cheap attempt that always wins |
+| The wasted spawn is mistaken for a bug | It remains only for `webp`, named in its decision row as a deliberate price for a real copy path; forcing the encoder removed it for `gif` and `avif` |
 | Someone reads the missing EXIF as a bug | Named as a vision non-goal with the prior-art entry that evidences it |
 
 ## Decision log
@@ -338,3 +341,8 @@ New-Item -ItemType Directory -Force in
   `gif` only CPU while costing `avif` a real generation loss plus seven seconds.
   The two had been bundled under one price sentence that overstated `gif`'s; the
   decision may now be answered per target.
+- 2026-08-26: Gate resolved both decisions. The image2 four extract the first
+  frame at the `last_resort`, keeping the common single-image case noise-free.
+  `gif` and `avif` force their encoder, so every standing note sits on a rung that
+  always wins — `gif` pays nothing for it, `avif` pays a generation loss and seven
+  seconds per already-AVIF file, accepted rather than leaving its losses silent.

--- a/docs/specs/spec-image-formats.md
+++ b/docs/specs/spec-image-formats.md
@@ -1,0 +1,205 @@
+# Spec: image-formats (roadmap phase 5)
+
+> Created: 2026-08-26
+
+Add the seven image target profiles — `png`, `jpg`, `webp`, `avif`, `gif`,
+`tiff`, `bmp` — completing the vision's 17 formats. This spec carries no
+lifecycle state — acceptance is the spec merged on the default branch with a
+milestone and issues, and all progress lives in the GitHub issues and milestone.
+A completed spec is moved to `docs/specs/archive/`.
+
+**Depends on milestone #2 (target-driven-cli).** Independent of phases 3 and 4.
+
+## Why this phase is not like the other two coverage phases
+
+Audio and video targets convert a stream into a stream. An image target converts
+a *frame*, and every source in the curated suffix set has either one frame or
+thousands. That difference is the whole design problem here, and it is what the
+open decision below is about — not codec masks, which are the easy part.
+
+## Outcome
+
+- [ ] `converter --to <fmt>` works for `png`, `jpg`, `webp`, `avif`, `gif`,
+      `tiff` and `bmp`.
+- [ ] `--list-formats` prints one line per registry entry — 17 targets, which is
+      `docs/vision.md`'s headline success criterion met in full.
+- [ ] **The diff of every PR in this milestone touches only
+      `converter/profiles.py`, `README.md` and files under `tests/`.**
+- [ ] Every new profile has a test pinning the exact argv it builds, for a
+      copyable and for a non-copyable input.
+- [ ] A multi-frame source under a single-frame target behaves as the gate
+      decides, and says so — never silently.
+- [ ] Converting an image with transparency into a target that cannot hold it
+      names the loss.
+
+## Scope
+
+### In scope
+
+- Seven new `Profile` entries with their stream rules, copy masks, fallback
+  encoders, `cheap_attempt`, `explicit_streams`, `last_resort` and standing
+  notes, plus registry entries.
+- Extending the curated source-suffix set with image containers: `.png`, `.jpg`,
+  `.jpeg`, `.webp`, `.avif`, `.gif`, `.tif`, `.tiff`, `.bmp`, `.ppm`, `.pgm`,
+  `.tga`.
+- `README.md`'s format list.
+- The tests those profiles require.
+
+### Out of scope
+
+- **HEIC, SVG and camera RAW** — `docs/vision.md` names all three as non-goals:
+  they need libheif or a rasteriser, not an ffmpeg muxer, and adding one would
+  break the single-dependency promise.
+- **EXIF/ICC preservation** — an explicit non-goal. ffmpeg strips metadata by
+  default and PNG cannot carry EXIF at all (`docs/prior-art.md`).
+- Resizing, cropping, rotation, colour management, or any encoder-tuning surface
+  beyond the one quality default per lossy format.
+- Extracting a frame *sequence* (`out_%04d.png`). One input file maps to one
+  output file — `paths.output_for` is built on that, and changing it would be a
+  different feature in a different phase.
+- **Any engine change.**
+
+## Constraints
+
+- A target format is data, not code.
+- One input file, one output file. Every design below is bounded by that.
+- `ffprobe` never runs on the happy path.
+- Never report success for a conversion that silently dropped something.
+- The test suite keeps passing with no ffmpeg installed.
+
+## Prior art
+
+- [Image conversion through ffmpeg (Phase 5)](../prior-art.md#image-conversion-through-ffmpeg-phase-5)
+  — the concern tagged for this phase. Its ADOPT is confirmed by measurement: PNG,
+  JPEG, WebP, AVIF, TIFF, BMP and GIF all have working ffmpeg muxers, so images
+  need no second backend. Its AVOID is the reason EXIF/ICC preservation is out of
+  scope rather than a bug.
+- [Container/codec capability modelling (Phase 1)](../prior-art.md#containercodec-capability-modelling-phase-1)
+  — the copy-mask vocabulary, and the rule that the mask is curated by hand.
+
+## Design
+
+No new design artifact. The ladder and the per-stream branch already cover this
+phase; what is new is *which rung does the work*, and that is a decision recorded
+below rather than a new diagram.
+
+## Human prerequisites
+
+- none.
+
+## Prior decisions
+
+### The muxer facts these profiles rest on
+
+Measured against ffmpeg 9.0 during planning. A later reader should re-verify.
+
+| Fact | Consequence |
+|---|---|
+| **A multi-frame source into a single-file image target fails hard**: `-i v.mp4 -map 0:v:0 out.png` exits 127 with "Cannot write more than one file with the same name. Are you missing the -update option or a sequence pattern?" | The single-frame targets do **not** silently produce garbage from a video. They fail into the ladder, which is where the decision below gets to name what it does |
+| **Adding `-frames:v 1` makes the same conversion succeed**, writing exactly one frame (verified with `-count_frames`) | The rung that carries `-frames:v 1` is the one that turns a video into an image |
+| **GIF is different: it is animated.** A 2-second video into `.gif` exits 0 and writes 20 frames | `gif` must **not** carry `-frames:v 1`, and it is the only image target that converts a video meaningfully |
+| **An alpha PNG into JPG exits 0 and silently drops the alpha channel** (`rgba` in, `yuvj444p` out) | A real silent loss, on the happy path, that only a standing note can cover |
+| PNG, JPG, WebP, AVIF, TIFF and BMP all encode from a PNG source at exit 0 | Every target in the vision's list has a working muxer; no second backend is needed |
+| A single-frame PNG copies into PNG with `-c copy` at exit 0 | The copy path is real for image-to-image where the codec matches |
+
+### Decisions
+
+| Decision | Rationale | Date |
+|---|---|---|
+| Cheap attempt for every single-frame target: `flags("-map 0:v? -c copy")`, `explicit_streams=False`, **without** `-frames:v 1` | A single-image source converts on the first attempt. A multi-frame source *fails* here, which is exactly what puts it in front of the ladder instead of quietly producing one frame with no explanation — the "turn a quiet loss into a failure the ladder can name" pattern phases 3 and 4 established | 2026-08-26 |
+| `gif`'s cheap attempt is `flags("-map 0:v? -c copy")` too, but it carries no frame limit anywhere: a video converts to an animated GIF | Measured: the GIF muxer takes every frame. It is the one image target for which a video source is an ordinary conversion rather than an extraction | 2026-08-26 |
+| Every single-frame target declares no audio, subtitle or attachment rule, so those streams are dropped by the selective rung with the engine's per-stream note | An image holds one thing. Nothing here needs a new rule kind | 2026-08-26 |
+| Copy masks: `png` -> `{png}`; `jpg` -> `{mjpeg}`; `webp` -> `{webp}`; `avif` -> `{av1}`; `gif` -> `{gif}`; `tiff` -> `{tiff}`; `bmp` -> `{bmp}` | ffprobe reports a still image's `codec_name` as its image codec, so an image-to-same-image conversion is a real stream copy. Everything else re-encodes | 2026-08-26 |
+| Fallback encoders: `png` -> `png`; `jpg` -> `mjpeg -q:v:{n} 2`; `webp` -> `libwebp -quality:v:{n} 80`; `avif` -> `libaom-av1 -crf:v:{n} 30 -still-picture 1`; `gif` -> `gif`; `tiff` -> `tiff`; `bmp` -> `bmp` | One quality default per lossy format, chosen at "you would need the original beside it to tell", and pinned by the argv tests. The lossless targets need no parameter | 2026-08-26 |
+| `png`, `tiff`, `bmp` and `gif` declare `fallback_name=None` — no note for the encode itself; `jpg`, `webp` and `avif` declare theirs | The rule phase 3 established: encoding into a target's own lossless codec gives up nothing worth naming, encoding into a lossy one does | 2026-08-26 |
+| **Standing note on `jpg`**: transparency is not carried into JPEG. Measured as a silent, exit-0 loss on the happy path | The phase-3 gate's mechanism, applied to the one measured silent loss in this phase. Whether `bmp` and `gif` need the same note depends on a measurement the review is asked to make | 2026-08-26 |
+| OPEN — what a single-frame target does with a multi-frame source | resolved at the spec-acceptance gate; see the note below | — |
+
+### The one open decision, in full
+
+Measured: `--to png` on a video fails the cheap attempt *and* the selective rung,
+because neither carries `-frames:v 1`. What happens next is the `last_resort`,
+and what that rung contains is the decision.
+
+1. **Extract the first frame.** `last_resort` is
+   `flags("-map 0:v:0 -frames:v 1")` plus the profile's encoder, with a note
+   saying a single frame was taken from a multi-frame source. `--to png` over a
+   mixed folder then produces a thumbnail per video, exit 0, and a re-run is
+   idempotent. It costs three ffmpeg spawns and a probe per video, and it answers
+   a question the user did not obviously ask.
+2. **Declare no `last_resort`.** A video under `--to png` ends the ladder and is
+   reported as `failed`, exit 1. Honest — the tool does not invent an answer — but
+   it breaks `docs/vision.md`'s idempotent-re-run criterion for any mixed tree:
+   the file produces no output, so every re-run fails again, and the run never
+   reaches `0 converted, 0 failed`.
+
+Option 2's cost is the one phase 2 already paid for elsewhere: the `unsupported`
+outcome exists precisely because a permanently-failing file poisons re-runs. It
+does not apply automatically here — `unsupported` fires when the source carries no
+stream of any type the profile has a rule for, and a video *does* match an image
+profile's video rule. Making it apply would be an engine change, which this phase
+does not take.
+
+## Tracking
+
+- Milestone: image-formats (created at the spec-acceptance gate)
+- Issues: created from this spec once it is merged (one per implementable step)
+
+## Verification
+
+Machine checks:
+
+- [ ] Verify passes on the merge commit.
+- [ ] For every PR in this milestone, `git diff main...<pr-head> --name-only`
+      lists only `converter/profiles.py`, `README.md` and paths under `tests/`.
+- [ ] Per new profile, a test pinning the full argv for a copyable input and for
+      a non-copyable one — fourteen tests, seven profiles, both cases each.
+- [ ] A test that `gif` carries no frame limit while the six single-frame targets
+      reach one through the rung the gate chose.
+- [ ] A test that no image profile declares an audio, subtitle or attachment
+      rule, so those streams are dropped with a note.
+- [ ] A test per degradation branch, including `jpg`'s standing note.
+- [ ] A test that converting into `png`, `tiff`, `bmp` or `gif` emits no note for
+      the encode itself.
+- [ ] `--list-formats` prints 17 lines.
+
+Human milestone-QA gate. `$FF` is the absolute ffmpeg path from *This machine*:
+
+```text
+New-Item -ItemType Directory -Force in
+& $FF -y -f lavfi -i color=c=red:size=320x240:d=1 -frames:v 1 in/flat.png
+& $FF -y -f lavfi -i "color=c=red@0.5:size=320x240:d=1,format=rgba" -frames:v 1 in/alpha.png
+& $FF -y -f lavfi -i testsrc=size=320x240:rate=10:duration=2 -c:v libx264 in/clip.mp4
+```
+
+- [ ] Each of the seven targets converts `flat.png` and the result opens.
+- [ ] `--to jpg in out` over `alpha.png` prints the transparency note. Check the
+      output's `pix_fmt` with `ffprobe` — the loss is real and silent without it.
+- [ ] `--to gif in out` over `clip.mp4` produces an **animated** GIF: count the
+      frames with `ffprobe -count_frames`, do not judge by eye.
+- [ ] `--to png in out` over `clip.mp4` behaves as the gate decided, and a second
+      run over the same tree reports the same thing with exit 0 if the gate chose
+      option 1.
+- [ ] `--to png in out` over `flat.png` with a different output root stream-copies
+      rather than re-encoding.
+- [ ] A second run over any converted tree reports `0 converted`, exit 0.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `--to png` over a video-heavy tree does something surprising | It is the phase's one open decision, put to the gate with both costs measured rather than settled quietly |
+| An alpha loss goes unnamed | Measured and covered by `jpg`'s standing note; the review is asked to measure `bmp` and `gif` for the same |
+| A copy mask is wrong and an image copy ships something unopenable | The QA gate opens one output per target, and phase 3's lesson applies: on the happy path the muxer is the authority, so the mask matters most on the failure path |
+| Someone reads the missing EXIF as a bug | Named as a vision non-goal in Out of scope, with the prior-art entry that evidences it |
+| The 17-format claim is asserted rather than checked | `--list-formats` printing 17 lines is a Verification item |
+
+## Decision log
+
+- 2026-08-26: The muxer facts were measured during planning, as in phase 4. The
+  decisive one was that a video into a single-file image target *fails* rather
+  than silently writing a frame — which is what makes the ladder, and therefore an
+  honest note, available at all.
+- 2026-08-26: `gif` is deliberately not grouped with the other six. It is the only
+  image target that is animated, and treating it as a still would silently discard
+  every frame but one.

--- a/docs/specs/spec-image-formats.md
+++ b/docs/specs/spec-image-formats.md
@@ -14,21 +14,30 @@ A completed spec is moved to `docs/specs/archive/`.
 
 Audio and video targets convert a stream into a stream. An image target converts
 a *frame*, and every source in the curated suffix set has either one frame or
-thousands. That difference is the whole design problem here, and it is what the
-open decision below is about — not codec masks, which are the easy part.
+thousands. Worse, the seven targets do not behave alike: three different muxer
+families sit behind them, and the differences are not cosmetic.
+
+| Group | Targets | Behaviour that sets it apart |
+|---|---|---|
+| **image2, permissive** | `png`, `jpg`, `tiff`, `bmp` | The muxer accepts **any** video codec under `-c copy`, so a copy ships a mislabelled file. A multi-frame source fails hard |
+| **animated** | `gif`, `webp` | Self-policing muxers, and a video source becomes a genuine animation — every frame is written |
+| **still, self-policing** | `avif` | Self-policing, but a multi-frame source is silently reduced to **one** frame at exit 0 |
+
+Everything below follows from that table.
 
 ## Outcome
 
 - [ ] `converter --to <fmt>` works for `png`, `jpg`, `webp`, `avif`, `gif`,
       `tiff` and `bmp`.
-- [ ] `--list-formats` prints one line per registry entry — 17 targets, which is
-      `docs/vision.md`'s headline success criterion met in full.
+- [ ] `--list-formats` prints one line per registry entry, including the seven
+      image targets.
 - [ ] **The diff of every PR in this milestone touches only
       `converter/profiles.py`, `README.md` and files under `tests/`.**
-- [ ] Every new profile has a test pinning the exact argv it builds, for a
-      copyable and for a non-copyable input.
-- [ ] A multi-frame source under a single-frame target behaves as the gate
-      decides, and says so — never silently.
+- [ ] `--to png` over a folder of JPEGs produces real PNGs, and `--to jpg` over a
+      folder of PNGs produces real JPEGs. The two commonest image conversions
+      there are, and a stream copy gets both wrong.
+- [ ] A multi-frame source behaves as its target's group requires, and says so —
+      never silently.
 - [ ] Converting an image with transparency into a target that cannot hold it
       names the loss.
 
@@ -37,8 +46,8 @@ open decision below is about — not codec masks, which are the easy part.
 ### In scope
 
 - Seven new `Profile` entries with their stream rules, copy masks, fallback
-  encoders, `cheap_attempt`, `explicit_streams`, `last_resort` and standing
-  notes, plus registry entries.
+  encoders, `cheap_attempt`, `explicit_streams`, `stream_limit`, `last_resort`,
+  `container_options` and standing notes, plus registry entries.
 - Extending the curated source-suffix set with image containers: `.png`, `.jpg`,
   `.jpeg`, `.webp`, `.avif`, `.gif`, `.tif`, `.tiff`, `.bmp`, `.ppm`, `.pgm`,
   `.tga`.
@@ -48,40 +57,39 @@ open decision below is about — not codec masks, which are the easy part.
 ### Out of scope
 
 - **HEIC, SVG and camera RAW** — `docs/vision.md` names all three as non-goals:
-  they need libheif or a rasteriser, not an ffmpeg muxer, and adding one would
-  break the single-dependency promise.
-- **EXIF/ICC preservation** — an explicit non-goal. ffmpeg strips metadata by
-  default and PNG cannot carry EXIF at all (`docs/prior-art.md`).
+  they need libheif or a rasteriser, not an ffmpeg muxer.
+- **EXIF/ICC preservation** — an explicit non-goal; PNG cannot carry EXIF at all
+  (`docs/prior-art.md`).
 - Resizing, cropping, rotation, colour management, or any encoder-tuning surface
   beyond the one quality default per lossy format.
-- Extracting a frame *sequence* (`out_%04d.png`). One input file maps to one
-  output file — `paths.output_for` is built on that, and changing it would be a
-  different feature in a different phase.
+- Extracting a frame *sequence* (`out_%04d.png`). One input file, one output
+  file — `paths.output_for` is built on that.
 - **Any engine change.**
 
 ## Constraints
 
 - A target format is data, not code.
-- One input file, one output file. Every design below is bounded by that.
+- One input file, one output file.
 - `ffprobe` never runs on the happy path.
 - Never report success for a conversion that silently dropped something.
+- `{n}` is substituted **only** in `StreamRule` templates. `cheap_attempt` and
+  `last_resort` are emitted verbatim, so a `{n}` in either reaches ffmpeg
+  literally — every attempt below is written without one.
 - The test suite keeps passing with no ffmpeg installed.
 
 ## Prior art
 
 - [Image conversion through ffmpeg (Phase 5)](../prior-art.md#image-conversion-through-ffmpeg-phase-5)
-  — the concern tagged for this phase. Its ADOPT is confirmed by measurement: PNG,
-  JPEG, WebP, AVIF, TIFF, BMP and GIF all have working ffmpeg muxers, so images
-  need no second backend. Its AVOID is the reason EXIF/ICC preservation is out of
-  scope rather than a bug.
+  — the concern tagged for this phase. Its ADOPT is confirmed by measurement: all
+  seven formats have working ffmpeg muxers, so images need no second backend. Its
+  AVOID is why EXIF/ICC preservation is a non-goal rather than a bug.
 - [Container/codec capability modelling (Phase 1)](../prior-art.md#containercodec-capability-modelling-phase-1)
   — the copy-mask vocabulary, and the rule that the mask is curated by hand.
 
 ## Design
 
-No new design artifact. The ladder and the per-stream branch already cover this
-phase; what is new is *which rung does the work*, and that is a decision recorded
-below rather than a new diagram.
+No new design artifact. What is new is *which rung does the work*, and that is
+recorded as decisions rather than as a new diagram.
 
 ## Human prerequisites
 
@@ -91,54 +99,68 @@ below rather than a new diagram.
 
 ### The muxer facts these profiles rest on
 
-Measured against ffmpeg 9.0 during planning. A later reader should re-verify.
+Measured against ffmpeg 9.0 during planning and re-measured by the review, exit
+codes taken from ffmpeg itself.
 
 | Fact | Consequence |
 |---|---|
-| **A multi-frame source into a single-file image target fails hard**: `-i v.mp4 -map 0:v:0 out.png` exits 127 with "Cannot write more than one file with the same name. Are you missing the -update option or a sequence pattern?" | The single-frame targets do **not** silently produce garbage from a video. They fail into the ladder, which is where the decision below gets to name what it does |
-| **Adding `-frames:v 1` makes the same conversion succeed**, writing exactly one frame (verified with `-count_frames`) | The rung that carries `-frames:v 1` is the one that turns a video into an image |
-| **GIF is different: it is animated.** A 2-second video into `.gif` exits 0 and writes 20 frames | `gif` must **not** carry `-frames:v 1`, and it is the only image target that converts a video meaningfully |
-| **An alpha PNG into JPG exits 0 and silently drops the alpha channel** (`rgba` in, `yuvj444p` out) | A real silent loss, on the happy path, that only a standing note can cover |
-| PNG, JPG, WebP, AVIF, TIFF and BMP all encode from a PNG source at exit 0 | Every target in the vision's list has a working muxer; no second backend is needed |
-| A single-frame PNG copies into PNG with `-c copy` at exit 0 | The copy path is real for image-to-image where the codec matches |
+| **The image2 muxer accepts any video codec under `-c copy`.** `flat.jpg -map 0:v? -c copy out.png` exits 0 and writes a JPEG named `.png`; `alpha.png -> out.jpg` writes a PNG named `.jpg` | `png`, `jpg`, `tiff` and `bmp` must **force their encoder** in the cheap attempt. A copy there mislabels the file on the default path, for the two commonest image conversions there are |
+| **`webp`, `avif` and `gif` self-police**: a non-matching codec copy exits 127 ("webp muxer supports only codec webp", "gif muxer supports only codec gif", "Could not find tag for codec png") | Those three can keep `-c copy` safely; the price is one wasted spawn plus one probe per non-matching source |
+| **A multi-frame source into an image2 target fails hard** at both the cheap attempt and the selective rung: "Cannot write more than one file with the same name" | Only a rung carrying `-frames:v 1` converts a video into a `png`/`jpg`/`tiff`/`bmp` |
+| **`gif` and `webp` write every frame**: a 20-frame video becomes a 20-frame GIF and a 20-frame animated WebP, both at exit 0 on the selective rung | `webp` is an *animated* target, not a still one. Neither carries a frame limit |
+| **`avif` silently reduces a 20-frame source to one frame at exit 0** — the muxer, not the flag: dropping `-still-picture 1` still yields one frame. With an AV1-in-MP4 source the copy mask hits and this happens on the **cheap attempt** | The one silent multi-frame loss in the phase, and it needs a standing note; no rung can turn it into a failure |
+| **Alpha, measured by round-tripping `rgba` (α=127) through each fallback encoder:** kept by `png`, `tiff`, `bmp`, `webp`; **lost by `jpg`, `gif` and `avif`** — `gif` loses even a fully transparent source, `avif` because `libaom-av1` has no alpha pix_fmt | `jpg`, `gif` and `avif` need a transparency standing note. `bmp` does not — the question the earlier draft left open is closed |
+| ffprobe reports a still's `codec_name` as `png`, `mjpeg`, `webp`, `tiff`, `bmp`, `gif`, `av1` | The copy masks below are right |
+| Option syntax parses and takes effect in the `{n}` form: `-quality:v:0` for libwebp (not `-compression_level`), `-q:v:0` for mjpeg, `-crf:v:0` for libaom-av1 | The fallback templates below are valid |
+| **`libaom-av1` is 17-34x slower than the alternatives**: a 3000x2000 still takes 6.9 s at `-crf 30 -still-picture 1`, against 0.41 s for `libwebp -quality 80` and 0.20 s for `mjpeg -q:v 2` | `--to avif` over a folder of camera JPEGs is a different tool from `--to webp` over the same folder. Priced here rather than discovered |
 
 ### Decisions
 
 | Decision | Rationale | Date |
 |---|---|---|
-| Cheap attempt for every single-frame target: `flags("-map 0:v? -c copy")`, `explicit_streams=False`, **without** `-frames:v 1` | A single-image source converts on the first attempt. A multi-frame source *fails* here, which is exactly what puts it in front of the ladder instead of quietly producing one frame with no explanation — the "turn a quiet loss into a failure the ladder can name" pattern phases 3 and 4 established | 2026-08-26 |
-| `gif`'s cheap attempt is `flags("-map 0:v? -c copy")` too, but it carries no frame limit anywhere: a video converts to an animated GIF | Measured: the GIF muxer takes every frame. It is the one image target for which a video source is an ordinary conversion rather than an extraction | 2026-08-26 |
-| Every single-frame target declares no audio, subtitle or attachment rule, so those streams are dropped by the selective rung with the engine's per-stream note | An image holds one thing. Nothing here needs a new rule kind | 2026-08-26 |
-| Copy masks: `png` -> `{png}`; `jpg` -> `{mjpeg}`; `webp` -> `{webp}`; `avif` -> `{av1}`; `gif` -> `{gif}`; `tiff` -> `{tiff}`; `bmp` -> `{bmp}` | ffprobe reports a still image's `codec_name` as its image codec, so an image-to-same-image conversion is a real stream copy. Everything else re-encodes | 2026-08-26 |
-| Fallback encoders: `png` -> `png`; `jpg` -> `mjpeg -q:v:{n} 2`; `webp` -> `libwebp -quality:v:{n} 80`; `avif` -> `libaom-av1 -crf:v:{n} 30 -still-picture 1`; `gif` -> `gif`; `tiff` -> `tiff`; `bmp` -> `bmp` | One quality default per lossy format, chosen at "you would need the original beside it to tell", and pinned by the argv tests. The lossless targets need no parameter | 2026-08-26 |
-| `png`, `tiff`, `bmp` and `gif` declare `fallback_name=None` — no note for the encode itself; `jpg`, `webp` and `avif` declare theirs | The rule phase 3 established: encoding into a target's own lossless codec gives up nothing worth naming, encoding into a lossy one does | 2026-08-26 |
-| **Standing note on `jpg`**: transparency is not carried into JPEG. Measured as a silent, exit-0 loss on the happy path | The phase-3 gate's mechanism, applied to the one measured silent loss in this phase. Whether `bmp` and `gif` need the same note depends on a measurement the review is asked to make | 2026-08-26 |
-| OPEN — what a single-frame target does with a multi-frame source | resolved at the spec-acceptance gate; see the note below | — |
+| **`png`, `jpg`, `tiff`, `bmp` force their encoder in the cheap attempt**: `flags("-map 0:v? -c:v png")`, `flags("-map 0:v? -c:v mjpeg -q:v 2")`, `flags("-map 0:v? -c:v tiff")`, `flags("-map 0:v? -c:v bmp")`. `explicit_streams=False` | Measured: image2 accepts any codec on copy, so `--to png` over JPEGs would ship JPEGs named `.png`. This is phase 3's carve-out — "where the muxer is looser than the format's identity, the profile does not rely on a copy at all" — and it is the same shape as `opus`. The copy still happens on the selective rung, on a mask hit | 2026-08-26 |
+| **`gif`, `webp`, `avif` keep `flags("-map 0:v? -c copy")`**, `explicit_streams=False` | Their muxers reject a non-matching codec, so a copy cannot mislabel. The cost is one wasted ffmpeg spawn plus one ffprobe for every non-matching source — which is nearly every source, since a copy only hits when the input is already that format. Accepted deliberately: it buys a real stream copy for the same-format case, which is the one conversion where it matters | 2026-08-26 |
+| Copy masks: `png` -> `{png}`; `jpg` -> `{mjpeg}`; `webp` -> `{webp}`; `avif` -> `{av1}`; `gif` -> `{gif}`; `tiff` -> `{tiff}`; `bmp` -> `{bmp}` | Measured against ffprobe's reported codec names | 2026-08-26 |
+| Fallback encoders, as full `StreamRule` templates: `png` -> `flags("-c:v:{n} png")`; `jpg` -> `flags("-c:v:{n} mjpeg -q:v:{n} 2")`; `webp` -> `flags("-c:v:{n} libwebp -quality:v:{n} 80")`; `avif` -> `flags("-c:v:{n} libaom-av1 -crf:v:{n} 30 -still-picture 1")`; `gif` -> `flags("-c:v:{n} gif")`; `tiff` -> `flags("-c:v:{n} tiff")`; `bmp` -> `flags("-c:v:{n} bmp")` | One quality default per lossy format, pinned by the argv tests. Written in full rather than as shorthand, because the `-c:v:{n}` is not optional | 2026-08-26 |
+| `png`, `tiff`, `bmp` and `gif` declare `fallback_name=None` — no note for the encode; `jpg`, `webp` and `avif` declare theirs | The phase-3 rule: encoding into a target's own lossless codec gives up nothing worth naming | 2026-08-26 |
+| **`stream_limit=1` on every image profile's video rule** | One image, one picture. A source with two video streams — cover art beside a video, an MJPEG-plus-video AVI — would otherwise map both into one output file and fail. `mp3` and `flac` got the same treatment in phase 3 for the same reason | 2026-08-26 |
+| No image profile declares an audio, subtitle or attachment rule; `container_options` is `()` for all seven | An image holds one thing, and none of these muxers takes a container flag | 2026-08-26 |
+| **Standing notes**: `jpg`, `gif` and `avif` say transparency is not carried; `avif` additionally says a multi-frame source is reduced to a single frame | Measured. `avif`'s frame note is the only way that loss is ever reported — no rung can turn it into a failure, and it can strike on the cheap attempt with an AV1-in-MP4 source | 2026-08-26 |
+| `last_resort`: `gif` -> `flags("-map 0:v:0 -c:v gif")`; `webp` -> `flags("-map 0:v:0 -c:v libwebp -quality:v 80")`; `avif` -> `flags("-map 0:v:0 -c:v libaom-av1 -crf 30 -still-picture 1")`. The four image2 targets' `last_resort` is what the gate decides | Phase 4's rule: every profile needs one or a ladder that reaches the end lands as `failed`. Written without `{n}`, which is not substituted outside `StreamRule` templates | 2026-08-26 |
+| OPEN — how `png`, `jpg`, `tiff` and `bmp` handle a multi-frame source | resolved at the spec-acceptance gate; see the note below | — |
 
 ### The one open decision, in full
 
-Measured: `--to png` on a video fails the cheap attempt *and* the selective rung,
-because neither carries `-frames:v 1`. What happens next is the `last_resort`,
-and what that rung contains is the decision.
+**Scope: four targets, not seven.** `gif` and `webp` convert a video into an
+animation, which needs no decision. `avif` reduces it to one frame whatever
+anyone does, which is covered by its standing note. Only the image2 four —
+`png`, `jpg`, `tiff`, `bmp` — reach a rung where this is a choice.
 
-1. **Extract the first frame.** `last_resort` is
-   `flags("-map 0:v:0 -frames:v 1")` plus the profile's encoder, with a note
-   saying a single frame was taken from a multi-frame source. `--to png` over a
-   mixed folder then produces a thumbnail per video, exit 0, and a re-run is
-   idempotent. It costs three ffmpeg spawns and a probe per video, and it answers
-   a question the user did not obviously ask.
-2. **Declare no `last_resort`.** A video under `--to png` ends the ladder and is
-   reported as `failed`, exit 1. Honest — the tool does not invent an answer — but
-   it breaks `docs/vision.md`'s idempotent-re-run criterion for any mixed tree:
-   the file produces no output, so every re-run fails again, and the run never
-   reaches `0 converted, 0 failed`.
+Measured: with the encoder forced, an image source converts on the cheap attempt.
+A video source fails the cheap attempt *and* the selective rung, because neither
+carries `-frames:v 1`. Three answers:
 
-Option 2's cost is the one phase 2 already paid for elsewhere: the `unsupported`
+1. **Extract the first frame at the `last_resort`.**
+   `flags("-map 0:v:0 -frames:v 1 -c:v png")` and its siblings, with a note saying
+   a single frame was taken. The common case — an actual image — converts on the
+   first attempt with no note at all. A video costs three ffmpeg spawns plus a
+   probe, and gets a thumbnail it did not obviously ask for.
+2. **Put `-frames:v 1` in the cheap attempt**, with a standing note that only the
+   first frame is kept. One spawn instead of three for a video, and the same
+   standing-note mechanism phases 3 and 4 chose elsewhere. The cost is noise: the
+   note prints on every single conversion, including the overwhelming majority
+   that are ordinary one-frame images with nothing to lose.
+3. **Declare no `last_resort`.** A video under `--to png` is reported as `failed`,
+   exit 1. The tool invents nothing — but the file produces no output, so every
+   re-run fails again and a mixed tree never reaches `0 converted, 0 failed`,
+   which `docs/vision.md` requires.
+
+Option 3's cost is the one phase 2 already paid for elsewhere: its `unsupported`
 outcome exists precisely because a permanently-failing file poisons re-runs. It
-does not apply automatically here — `unsupported` fires when the source carries no
-stream of any type the profile has a rule for, and a video *does* match an image
-profile's video rule. Making it apply would be an engine change, which this phase
-does not take.
+does **not** apply automatically here — `unsupported` fires when the source
+carries no stream of any type the profile has a rule for, and a video does match
+an image profile's video rule. Making it apply would be a `jobs.py` change, which
+this phase does not take.
 
 ## Tracking
 
@@ -153,53 +175,75 @@ Machine checks:
 - [ ] For every PR in this milestone, `git diff main...<pr-head> --name-only`
       lists only `converter/profiles.py`, `README.md` and paths under `tests/`.
 - [ ] Per new profile, a test pinning the full argv for a copyable input and for
-      a non-copyable one — fourteen tests, seven profiles, both cases each.
-- [ ] A test that `gif` carries no frame limit while the six single-frame targets
-      reach one through the rung the gate chose.
+      a non-copyable one. `png`, `jpg`, `tiff` and `bmp` carry the same exception
+      `spec-profile-registry.md` recorded for WAV and phase 3 for `opus`: their
+      cheap attempt never copies, so the copyable case exists only on the
+      selective rung.
+- [ ] A test that `gif` and `webp` carry no frame limit anywhere, and that the
+      image2 four reach one through the rung the gate chose.
+- [ ] A test that `png`, `jpg`, `tiff` and `bmp` force `-c:v` in their cheap
+      attempt — the check that stops a copy from shipping a mislabelled file.
 - [ ] A test that no image profile declares an audio, subtitle or attachment
-      rule, so those streams are dropped with a note.
-- [ ] A test per degradation branch, including `jpg`'s standing note.
+      rule, so those streams are dropped with a note, and that every one declares
+      `stream_limit=1`.
+- [ ] A test per standing note, pinning its exact wording: transparency for
+      `jpg`, `gif`, `avif`, and the single-frame note for `avif`.
 - [ ] A test that converting into `png`, `tiff`, `bmp` or `gif` emits no note for
       the encode itself.
-- [ ] `--list-formats` prints 17 lines.
+- [ ] `--list-formats` prints one line per registry entry, including the seven
+      image names. The 17-line total is a QA-gate item for whichever of the three
+      coverage milestones closes last, not a machine check here — phases 3, 4 and
+      5 may run as parallel orchestrators, so this milestone can close while the
+      registry holds nine or twelve entries.
 
 Human milestone-QA gate. `$FF` is the absolute ffmpeg path from *This machine*:
 
 ```text
 New-Item -ItemType Directory -Force in
 & $FF -y -f lavfi -i color=c=red:size=320x240:d=1 -frames:v 1 in/flat.png
+& $FF -y -f lavfi -i color=c=red:size=320x240:d=1 -frames:v 1 in/flat.jpg
 & $FF -y -f lavfi -i "color=c=red@0.5:size=320x240:d=1,format=rgba" -frames:v 1 in/alpha.png
 & $FF -y -f lavfi -i testsrc=size=320x240:rate=10:duration=2 -c:v libx264 in/clip.mp4
 ```
 
 - [ ] Each of the seven targets converts `flat.png` and the result opens.
-- [ ] `--to jpg in out` over `alpha.png` prints the transparency note. Check the
-      output's `pix_fmt` with `ffprobe` — the loss is real and silent without it.
-- [ ] `--to gif in out` over `clip.mp4` produces an **animated** GIF: count the
-      frames with `ffprobe -count_frames`, do not judge by eye.
-- [ ] `--to png in out` over `clip.mp4` behaves as the gate decided, and a second
-      run over the same tree reports the same thing with exit 0 if the gate chose
-      option 1.
-- [ ] `--to png in out` over `flat.png` with a different output root stream-copies
-      rather than re-encoding.
+- [ ] `--to png in out` over `flat.jpg` produces a **real PNG** — `ffprobe` it,
+      and check `file` too. A stream copy would produce a JPEG named `.png` at
+      exit 0, which is the defect this phase's cheap attempts exist to prevent.
+- [ ] `--to jpg in out` over `flat.png` produces a real JPEG, same check.
+- [ ] `--to jpg in out` over `alpha.png` prints the transparency note, and the
+      output's `pix_fmt` shows the alpha is gone. Repeat for `--to gif` and
+      `--to avif`; `--to bmp`, `--to png`, `--to tiff` and `--to webp` keep it and
+      print no such note.
+- [ ] `--to gif in out` over `clip.mp4` produces an **animated** GIF, and
+      `--to webp` an animated WebP: count frames with `ffprobe -count_frames`.
+- [ ] `--to avif in out` over `clip.mp4` produces a single frame and **says so**.
+- [ ] `--to png in out` over `clip.mp4` behaves as the gate decided; a second run
+      reports the same thing with exit 0 unless the gate chose option 3.
+- [ ] Time `--to avif` over a large still and compare with `--to webp`. The
+      measured gap is 17x; confirm it is tolerable on real photographs.
 - [ ] A second run over any converted tree reports `0 converted`, exit 0.
 
 ## Risks and mitigations
 
 | Risk | Mitigation |
 |---|---|
-| `--to png` over a video-heavy tree does something surprising | It is the phase's one open decision, put to the gate with both costs measured rather than settled quietly |
-| An alpha loss goes unnamed | Measured and covered by `jpg`'s standing note; the review is asked to measure `bmp` and `gif` for the same |
-| A copy mask is wrong and an image copy ships something unopenable | The QA gate opens one output per target, and phase 3's lesson applies: on the happy path the muxer is the authority, so the mask matters most on the failure path |
-| Someone reads the missing EXIF as a bug | Named as a vision non-goal in Out of scope, with the prior-art entry that evidences it |
-| The 17-format claim is asserted rather than checked | `--list-formats` printing 17 lines is a Verification item |
+| A stream copy ships a mislabelled file | The four image2 targets force their encoder, with a Verification item and a QA check on both directions of the commonest conversion |
+| `avif` silently drops frames | Its standing note is the only reporting path, and the QA gate checks it explicitly |
+| `--to avif` over a photo library is unusably slow | Measured and priced in the muxer table; the QA gate confirms it on real photographs |
+| An alpha loss goes unnamed | Measured per target; three need the note and four do not |
+| The wasted spawn on `gif`/`webp`/`avif` is mistaken for a bug | Named in its decision row as a deliberate price for a real copy path |
+| Someone reads the missing EXIF as a bug | Named as a vision non-goal with the prior-art entry that evidences it |
 
 ## Decision log
 
-- 2026-08-26: The muxer facts were measured during planning, as in phase 4. The
-  decisive one was that a video into a single-file image target *fails* rather
-  than silently writing a frame — which is what makes the ladder, and therefore an
-  honest note, available at all.
-- 2026-08-26: `gif` is deliberately not grouped with the other six. It is the only
-  image target that is animated, and treating it as a still would silently discard
-  every frame but one.
+- 2026-08-26: The muxer facts were measured during planning, as in phase 4, and
+  the review falsified three of them. The decisive correction: image2 accepts any
+  codec on copy, so the four targets behind it must force their encoder — without
+  that, `--to png` over JPEGs and `--to jpg` over PNGs both ship mislabelled files
+  at exit 0.
+- 2026-08-26: `webp` was moved out of the single-frame group after the review
+  measured it writing a 20-frame animation. `gif` was never in it.
+- 2026-08-26: `avif`'s silent frame reduction has no failure path to hang a
+  per-stream note on, so it is the one loss in this phase that only a standing
+  note can report — including on the cheap attempt, for an AV1-in-MP4 source.

--- a/docs/specs/spec-image-formats.md
+++ b/docs/specs/spec-image-formats.md
@@ -106,7 +106,7 @@ codes taken from ffmpeg itself.
 |---|---|
 | **The image2 muxer accepts any video codec under `-c copy`.** `flat.jpg -map 0:v? -c copy out.png` exits 0 and writes a JPEG named `.png`; `alpha.png -> out.jpg` writes a PNG named `.jpg` | `png`, `jpg`, `tiff` and `bmp` must **force their encoder** in the cheap attempt. A copy there mislabels the file on the default path, for the two commonest image conversions there are |
 | **`webp`, `avif` and `gif` self-police**: a non-matching codec copy exits 127 ("webp muxer supports only codec webp", "gif muxer supports only codec gif", "Could not find tag for codec png") | Those three can keep `-c copy` safely; the price is one wasted spawn plus one probe per non-matching source |
-| **GIF is a 256-colour palette format, not a lossless one**: a photograph through `-c:v gif` keeps 182 of 36 485 distinct colours at exit 0 | `gif` must declare a `fallback_name`, or the quantisation is reported nowhere |
+| **GIF is a 256-colour palette format, not a lossless one**: a photograph through `-c:v gif` keeps 182 of 36 485 distinct colours at exit 0. But a **GIF source** re-encoded through the same template is pixel-identical (PSNR infinite, same byte count, all frames kept) -- it already holds at most 256 colours | `gif` must declare a `fallback_name`, or the quantisation from a photograph is reported nowhere. It also means forcing `gif`'s encoder costs a same-format source nothing but CPU |
 | **Forcing `jpg`'s encoder re-encodes an already-JPEG source**: 44 893 B -> 51 865 B (+15.5%), PSNR 53.5 dB, where `-c copy` is byte-identical | The price of not shipping a mislabelled file. `png`, `tiff` and `bmp` re-encode losslessly and pay nothing |
 | **A multi-frame source into an image2 target fails hard** at both the cheap attempt and the selective rung: "Cannot write more than one file with the same name" | Only a rung carrying `-frames:v 1` converts a video into a `png`/`jpg`/`tiff`/`bmp` |
 | **`gif` and `webp` write every frame**: a 20-frame video becomes a 20-frame GIF and a 20-frame animated WebP, both at exit 0 on the selective rung | `webp` is an *animated* target, not a still one. Neither carries a frame limit |
@@ -125,7 +125,7 @@ codes taken from ffmpeg itself.
 | Copy masks: `png` -> `{png}`; `jpg` -> `{mjpeg}`; `webp` -> `{webp}`; `avif` -> `{av1}`; `gif` -> `{gif}`; `tiff` -> `{tiff}`; `bmp` -> `{bmp}` | Measured against ffprobe's reported codec names | 2026-08-26 |
 | Fallback encoders, as full `StreamRule` templates: `png` -> `flags("-c:v png")`; `jpg` -> `flags("-c:v mjpeg -q:v 2")`; `webp` -> `flags("-c:v libwebp -quality:v 80")`; `avif` -> `flags("-c:v libaom-av1 -crf:v 30 -still-picture 1")`; `gif` -> `flags("-c:v gif")`; `tiff` -> `flags("-c:v tiff")`; `bmp` -> `flags("-c:v bmp")` -- all placeholder-free, per the stream-limit row below | One quality default per lossy format, pinned by the argv tests. Written in full rather than as shorthand, because the `-c:v` is not optional | 2026-08-26 |
 | Only `png`, `tiff` and `bmp` declare `fallback_name=None`. `gif`, `jpg`, `webp` and `avif` declare theirs | The phase-3 rule -- encoding into a target's own lossless codec gives up nothing worth naming -- covers `png`, `tiff` and `bmp` only. **GIF is not lossless**: it is a 256-colour palette format, and measured, a 1280x720 photograph goes from 36 485 distinct colours to 182 (PSNR 39.4 dB against 47.0 for png and bmp). With `fallback_name=None` that loss would be reported nowhere at all | 2026-08-26 |
-| **`accept_options=flags("-c:v copy")` on every image profile's video rule**, placeholder-free like the rest | Follow `opus`'s precedent, **not** WAV's `accept_options=()`. WAV's empty form is safe only because its mask is empty, so the accept branch is unreachable; here every mask hits, and measured, `()` emits a map with no codec option -- `-map 0:0` alone on a JPEG re-encodes it at exit 0 (44 867 B against 44 893 B, PSNR 66 dB) where `-c:v copy` is byte-identical. A silent lossy re-encode on the one path the copy mask exists to protect | 2026-08-26 |
+| **`accept_options=flags("-c:v copy")` on every image profile's video rule**, placeholder-free like the rest | Follow `opus`'s precedent, **not** WAV's `accept_options=()`. WAV's empty form is safe only because its mask is empty, so its accept branch is unreachable at all; every mask here is non-empty, so the branch is live. Measured, `()` emits a map with no codec option -- `-map 0:0` alone on a JPEG re-encodes it at exit 0 (44 867 B against 44 893 B, PSNR 66 dB) where `-c:v copy` is byte-identical. A silent lossy re-encode on the one path the copy mask exists to protect | 2026-08-26 |
 | **`stream_limit=1` on every image profile's video rule**, and -- following the convention `spec-profile-registry.md` recorded -- their templates are written **without** `{n}`: `flags("-c:v png")`, `flags("-c:v mjpeg -q:v 2")` and so on | A rule limited to one stream can only ever produce output stream 0, so it writes the bare specifier and the engine substitutes nothing. That is phase 1's rule, and the argv tests pin whichever form is chosen, so it is worth choosing deliberately. One image, one picture. A source with two video streams — cover art beside a video, an MJPEG-plus-video AVI — would otherwise map both into one output file and fail. `mp3` and `flac` got the same treatment in phase 3 for the same reason | 2026-08-26 |
 | No image profile declares an audio, subtitle or attachment rule; `container_options` is `()` for all seven | An image holds one thing, and none of these muxers takes a container flag | 2026-08-26 |
 | **Standing notes**: `jpg` says transparency is not carried **and** that the image was re-encoded. `gif` and `avif` need the same treatment for transparency, and `avif` for frame reduction -- but whether those notes are reachable depends on the second open decision | `jpg`'s cheap attempt always wins, so its note always prints. `gif`'s and `avif`'s cheap attempt is a copy that wins only for a source already in that format, so as drafted their notes print for exactly the inputs that lose nothing. That is the defect the second open decision exists to close | 2026-08-26 |
@@ -136,9 +136,10 @@ codes taken from ffmpeg itself.
 ### The one open decision, in full
 
 **Scope: four targets, not seven.** `gif` and `webp` convert a video into an
-animation, which needs no decision. `avif` reduces it to one frame whatever
-anyone does, which is covered by its standing note. Only the image2 four —
-`png`, `jpg`, `tiff`, `bmp` — reach a rung where this is a choice.
+animation, which needs no decision. `avif` reduces it to one frame no matter what
+this decision says — whether that reduction is *reported* is the second open
+decision's business, not this one's. Only the image2 four — `png`, `jpg`, `tiff`,
+`bmp` — reach a rung where this is a choice.
 
 Measured: with the encoder forced, an image source converts on the cheap attempt.
 A video source fails the cheap attempt *and* the selective rung, because neither
@@ -183,11 +184,21 @@ real engine:
 So the drafted notes are attached to a path they do not print on. The only lever
 this phase has is the cheap attempt:
 
-1. **Force the encoder for `gif` and `avif` too**, as `png`/`jpg`/`tiff`/`bmp`
-   now do. The cheap attempt then always wins, so both standing notes always
-   print, and the wasted spawn plus probe on every non-matching source disappears.
-   The price is that a same-format source is re-encoded rather than copied: a GIF
-   is re-quantised, and an AVIF pays a lossy re-encode plus about 7 seconds.
+1. **Force the encoder**, as `png`/`jpg`/`tiff`/`bmp` now do:
+   `flags("-map 0:v? -c:v gif")` and
+   `flags("-map 0:v? -c:v libaom-av1 -crf:v 30 -still-picture 1")`. The cheap
+   attempt then always wins, so both standing notes always print, and the wasted
+   spawn plus probe on every non-matching source disappears.
+
+   **The price differs sharply between the two, so this may be answered per
+   target.** Measured: re-encoding a GIF source through `-c:v gif` is
+   **pixel-identical** (PSNR infinite, same byte count, all 20 frames of an
+   animation preserved) -- a GIF already holds at most 256 colours, so the palette
+   reproduces them exactly, and option 1 costs `gif` nothing but CPU. Re-encoding
+   an AVIF source is genuinely lossy and slow: 7.07 s and PSNR 55.7 dB on a
+   3000x2000 still. One caveat that resisted measurement: an animated GIF using
+   per-frame local palettes could exceed 256 colours across the whole file, where
+   a single global palette would quantise. Both fixtures tried came back lossless.
 2. **Keep the copy.** A same-format source is copied perfectly and cheaply. The
    price is that a non-GIF source into `gif` loses transparency, and a video into
    `avif` loses frames, with nothing naming either -- which `docs/constitution.md`
@@ -322,3 +333,8 @@ New-Item -ItemType Directory -Force in
   mirror of the standing notes' — reachable under option 2, unreachable under
   option 1 — so the second open decision now states where each note lives per
   option, and the checks that depend on it say they are conditional.
+- 2026-08-26: Review round 4 measured that a GIF source re-encoded through
+  `-c:v gif` is pixel-identical, so the second open decision's option 1 costs
+  `gif` only CPU while costing `avif` a real generation loss plus seven seconds.
+  The two had been bundled under one price sentence that overstated `gif`'s; the
+  decision may now be answered per target.


### PR DESCRIPTION
Roadmap phase 5 — the last coverage phase: `png`, `jpg`, `webp`, `avif`, `gif`, `tiff`, `bmp`. Completing it meets `docs/vision.md`'s headline criterion of 17 target formats.

This phase is not like phases 3 and 4. Audio and video targets convert a stream into a stream; an image target converts a **frame**, and every source in the suffix set has either one frame or thousands. That, not codec masks, is the design problem.

Measured during planning:

- A multi-frame source into a single-file image target **fails hard** ("Cannot write more than one file with the same name") rather than quietly writing one frame — which is what makes the ladder, and therefore an honest note, available at all.
- **GIF is animated**: a 2-second video became a 20-frame GIF at exit 0. It is deliberately not grouped with the other six.
- **An alpha PNG into JPG exits 0 and silently drops the transparency** — a real silent loss on the happy path, covered by a standing note.

Depends on milestone #2. Independent of phases 3 and 4.

One decision is left open for the acceptance gate: what a single-frame target does with a video source — extract the first frame, or fail.
