### PR TITLE
docs(roadmap): seed stream-disposition and lossy-source-notes

### DIFF
--- a/docs/prior-art.md
+++ b/docs/prior-art.md
@@ -164,3 +164,84 @@ evidenced, not assumed — see the image-conversion concern.
     tool, not the format. Document this as a non-goal rather than treating it as a
     bug. HEIC and SVG stay out of scope for the same class of reason: they need
     libheif or a rasteriser, not an ffmpeg muxer.
+
+## Cover art and stream disposition (Phase 6)
+
+### beetbox/beets — the `convert` plugin
+
+- Path: `beetsplug/convert.py`, documented in `docs/plugins/convert.rst`
+- License: MIT
+- Verdict: reference-only — adopt the stance, not the mechanism
+- Date: 2026-08-26
+- Notes:
+  - ADOPT: artwork is a **first-class, default-on concern** of a conversion
+    pipeline, not an incidental stream. beets ships `embed: yes` as the default
+    for transcoded items, plus a separate `copy_album_art` for the album-level
+    case. The lesson for this project is the stance: a converter that touches
+    music has to *decide* about artwork explicitly. Phases 3 and 5 both hit the
+    consequence of not deciding — a picture stream that is silently dropped, or
+    silently truncated to one frame.
+  - AVOID: the mechanism and the surface. beets embeds through a tag library
+    (`mediafile`), which here would be a second runtime dependency and is ruled
+    out by `docs/vision.md`. Its `album_art_maxwidth` downscaling is an asset
+    tuning surface, an explicit non-goal. This project can only do it through
+    ffmpeg's own disposition, or not at all.
+
+### ffprobe's `stream_disposition` (measured, not searched)
+
+- Path: `ffprobe -show_entries stream=...:stream_disposition=attached_pic`
+- License: LGPL-2.1-or-later / GPL-2.0-or-later
+- Verdict: reuse — this is the whole mechanism
+- Date: 2026-08-26
+- Notes:
+  - ADOPT: one probe query returns the disposition alongside the fields
+    `probe_streams` already asks for. Measured on ffmpeg 9.0: an MP3 with cover
+    art yields `0,mp3,audio,0` and `1,png,video,1`; a plain h264 file yields
+    `0,h264,video,0`. So the cost is one extra `-show_entries` clause, one field
+    on `Stream`, and one branch in the engine — materially cheaper than the
+    "engine change" framing `docs/specs/spec-audio-formats.md` recorded when the
+    idea was first deferred.
+  - AVOID: inferring artwork from the codec name. `mjpeg` and `png` are the codecs
+    of both a cover picture and a real video stream, which is exactly why `m4a`
+    hard-fails on one and silently truncates the other (measured in phase 3).
+    Disposition is the only honest discriminator.
+
+### bhemsen/converter (this codebase)
+
+- Path: `converter/ffmpegtool.py` (`Stream`, `probe_streams`), `converter/jobs.py`
+- License: MIT
+- Verdict: reuse — the gap is named, the shape is known
+- Date: 2026-08-26
+- Notes:
+  - ADOPT: the deferral is already documented with its cost, in
+    `docs/specs/spec-audio-formats.md`'s "Two roadmap candidates this phase
+    deliberately does not take". This phase cashes it in rather than rediscovering
+    it.
+  - AVOID: re-opening the phase-3 gate decision. Audio profiles currently drop
+    every video stream and say so in a standing note; once disposition exists, the
+    note narrows rather than disappears — a real video stream under `--to mp3` is
+    still dropped, and still has to be named.
+
+## Generation-loss advisories (Phase 7)
+
+### Curated codec data, reused from Phase 1's concern
+
+- Path: `docs/prior-art.md#containercodec-capability-modelling-phase-1`
+- License: n/a — a method, not a source
+- Verdict: reuse the method
+- Date: 2026-08-26
+- Notes:
+  - ADOPT: a lossy-codec set is the same kind of artifact as a copy mask —
+    curated by hand, because `ffmpeg -codecs` reports what a build contains and
+    never a judgement about it. The Phase 1 concern already argues this and the
+    argument transfers unchanged.
+  - AVOID: deriving lossiness from ffmpeg. There is no flag that answers it, and
+    guessing from the codec name would misfile the awkward cases (`alac` and
+    `flac` are lossless, `wmalossless` and `truehd` are too).
+  - **Not researched.** The sparring deliberately chose research mode `none` for
+    this idea, on the grounds that the method is already settled by the concern
+    above. What was therefore *not* checked is whether any comparable converter
+    warns about generation loss at all, and whether a maintained lossy-codec list
+    exists to adopt instead of curating one. That gap is this entry's known
+    weakness; the phase's `/loopkit:plan` cycle may close it before committing to
+    a hand-curated set.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,10 +16,18 @@
 | 3 | audio-formats | [spec-audio-formats.md](specs/spec-audio-formats.md) | [#3](https://github.com/bhemsen/converter/milestone/3) |
 | 4 | video-formats | [spec-video-formats.md](specs/spec-video-formats.md) | [#4](https://github.com/bhemsen/converter/milestone/4) |
 | 5 | image-formats | [spec-image-formats.md](specs/spec-image-formats.md) | [#5](https://github.com/bhemsen/converter/milestone/5) |
+| 6 | stream-disposition | — | — |
+| 7 | lossy-source-notes | — | — |
 
 A phase gets a Spec link once `/plan` drafts it, and a Milestone link once the
 spec is merged. The milestone (open/closed + issue progress) is where status
 lives.
+
+Foundation impact, recorded at seeding and authored in that phase's `/plan` spec
+PR — never edited here:
+
+- Phase 6 — Foundation impact: vision — none; constitution — none; architecture — yes: Key flow 2's per-stream match gains a disposition branch, and `docs/design/stream-decision.md` gains the node that distinguishes a picture from a video stream.
+- Phase 7 — Foundation impact: vision — none; constitution — yes: the notes convention and its test gate assume a note describes what *this* conversion gave up, and an advisory about loss the source already carried is a second kind that has to be defined; architecture — yes: a lossy-codec set is cross-cutting data, and `converter/profiles.py` is currently described as holding one profile per target format.
 
 ## What each phase covers
 
@@ -37,6 +45,17 @@ lives.
 4. **video-formats** — Profiles for `mp4`, `mkv`, `webm`, `mov`.
 5. **image-formats** — Profiles for `png`, `jpg`, `webp`, `avif`, `gif`, `tiff`,
    `bmp`.
+6. **stream-disposition** — Teach the engine to tell a cover picture from a real
+   video stream: a `disposition` field on `Stream`, the matching `-show_entries`
+   clause in `ffmpegtool.py`, and the branch that uses it. Then `mp3`, `m4a` and
+   `flac` carry artwork through instead of dropping it, and their standing note
+   narrows to the case that is still a real loss. Measured cost: one probe field,
+   one dataclass field, one branch — materially less than the "engine change"
+   framing under which phase 3 deferred it.
+7. **lossy-source-notes** — A curated set of lossy codecs, so converting an
+   already-lossy source into a lossless target says so: the "40 MB FLAC from a
+   128 kbit/s MP3" advisory. Deferred out of phase 3 because `Stream` carries no
+   such notion and that phase was deliberately data-only.
 
 ## Sequencing rationale
 
@@ -50,6 +69,13 @@ before the harder video cases.
 Phases 3, 4 and 5 depend only on phase 2, not on each other, so their milestones
 can run as parallel orchestrators. That independence is recorded as the
 `Depends on milestone:` line in each milestone description.
+
+Phases 6 and 7 both follow phase 3: each revisits audio profiles that phase 3
+creates, and neither is worth planning before those exist. They are independent
+of each other and of phases 4 and 5. Both were deferred out of phase 3 by name,
+with their costs recorded in `docs/specs/spec-audio-formats.md` rather than left
+to be rediscovered — and phase 6's cost turned out to be smaller than that
+deferral assumed.
 
 There is deliberately no separate release or documentation phase. README changes
 belong to the phase that makes them necessary — phase 2 breaks the CLI, so phase 2


### PR DESCRIPTION
Seeds two roadmap phases from the candidates phase 3's spec deferred by name, each with a backing prior-art concern.

**Phase 6 — stream-disposition.** The sparring sharpened this one materially: a single ffprobe query returns the disposition alongside the fields `probe_streams` already asks for (measured — `1,png,video,1` for cover art, `0,h264,video,0` for a real video). So the cost is one probe field, one dataclass field and one branch, not the engine change the phase-3 deferral implied.

**Phase 7 — lossy-source-notes.** A curated lossy-codec set so a re-encode into a lossless target can say the source was already lossy.

Prior art: beets' `convert` plugin is recorded as the **stance** to adopt (artwork is a first-class, default-on concern of a conversion pipeline) and the **mechanism** to avoid (it embeds via a tag library, which here would be a second runtime dependency). ffprobe's `stream_disposition` is the reuse. Phase 7 leans on phase 1's curated-data concern for its method.

Phase 7 is seeded **honestly unbacked on one axis**: research mode `none` was chosen for it, so whether any comparable converter warns about generation loss — and whether a maintained lossy-codec list exists to adopt — was not checked. That gap is written into the entry rather than glossed over, and its `/loopkit:plan` cycle may close it.

Foundation impact is recorded per phase on the roadmap and authored later in each phase's spec PR, never here.
