### PR TITLE
docs(roadmap): restore the phase-4 spec and milestone links

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,7 +14,7 @@
 | 1 | profile-registry | [spec-profile-registry.md](specs/spec-profile-registry.md) | [#1](https://github.com/bhemsen/converter/milestone/1) |
 | 2 | target-driven-cli | [spec-target-driven-cli.md](specs/spec-target-driven-cli.md) | [#2](https://github.com/bhemsen/converter/milestone/2) |
 | 3 | audio-formats | [spec-audio-formats.md](specs/spec-audio-formats.md) | [#3](https://github.com/bhemsen/converter/milestone/3) |
-| 4 | video-formats | — | — |
+| 4 | video-formats | [spec-video-formats.md](specs/spec-video-formats.md) | [#4](https://github.com/bhemsen/converter/milestone/4) |
 | 5 | image-formats | — | — |
 
 A phase gets a Spec link once `/plan` drafts it, and a Milestone link once the

--- a/docs/specs/spec-video-formats.md
+++ b/docs/specs/spec-video-formats.md
@@ -162,7 +162,7 @@ existing entry needs no companion.)
 
 ## Tracking
 
-- Milestone: video-formats (created at the spec-acceptance gate)
+- Milestone: [video-formats](https://github.com/bhemsen/converter/milestone/4) (#4)
 - Issues: created from this spec once it is merged (one per implementable step)
 
 ## Verification


### PR DESCRIPTION
The commit adding them was lost in a rebase before #25 merged, so `docs/roadmap.md` and `spec-video-formats.md`'s Tracking section both pointed at nothing. Caught by the phase-5 spec review.