### PR TITLE
fix(batch): verify a structurally partial cheap attempt on success

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,11 @@ least one file failed, and `2` for a usage error or a missing ffmpeg.
 1. **Remux first.** Video, audio and text subtitles are stream-copied into MP4
    (`-c copy`, subtitles to `mov_text`). Nothing is re-encoded, so there is no
    quality loss and it runs at disk speed. MKV attachments (such as fonts for ASS
-   subtitles) and data streams are dropped, because MP4 cannot hold them.
-2. **If that fails, look at the file.** `ffprobe` reports the streams, and each
+   subtitles) and data streams are dropped, because MP4 cannot hold them — and
+   because that mapping cannot carry them whatever the file turns out to hold,
+   a successful remux still spends one `ffprobe` call to name each stream it left
+   behind, rather than reporting a plain success.
+2. **If that fails, look at the file instead.** `ffprobe` reports the streams, and each
    one is handled individually: compatible streams are still copied, incompatible
    audio or video is re-encoded, and bitmap subtitles (PGS, VobSub) are dropped.
 3. **As a last resort, re-encode.** One video and all audio streams to

--- a/converter/batch.py
+++ b/converter/batch.py
@@ -66,6 +66,25 @@ def _discard_partial_output(dst: Path, *, existed: bool) -> None:
         dst.unlink(missing_ok=True)
 
 
+def _verify_cheap_attempt(job: Job, task: Task, tools: Tools) -> tuple[str, ...]:
+    """Name whatever a structurally partial cheap attempt left behind.
+
+    The one place ffprobe runs after an attempt has *succeeded*. A job whose
+    cheap attempt maps the source exhaustively declares no verifier and never
+    gets here, so the common case keeps its probe-free happy path
+    (``docs/design/degradation-ladder.md``).
+    """
+    if job.verify_success is None:
+        return ()
+    try:
+        streams = ffmpegtool.probe_streams(tools, task.src)
+    except ProbeError as exc:
+        # A run whose completeness could not be established must not read as a
+        # plain success either (``docs/constitution.md``).
+        return (f"could not verify which source streams were kept: {exc}",)
+    return job.verify_success(streams)
+
+
 def _attempt_conversion(job: Job, task: Task, tools: Tools, *, overwrite: bool) -> Result:
     existed = task.dst.exists()
     if existed and not overwrite:
@@ -84,7 +103,11 @@ def _attempt_conversion(job: Job, task: Task, tools: Tools, *, overwrite: bool) 
         argv = ffmpegtool.build_argv(tools.ffmpeg, task.src, attempt.options, task.dst)
         result = ffmpegtool.run(argv)
         if result.ok:
-            return Result(task, Outcome.CONVERTED, attempt.label, attempt.notes)
+            # `probed` still being false means this was the cheap attempt: every
+            # later rung was built from the stream list itself and already
+            # carries accurate notes, so only this one needs verifying.
+            extra = () if probed else _verify_cheap_attempt(job, task, tools)
+            return Result(task, Outcome.CONVERTED, attempt.label, (*attempt.notes, *extra))
 
         errors.append(f"[{attempt.label}] {result.stderr or f'exit code {result.returncode}'}")
         if not probed:

--- a/converter/ffmpegtool.py
+++ b/converter/ffmpegtool.py
@@ -194,8 +194,10 @@ def version(tools: Tools) -> str:
 def probe_streams(tools: Tools, src: str | os.PathLike[str]) -> list[Stream]:
     """List the elementary streams of *src*.
 
-    Only called after a stream-copy attempt has already failed, so the ffprobe
-    round-trip is never on the happy path.
+    Called at most once per file, and never for a cheap attempt whose mapping is
+    exhaustive: either after an attempt has failed, or -- when the profile
+    declares its cheap attempt partial by construction -- to name what that
+    attempt could not carry (``docs/design/degradation-ladder.md``).
     """
     result = run(
         [

--- a/converter/jobs.py
+++ b/converter/jobs.py
@@ -24,7 +24,14 @@ from converter.profiles import MP4, WAV, Attempt, Profile
 
 @dataclass(frozen=True)
 class Job:
-    """A source suffix, a target suffix, and how to get from one to the other."""
+    """A source suffix, a target suffix, and how to get from one to the other.
+
+    ``verify_success`` turns the source's stream list into the notes the *cheap*
+    attempt owes once it has already succeeded, and is ``None`` for a cheap
+    attempt whose mapping is exhaustive -- which is how ``batch.py`` knows
+    whether that success is worth an ffprobe round-trip at all
+    (``docs/design/degradation-ladder.md``).
+    """
 
     name: str
     description: str
@@ -32,6 +39,9 @@ class Job:
     target_suffix: str
     first_attempt: Callable[[], Attempt] = field(repr=False)
     retries: Callable[[Sequence[Stream]], list[Attempt]] = field(repr=False)
+    verify_success: Callable[[Sequence[Stream]], tuple[str, ...]] | None = field(
+        default=None, repr=False
+    )
 
 
 def _with_container_options(attempt: Attempt, profile: Profile) -> Attempt:
@@ -69,6 +79,43 @@ def _room_reason(profile: Profile, stream_type: str, limit: int) -> str:
     return f"{profile.label} holds {limit} {stream_type} {noun}"
 
 
+def _structural_drop(profile: Profile, stream: Stream, counts: dict[str, int]) -> str | None:
+    """D1 and D2 of stream-decision.md: the drops the profile's *shape* forces.
+
+    Split out because both verdicts are reached from the declared rules alone,
+    without ever looking at the stream's codec. That is what lets the
+    success-side verification in :func:`_unmapped_notes` reuse them without
+    asserting anything about what an already-successful attempt encoded.
+    """
+    rule = profile.rules.get(stream.codec_type)
+    if rule is None:
+        return _drop_note(stream, f"not supported by {profile.label}")
+
+    position = counts.get(stream.codec_type, 0)
+    if rule.stream_limit is not None and position >= rule.stream_limit:
+        return _drop_note(stream, _room_reason(profile, stream.codec_type, rule.stream_limit))
+    return None
+
+
+def _unmapped_notes(profile: Profile, streams: Sequence[Stream]) -> tuple[str, ...]:
+    """Name what a structurally partial cheap attempt cannot have carried over.
+
+    Only the structural verdicts above are consulted. Codec-level ones are
+    deliberately left out: the cheap attempt has already exited 0, so whatever
+    it did with a stream's codec worked, and announcing a re-encode it never
+    performed would just swap one dishonest report for another.
+    """
+    notes: list[str] = []
+    counts: dict[str, int] = {}
+    for stream in streams:
+        note = _structural_drop(profile, stream, counts)
+        if note is None:
+            counts[stream.codec_type] = counts.get(stream.codec_type, 0) + 1
+        else:
+            notes.append(note)
+    return tuple(notes)
+
+
 def _decide_stream(
     profile: Profile, stream: Stream, counts: dict[str, int]
 ) -> tuple[list[str], list[str], str | None]:
@@ -78,15 +125,12 @@ def _decide_stream(
     produces (or ``None``). ``counts`` is mutated so later streams see how many
     output streams of their type already exist.
     """
-    rule = profile.rules.get(stream.codec_type)
-    if rule is None:
-        return [], [], _drop_note(stream, f"not supported by {profile.label}")
+    structural = _structural_drop(profile, stream, counts)
+    if structural is not None:
+        return [], [], structural
 
+    rule = profile.rules[stream.codec_type]
     position = counts.get(stream.codec_type, 0)
-    if rule.stream_limit is not None and position >= rule.stream_limit:
-        reason = _room_reason(profile, stream.codec_type, rule.stream_limit)
-        return [], [], _drop_note(stream, reason)
-
     maps = ["-map", f"0:{stream.index}"]
     if stream.codec_name in rule.copy_mask:
         codecs = list(_substitute_position(rule.accept_options, position))
@@ -148,6 +192,22 @@ def make_attempts(
     return first_attempt, retries
 
 
+def make_verifier(profile: Profile) -> Callable[[Sequence[Stream]], tuple[str, ...]] | None:
+    """Build the success-side verifier of degradation-ladder.md, if one is owed.
+
+    A profile whose cheap attempt maps the source exhaustively gets ``None``, and
+    its happy path then still costs no ffprobe round-trip -- the narrowed form of
+    the rule in ``docs/constitution.md``.
+    """
+    if not profile.partial_mapping:
+        return None
+
+    def verify(streams: Sequence[Stream]) -> tuple[str, ...]:
+        return _unmapped_notes(profile, streams)
+
+    return verify
+
+
 @dataclass(frozen=True)
 class _Binding:
     """A source-pair binding: CLI-visible name plus which suffixes feed which
@@ -189,6 +249,7 @@ def _job_from_binding(binding: _Binding) -> Job:
         target_suffix=binding.profile.target_suffix,
         first_attempt=first_attempt,
         retries=retries,
+        verify_success=make_verifier(binding.profile),
     )
 
 

--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -64,6 +64,14 @@ class Profile:
     by index (WAV's ``-map 0:a:0``) rather than blindly by type (MP4's
     ``-map 0:v?``) -- the one fact the engine cannot derive without parsing
     ffmpeg's own option syntax, per ``docs/design/degradation-ladder.md``.
+
+    ``partial_mapping`` says whether ``cheap_attempt``'s mapping can, *by
+    construction*, leave source streams unmapped. It is declared for the same
+    reason ``explicit_streams`` is: deriving it would mean parsing the option
+    list. A profile that declares it true is verified by an ffprobe round-trip
+    even when its cheap attempt exits 0, so a stream that attempt silently left
+    behind is named rather than reported as a plain success
+    (``docs/design/degradation-ladder.md``).
     """
 
     label: str
@@ -71,6 +79,7 @@ class Profile:
     container_options: tuple[str, ...]
     cheap_attempt: Attempt
     explicit_streams: bool
+    partial_mapping: bool
     rules: dict[str, StreamRule]
     last_resort: Attempt | None = None
 
@@ -97,6 +106,10 @@ MP4 = Profile(
         options=flags("-map 0:v? -map 0:a? -map 0:s? -c copy -c:s mov_text"),
     ),
     explicit_streams=False,
+    # The same "?" selectors that make the remux survivable also make it
+    # incomplete: nothing selects attachments or data streams, so a source
+    # carrying either loses it without ffmpeg ever complaining.
+    partial_mapping=True,
     rules={
         "video": StreamRule(
             copy_mask=MP4_VIDEO_CODECS,
@@ -141,6 +154,9 @@ WAV = Profile(
     # predictably instead of quietly depending on which one ffmpeg prefers.
     cheap_attempt=Attempt(label="pcm_s16le", options=flags("-map 0:a:0 -c:a pcm_s16le")),
     explicit_streams=True,
+    # One index is named and nothing else is, so every further stream the
+    # source carries -- a second audio track, cover art -- is left behind.
+    partial_mapping=True,
     rules={
         "audio": StreamRule(
             # Empty by construction: WAV holds nothing as-is, only PCM.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,8 +11,8 @@ Everything else exists today.
 | Component | Responsibility |
 | --------- | -------------- |
 | `converter/cli.py` | Argument parsing, target-format selection, the interactive prompt, usage errors, exit codes |
-| `converter/profiles.py` | One declarative profile per target format: the copy mask, the fallback encoder and the drop reason per stream type, the container flags, and the cheap and last-resort attempts the format declares as data |
-| `converter/jobs.py` | The generic conversion engine: turns a profile plus a probed stream list into an ordered ladder of attempts. It owns the *order* of the rungs and how the selective rung is built; the profiles own what each declared rung contains |
+| `converter/profiles.py` | One declarative profile per target format: the copy mask, the fallback encoder and the drop reason per stream type, the container flags, the cheap and last-resort attempts the format declares as data, and whether that cheap attempt's mapping is partial by construction |
+| `converter/jobs.py` | The generic conversion engine: turns a profile plus a probed stream list into an ordered ladder of attempts, and into the notes a *successful* partial cheap attempt owes. It owns the *order* of the rungs and how the selective rung is built; the profiles own what each declared rung contains |
 | `converter/batch.py` | Bounded parallel execution, the per-file outcome, progress reporting, the aggregate summary and the process exit code |
 | `converter/paths.py` | Input discovery, output-path construction, tree mirroring, collision detection, Windows path-length diagnosis |
 | `converter/ffmpegtool.py` | Locating ffmpeg and ffprobe, building argv, running without a shell, probing streams |
@@ -50,7 +50,15 @@ The internal import graph is acyclic today and must stay that way:
    `paths.find_sources` collects the inputs, `paths.find_collisions` refuses up
    front if two inputs would write to the same output, then `batch.run_batch`
    runs the profile's cheapest attempt per file through the engine in `jobs.py`.
-   On success nothing else happens — no ffprobe round-trip is ever spent.
+   On success nothing else happens — no ffprobe round-trip is ever spent —
+   *provided* that attempt's mapping is exhaustive. A profile that declares its
+   cheap attempt **partial by construction** (`partial_mapping`: MP4's blind
+   `?`-selectors reach no attachment, WAV's single index reaches no second audio
+   stream) spends one probe on success too, and every source stream that mapping
+   could not carry becomes a note. The verification reads the profile's
+   *structural* verdicts only — whether it declares a rule for the stream's type,
+   and how many streams of that type it holds — never a codec-level one: the
+   attempt exited 0, so what it did with a codec worked.
 2. **Degradation.** The attempt exits non-zero, so *now* `ffmpegtool.probe_streams`
    describes the file. The engine matches each stream against the profile's copy
    mask: streams the mask accepts pass through unchanged — as a literal `copy`, or

--- a/docs/constitution.md
+++ b/docs/constitution.md
@@ -26,8 +26,13 @@
 - Maximum 50 lines per function.
 - Every function parameter and every return value carries a type annotation.
 - Every module has a module docstring.
-- `ffprobe` never runs on the happy path — only after a conversion attempt has
-  actually failed.
+- `ffprobe` never runs on the happy path of a cheap attempt whose mapping is
+  *exhaustive* — for that attempt it runs only after a conversion attempt has
+  actually failed. A cheap attempt that is **partial by construction** — one
+  whose mapping can leave source streams unmapped, and which says so as a
+  declared field on its profile — is probed once even when it succeeds, so that
+  what it dropped is named rather than reported as a plain success. Either way,
+  at most one probe per file.
 - A target format is data, not code: adding one must produce no diff in
   `cli.py`, `batch.py` or `paths.py`.
 - One broken input file must not abort the batch.

--- a/docs/design.md
+++ b/docs/design.md
@@ -116,7 +116,11 @@ Instead of UI components, these are the rules a diagram in this project follows.
   engine is generic. A diagram that takes the generic form says so in its header.
 - **Cost markers** — any node that spends a subprocess call says so
   (`ffprobe`, `ffmpeg`). The point of the ladder is that ffprobe stays off the
-  happy path, and a diagram that hides where processes start defeats that.
+  happy path of an *exhaustive* cheap attempt, and that the one exception — a
+  cheap attempt the profile declares partial by construction, which is probed
+  once even on success so its silent drops get named — is visible as its own
+  node on the success side. A diagram that hides where processes start defeats
+  both halves of that.
 
 ## Do's and Don'ts
 

--- a/docs/design/degradation-ladder.md
+++ b/docs/design/degradation-ladder.md
@@ -8,20 +8,26 @@
 
 In which order the engine tries to produce one output file, where a subprocess is
 spent, and which conditions move it down a rung. The point of the ladder is that
-`ffprobe` never runs on the happy path (`docs/constitution.md`), so every node
-that costs a process call is marked.
+`ffprobe` stays off the happy path of an *exhaustive* cheap attempt
+(`docs/constitution.md`), so every node that costs a process call is marked —
+including the one node on the success side, which only a cheap attempt the
+profile declares *partial by construction* ever reaches.
 
 ```mermaid
 flowchart TD
     A["Attempt 1 — the profile's cheap attempt<br/>(ffmpeg)"]
-    P["describe the source's streams<br/>(ffprobe — first and only probe)"]
+    V["verify what that mapping could carry<br/>(ffprobe — the only probe on the success side)"]
+    P["describe the source's streams<br/>(ffprobe — the only probe on the failure side)"]
     PLAN["build the selective plan<br/>(no subprocess — see stream-decision.md)"]
     SEL["Attempt 2 — selective<br/>(ffmpeg)"]
     FIN["Attempt 3 — the profile's last-resort attempt<br/>(ffmpeg; a profile may declare none)"]
     OK["converted — the winning attempt's notes are reported"]
     BAD["failed — partial output removed, ffmpeg's stderr kept per rung"]
 
-    A -->|"exit 0"| OK
+    A -->|"exit 0, and the profile declares the mapping exhaustive"| OK
+    A -->|"exit 0, and the profile declares the mapping partial"| V
+    V -->|"stream list — plus a note per source stream<br/>the mapping could not carry"| OK
+    V -->|"probe failed — plus a note that the run is unverified,<br/>so it is not a plain success"| OK
     A -->|"exit != 0"| P
     P -->|"probe failed"| BAD
     P -->|"stream list"| PLAN
@@ -36,9 +42,23 @@ flowchart TD
 
 ## Rules the diagram encodes
 
-- **One probe per file, never on the happy path.** The `ffprobe` node sits behind
-  the first non-zero exit and is reached at most once; every later rung reuses the
-  same stream list.
+- **At most one probe per file, and none for an exhaustive cheap attempt.** The
+  failure-side `ffprobe` node sits behind the first non-zero exit and is reached
+  at most once; every later rung reuses the same stream list. The success-side
+  node is reached only when the profile declares its cheap attempt *partial by
+  construction*. The two are mutually exclusive — a file takes one path or the
+  other — so no file is ever probed twice.
+- **A partial cheap attempt's success is verified, not assumed.** A mapping is
+  partial by construction when it can leave source streams unmapped whatever the
+  source turns out to contain: MP4's `-map 0:v? -map 0:a? -map 0:s?` selects no
+  attachment and no data stream, WAV's `-map 0:a:0` selects no second audio
+  stream. The profile declares this as data, exactly as it declares whether the
+  attempt is stream-explicit — the engine never parses an option list to find
+  out. The verification consults only the *structural* verdicts of
+  `stream-decision.md` — is there a rule for this stream's type, and is the
+  container already holding as many of that type as it can — never a codec-level
+  one: ffmpeg exited 0, so whatever the attempt did with a codec worked, and
+  naming a re-encode that never ran would trade one dishonest report for another.
 - **Cheapest first.** Rung 1 is whatever the profile declares as its cheap attempt:
   a *blind* stream copy for a container that can hold the source codecs
   (`-map 0:v? -map 0:a? ...`), or a *stream-explicit* selection where it cannot
@@ -54,7 +74,10 @@ flowchart TD
   re-encode declares one; a container with nothing further to give up (WAV) does
   not, and a failure at the rung before it is then the end of the ladder.
 - **Every rung carries its own notes.** The notes of the attempt that actually
-  succeeded are what the batch reports — the discarded rungs' notes are not.
+  succeeded are what the batch reports — the discarded rungs' notes are not. Only
+  the cheap attempt's notes are ever added to, and only by the verification node
+  above it; a later rung was built from the stream list itself, so its notes are
+  already complete and it is never verified a second time.
 - **Container-wide options are appended by the engine, once, at the end of every
   attempt.** The profile declares them in one place instead of repeating them in
   each attempt it declares.

--- a/docs/design/degradation-ladder.md
+++ b/docs/design/degradation-ladder.md
@@ -59,6 +59,24 @@ flowchart TD
   container already holding as many of that type as it can — never a codec-level
   one: ffmpeg exited 0, so whatever the attempt did with a codec worked, and
   naming a re-encode that never ran would trade one dishonest report for another.
+- **What a partial profile owes in exchange.** Reading the declared rules instead
+  of the option list is sound only while the rules and the mapping agree, so a
+  profile that sets `partial_mapping` must satisfy both halves of this. A new
+  profile that cannot is the bug — not the verification.
+  1. **A rule for every stream type its cheap attempt maps.** Otherwise the
+     verification announces a drop that never happened. A profile that carries
+     attachments with `-map 0:t?` has to declare an `attachment` rule, or every
+     font it faithfully copied is reported as lost.
+  2. **No `stream_limit` on a type its cheap attempt selects blindly.** A blind
+     `-map 0:a?` maps *every* audio stream, so a limit the mapping does not
+     enforce would have the verification report surplus streams the output does
+     contain. A limit belongs to a type the cheap attempt names by index (WAV's
+     `-map 0:a:0`) or does not map at all.
+
+  The two shipped profiles satisfy both by construction — MP4's selectors match
+  its three rules exactly and it declares no limit, WAV names one audio index and
+  limits audio to 1 — and `tests/test_profiles.py` checks the pair per profile
+  rather than leaving it to review.
 - **Cheapest first.** Rung 1 is whatever the profile declares as its cheap attempt:
   a *blind* stream copy for a container that can hold the source codecs
   (`-map 0:v? -map 0:a? ...`), or a *stream-explicit* selection where it cannot

--- a/docs/design/source-selection.md
+++ b/docs/design/source-selection.md
@@ -122,6 +122,10 @@ flowchart TD
   evidence the vision promises. A `.txt`, or a file inside the output tree, is not,
   because counting everything a directory happens to hold means nothing.
 - **Selection cannot tell whether a source can *produce* the target.** Whether a
-  video-only file has audio to put in a WAV is only knowable from a probe, and a
-  probe on the happy path is forbidden. That question belongs to the ladder, not
-  here — see `degradation-ladder.md` and the spec that owns the outcome it ends in.
+  video-only file has audio to put in a WAV is only knowable from a probe, and
+  selection has no probe to spend: the one the ladder may now spend on a
+  partial cheap attempt's success (`degradation-ladder.md`, narrowed by issue
+  #18) happens after an attempt has already run, which is far too late to
+  decide whether the file was a candidate. That question belongs to the
+  ladder, not here — see `degradation-ladder.md` and the spec that owns the
+  outcome it ends in.

--- a/docs/design/stream-decision.md
+++ b/docs/design/stream-decision.md
@@ -51,6 +51,10 @@ flowchart TD
 - **Every note names three things:** the stream index, that stream's codec, and
   what was given up (`docs/vision.md`). A note that omits one of them is a review
   finding. A stream with no codec name reported by ffprobe reads as `unknown`.
+  The one note that names no stream is the ladder's *unverified-run* note, which
+  exists precisely because no stream list could be obtained
+  (`degradation-ladder.md`); it reports the absence of the facts this rule
+  demands, and is not a per-stream verdict at all.
 - **A re-encode that gives up nothing carries no note.** Decoding to a container's
   only codec is the definition of that target format, not a loss — WAV's PCM rule
   declares no note, MP4's `aac` and `h264` fallbacks do. Whether the note exists

--- a/docs/prior-art.md
+++ b/docs/prior-art.md
@@ -81,8 +81,11 @@ evidenced, not assumed — see the image-conversion concern.
 - Notes:
   - ADOPT: trial-and-fallback. Attempt the cheap stream copy first; only on a
     non-zero exit spend an ffprobe round-trip and degrade deliberately
-    (`mp4_remux` to `_mp4_selective` to `mp4_reencode`). ffprobe never runs on the
-    happy path. Combined with HandBrake's copy mask this gets both: the mask
+    (`mp4_remux` to `_mp4_selective` to `mp4_reencode`). ffprobe never runs on
+    the happy path of an *exhaustive* cheap attempt — issue #18 narrowed this
+    to admit one probe on the success of a mapping that is partial by
+    construction, which is what keeps the loss accounting honest.
+    Combined with HandBrake's copy mask this gets both: the mask
     PREDICTS a doomed attempt, trial-and-fallback remains the safety net for what
     the mask gets wrong.
   - AVOID: writing the ladder per format pair. `mp4_retries` and `wav_retries` are

--- a/docs/specs/spec-audio-formats.md
+++ b/docs/specs/spec-audio-formats.md
@@ -70,9 +70,16 @@ merged.** Everything this phase builds on — the `PROFILES` registry, `name` an
 - A target format is data, not code (`docs/constitution.md`,
   `docs/architecture.md`): `converter/profiles.py` stays a leaf, and this phase's
   diff proves the rule rather than asserting it.
-- `ffprobe` never runs on the happy path. This is what bounds how precise a note
-  can be for a conversion the cheap attempt completes — see the two open
-  decisions.
+- `ffprobe` never runs on the happy path of a cheap attempt whose mapping is
+  *exhaustive*. Issue #18 narrowed this after the spec was merged: a profile
+  whose cheap attempt is partial by construction declares
+  `partial_mapping=True` and is probed once on its success, so what that
+  mapping could not carry is named. Every cheap attempt in the table below is
+  an `-map 0:a?` / `-map 0:a:0` shape, so every profile in this phase is
+  partial and must declare it -- together with a rule for each stream type it
+  maps, per the invariant in `docs/design/degradation-ladder.md`. This is no
+  longer what bounds how precise a note can be on a completed cheap attempt;
+  see the supersession note on the cover-art decision below.
 - No second external dependency, and no second backend.
 - Never report success for a conversion that silently dropped something.
 - The test suite keeps passing with no ffmpeg installed.
@@ -237,6 +244,35 @@ gate picks:
 to `wav`.** The noise was judged the smaller cost against a silent loss, and
 touching `wav` would have changed a phase-1 note assertion this phase promised to
 leave alone. `wav`'s hole stays open and is now written down.
+
+> **Superseded in part, 2026-08-26 (issue #18).** The premise of this whole
+> decision — "a conversion the cheap attempt completes has **no stream list**" —
+> is no longer true. `docs/constitution.md`'s happy-path rule was narrowed: a
+> cheap attempt that is *partial by construction* is probed once on its success,
+> and every source stream its mapping could not carry is named with its index and
+> codec. Two consequences this phase must settle before it implements:
+>
+> - **`wav`'s hole is already closed**, ahead of this spec. `WAV` declares
+>   `partial_mapping=True`, so an `.opus` carrying an `attached_pic` now reports
+>   `video stream 1 (mjpeg) dropped: not supported by WAV` on the success path.
+>   The sentence above saying the hole stays open is obsolete; the phase-1 note
+>   assertion it protected was on `Attempt.notes`, which is untouched — the note
+>   comes from the verification, not from the cheap attempt's data.
+> - **Option 1's standing note is now redundant, and doubles up.** A fixed line
+>   like "non-audio streams, including cover art, are not carried into MP3" would
+>   print *alongside* the verification's precise per-stream note for exactly the
+>   files that lost something, and alone for the majority that lost nothing —
+>   which is the noise cost the gate accepted only because nothing better was
+>   available. Whether to drop the standing note in favour of the verification is
+>   this phase's call to re-take at its own gate, not issue #18's to make; it is
+>   recorded here so the choice is deliberate rather than inherited.
+>
+> The related 2026-08-25 decision row above ("on the happy path the muxer is the
+> authority, not the copy mask") still stands: the verification reads only
+> *structural* verdicts and never a codec-level one, so it still cannot catch a
+> Vorbis stream shipped inside a `.opus`. Only its stated reason — that a probe
+> is forbidden there — has changed to "that probe deliberately does not look at
+> codecs".
 
 ### The opus decision, in full (resolved at the gate)
 

--- a/docs/specs/spec-image-formats.md
+++ b/docs/specs/spec-image-formats.md
@@ -70,7 +70,14 @@ Everything below follows from that table.
 
 - A target format is data, not code.
 - One input file, one output file.
-- `ffprobe` never runs on the happy path.
+- `ffprobe` never runs on the happy path of a cheap attempt whose mapping is
+  *exhaustive*. A profile whose cheap attempt is partial by construction
+  declares `partial_mapping=True` and is probed once on its success, so what
+  that mapping could not carry is named (`docs/constitution.md`, narrowed by
+  issue #18). Every cheap attempt below maps by type, so every profile in
+  this phase is partial and must declare it -- together with a rule for each
+  stream type it maps, per the invariant in
+  `docs/design/degradation-ladder.md`.
 - Never report success for a conversion that silently dropped something.
 - `{n}` is substituted **only** in `StreamRule` templates. `cheap_attempt` and
   `last_resort` are emitted verbatim, so a `{n}` in either reaches ffmpeg

--- a/docs/specs/spec-profile-registry.md
+++ b/docs/specs/spec-profile-registry.md
@@ -76,8 +76,11 @@ and milestone. A completed spec is moved to `docs/specs/archive/`.
   imported.
 - `jobs.py` may import `profiles` and `ffmpegtool`, and nothing else. The import
   graph stays acyclic.
-- `ffprobe` never runs on the happy path (`docs/constitution.md`): the engine
-  probes at most once per file, and only after an attempt has already failed.
+- `ffprobe` never runs on the happy path of an exhaustive cheap attempt
+  (`docs/constitution.md`): the engine probes at most once per file — after an
+  attempt has failed, or, for a cheap attempt the profile declares partial by
+  construction, once on its success so that what it dropped is named. See the
+  2026-08-26 (issue #18) Decision log entry for how that narrowing was reached.
 - Maximum 50 lines per function, every parameter and return annotated, a
   docstring on every module and public function (`docs/constitution.md`).
   `_mp4_selective` is 51 lines today and is listed as tech debt to be cleared by
@@ -197,6 +200,11 @@ Machine checks — Verify is the per-iteration gate (`docs/workflow.md`):
       attempt's own two notes (lossy re-encode; 10-bit/HDR reduced to 8-bit).
 - [ ] A test asserting WAV's PCM conversion emits **no** note — the one re-encode
       that is not a degradation.
+- [ ] A test per symptom of issue #18, driving the *cheap-attempt-succeeds* path
+      rather than calling `.retries()` directly: the dropped attachment and the
+      dropped surplus audio stream are each named on a run that reports
+      `converted`, and an exhaustive cheap attempt still spends no probe on
+      success.
 - [ ] A test per failure-path delta, since the QA gate cannot reach them: the
       engine-built rung is labelled `selective` for WAV too (delta 3), and a WAV
       source carrying a non-audio stream yields exactly one rung that drops it
@@ -363,3 +371,51 @@ why both audio fixtures use that suffix.
   machine-dependent, which contradicts the mask being declarative data
   (`docs/architecture.md`). Not a design fork requiring escalation: the prior-art
   AVOID note and the playability criterion already answer it.
+- 2026-08-26 (issue #18): the `ffprobe`-never-on-the-happy-path rule is
+  **narrowed** rather than kept absolute. `ffprobe` stays off the happy path of a
+  cheap attempt whose mapping is *exhaustive*; a cheap attempt that is
+  **structurally partial** — one whose mapping can by construction leave source
+  streams unmapped (MP4's blind `-map 0:v? -map 0:a? -map 0:s?`, WAV's
+  single-index `-map 0:a:0`) — is verified by a probe **on success**, so a silent
+  drop is never reported as a plain success. Issue #18 escalated this as a design
+  fork because `docs/constitution.md` states both "`ffprobe` never runs on the
+  happy path" and "never report success for a conversion that silently dropped
+  something", and naming a dropped stream's index and codec is only knowable from
+  the source's stream list — parsing ffmpeg's stderr for it being an explicit
+  Don't. Rationale for narrowing: the ladder's cost argument is about the common
+  case, a copyable source converting without a round-trip. Keeping the rule
+  absolute would have forced the two fixture-specific acceptance items
+  (`attached.mkv` naming the `ttf` attachment, `two-tone.opus` naming the second
+  audio stream and its codec) to be relaxed, trading away the loss-accounting USP
+  in `docs/vision.md` to protect a probe on a minority of runs. All four
+  restatements of the old rule moved together — `docs/constitution.md`
+  (Architecture principles), `docs/architecture.md` (Key flows §1),
+  `docs/design.md` (Cost markers), `docs/design/degradation-ladder.md` (the
+  diagram gains a success-side probe node) — plus this spec's Constraints and the
+  `probe_streams` docstring, which restated it a fifth time in code.
+- 2026-08-26 (issue #18): "partial by construction" is a **declared field on the
+  profile** (`Profile.partial_mapping`), with no default, rather than inferred.
+  Inferring it would mean parsing the cheap attempt's option list for `?`
+  selectors and stream indices, which is exactly the ffmpeg-syntax knowledge
+  `docs/design/degradation-ladder.md` keeps out of the engine — the same
+  reasoning that already made `explicit_streams` a declared flag. Omitting the
+  default forces every future target profile to state the answer instead of
+  inheriting a silent one.
+- 2026-08-26 (issue #18): the success-side verification reads only the profile's
+  **structural** verdicts — no rule declared for the stream's type (D1), or the
+  container already holding as many streams of that type as it can (D2) — and
+  never a codec-level one (the D3 no-fallback drop, or a re-encode). Both
+  structural verdicts follow from the declared rules alone, independently of what
+  the source's codecs turned out to be, so they are exactly the drops a
+  structurally partial mapping cannot avoid. A codec-level verdict would be a
+  lie on this path: ffmpeg exited 0, so the stream was carried over whatever the
+  copy mask says, and reporting a re-encode that never ran would trade one
+  dishonest report for another. The shared helper is `_structural_drop` in
+  `converter/jobs.py`, used by both `_decide_stream` and `_unmapped_notes` so the
+  two readings of D1/D2 cannot drift.
+- 2026-08-26 (issue #18): a verification probe that itself fails does not fail the
+  conversion — the output is written and valid — but the run is reported with the
+  note `could not verify which source streams were kept: <error>` instead of as a
+  plain success. Failing an otherwise good conversion because its bookkeeping
+  could not be completed would be worse than the silence being fixed; saying
+  nothing would re-open it.

--- a/docs/specs/spec-profile-registry.md
+++ b/docs/specs/spec-profile-registry.md
@@ -387,12 +387,20 @@ why both audio fixtures use that suffix.
   absolute would have forced the two fixture-specific acceptance items
   (`attached.mkv` naming the `ttf` attachment, `two-tone.opus` naming the second
   audio stream and its codec) to be relaxed, trading away the loss-accounting USP
-  in `docs/vision.md` to protect a probe on a minority of runs. All four
-  restatements of the old rule moved together — `docs/constitution.md`
+  in `docs/vision.md` to protect a probe on a minority of runs. The four
+  restatements the escalation named moved together — `docs/constitution.md`
   (Architecture principles), `docs/architecture.md` (Key flows §1),
   `docs/design.md` (Cost markers), `docs/design/degradation-ladder.md` (the
-  diagram gains a success-side probe node) — plus this spec's Constraints and the
-  `probe_streams` docstring, which restated it a fifth time in code.
+  diagram gains a success-side probe node) — and review found seven more that a
+  grep disproved the completeness of, all amended in the same PR: this spec's
+  Constraints, `converter/ffmpegtool.probe_streams`'s docstring,
+  `docs/design/source-selection.md`, `docs/prior-art.md`'s ADOPT note, the
+  Constraints bullet of each of the three merged coverage specs
+  (`spec-audio-formats.md`, `spec-video-formats.md`, `spec-image-formats.md`),
+  and `spec-target-driven-cli.md`'s mixed-tree decision. The phase-3 cover-art
+  decision, whose premise this narrowing invalidates outright, carries a
+  supersession note rather than a re-decision — that choice is phase 3's to
+  re-take at its own gate.
 - 2026-08-26 (issue #18): "partial by construction" is a **declared field on the
   profile** (`Profile.partial_mapping`), with no default, rather than inferred.
   Inferring it would mean parsing the cheap attempt's option list for `?`

--- a/docs/specs/spec-target-driven-cli.md
+++ b/docs/specs/spec-target-driven-cli.md
@@ -149,7 +149,9 @@ milestone. A completed spec is moved to `docs/specs/archive/`.
 ### The mixed-tree decision, in full
 
 Selection cannot know whether a source *can* produce the target: that needs a
-probe, and a probe on the happy path is forbidden. So under `--to wav`, a
+probe before any attempt runs, and selection has none to spend — the
+success-side probe issue #18 added to the ladder happens only *after* an
+attempt has succeeded, so it cannot inform selection. So under `--to wav`, a
 video-only `.mkv` is selected, its attempt fails, the probe finds no audio, the
 selective rung has no streams to map, WAV declares no last-resort rung — and the
 file lands as `failed`, exit 1. Pointing `--to wav` at any mixed tree therefore

--- a/docs/specs/spec-video-formats.md
+++ b/docs/specs/spec-video-formats.md
@@ -64,7 +64,16 @@ orchestrators (`docs/workflow.md`).
   it turns a remuxable file into a failure. Measured: `-map 0 -c copy` of a
   timecode-bearing MOV into MKV exits 127 with "Only audio, video, and subtitles
   are supported for Matroska". Every cheap attempt selects by type.
-- `ffprobe` never runs on the happy path.
+- `ffprobe` never runs on the happy path of a cheap attempt whose mapping is
+  *exhaustive*. A profile whose cheap attempt is partial by construction
+  declares `partial_mapping=True` and is probed once on its success, so what
+  that mapping could not carry is named (`docs/constitution.md`, narrowed by
+  issue #18). Every cheap attempt in the table below selects by type or by
+  index, so every profile in this phase is partial and must declare it --
+  together with a rule for each stream type it maps, per the invariant in
+  `docs/design/degradation-ladder.md`. `mkv`'s `-map 0:t?` is the case to
+  watch: it carries attachments, so the profile owes an `attachment` rule or
+  the fonts it keeps get reported as dropped.
 - Never report success for a conversion that silently dropped something.
 - The test suite keeps passing with no ffmpeg installed.
 

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -451,6 +451,17 @@ class TestSuccessSideVerification:
 
         assert notes == ("audio stream 1 (opus) dropped: WAV holds 1 audio stream",)
 
+    @pytest.mark.parametrize("profile", [MP4, WAV], ids=lambda profile: profile.label)
+    def test_no_profile_invents_a_loss_for_a_source_it_fully_maps(self, profile):
+        """One stream of each type the profile declares a rule for, and never more
+        than one, so nothing in this source can have been left behind."""
+        verify = make_verifier(profile)
+        assert verify is not None
+
+        streams = [Stream(i, kind, "whatever") for i, kind in enumerate(profile.rules)]
+
+        assert verify(streams) == ()
+
     def test_a_codec_outside_the_copy_mask_produces_no_note(self):
         """Codec-level verdicts are out of scope here: the attempt exited 0, so
         the stream was carried over whatever the copy mask says."""

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -1,12 +1,14 @@
 """Tests for the ffmpeg command lines we build, without running ffmpeg."""
 
 import subprocess
+from dataclasses import replace
 
 import pytest
 
 from converter import ffmpegtool
 from converter.ffmpegtool import Stream, build_argv, cli_path
-from converter.jobs import MKV_TO_MP4, OPUS_TO_WAV
+from converter.jobs import MKV_TO_MP4, OPUS_TO_WAV, make_verifier
+from converter.profiles import MP4, WAV
 
 
 def options_of(argv: list[str], src: str, dst: str) -> list[str]:
@@ -420,6 +422,42 @@ class TestProfileArgvPinning:
             "pcm_s16le",
             "out.wav",
         ]
+
+
+class TestSuccessSideVerification:
+    """`make_verifier`: what the engine owes a cheap attempt that already won."""
+
+    def test_a_partial_profile_gets_a_verifier(self):
+        assert make_verifier(MP4) is not None
+        assert make_verifier(WAV) is not None
+
+    def test_an_exhaustive_profile_gets_none(self):
+        """`None` is what keeps the probe off an exhaustive profile's happy path."""
+        assert make_verifier(replace(MP4, partial_mapping=False)) is None
+
+    def test_mp4_names_the_attachment_its_selectors_cannot_reach(self):
+        verify = make_verifier(MP4)
+        assert verify is not None
+
+        notes = verify([Stream(0, "video", "h264"), Stream(1, "attachment", "ttf")])
+
+        assert notes == ("attachment stream 1 (ttf) dropped: not supported by MP4",)
+
+    def test_wav_names_the_audio_stream_its_single_index_cannot_reach(self):
+        verify = make_verifier(WAV)
+        assert verify is not None
+
+        notes = verify([Stream(0, "audio", "opus"), Stream(1, "audio", "opus")])
+
+        assert notes == ("audio stream 1 (opus) dropped: WAV holds 1 audio stream",)
+
+    def test_a_codec_outside_the_copy_mask_produces_no_note(self):
+        """Codec-level verdicts are out of scope here: the attempt exited 0, so
+        the stream was carried over whatever the copy mask says."""
+        verify = make_verifier(MP4)
+        assert verify is not None
+
+        assert verify([Stream(0, "video", "vp8"), Stream(1, "subtitle", "dvd_subtitle")]) == ()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -7,9 +7,39 @@ import pytest
 from converter import batch
 from converter.batch import Outcome, Result, Task, convert_one, run_batch, summarise
 from converter.ffmpegtool import CommandResult, ProbeError, Stream, Tools
-from converter.jobs import MKV_TO_MP4, OPUS_TO_WAV
+from converter.jobs import MKV_TO_MP4, OPUS_TO_WAV, Job, make_attempts, make_verifier
+from converter.profiles import Attempt, Profile, StreamRule, flags
 
 TOOLS = Tools(ffmpeg="ffmpeg", ffprobe="ffprobe")
+
+
+def exhaustive_job() -> Job:
+    """A job whose cheap attempt maps everything its source can carry.
+
+    No shipped profile is exhaustive -- MP4's ``?``-selectors and WAV's single
+    index are both partial by construction -- so the half of the narrowed
+    happy-path rule that keeps an exhaustive cheap attempt probe-free needs a
+    profile of its own before it can be asserted at all.
+    """
+    profile = Profile(
+        label="EXH",
+        target_suffix=".exh",
+        container_options=(),
+        cheap_attempt=Attempt(label="copy-all", options=flags("-c copy")),
+        explicit_streams=False,
+        partial_mapping=False,
+        rules={"video": StreamRule(frozenset({"h264"}), flags("-c:v copy"))},
+    )
+    first_attempt, retries = make_attempts(profile)
+    return Job(
+        name="exhaustive",
+        description="a test double, not a shipped format",
+        suffixes=(".mkv",),
+        target_suffix=profile.target_suffix,
+        first_attempt=first_attempt,
+        retries=retries,
+        verify_success=make_verifier(profile),
+    )
 
 
 @pytest.fixture
@@ -111,16 +141,21 @@ class TestConvertOne:
         assert len(fake_ffmpeg.calls) == 2
         assert any("pcm_s16le" in note for note in result.notes)
 
-    def test_probe_does_not_run_when_the_first_attempt_succeeds(
+    def test_probe_does_not_run_when_an_exhaustive_first_attempt_succeeds(
         self, tmp_path, fake_ffmpeg, monkeypatch
     ):
-        """An ffprobe round-trip per file would be pure waste on the happy path."""
+        """An ffprobe round-trip per file would be pure waste on the happy path.
+
+        The narrowed rule (`docs/constitution.md`): a cheap attempt whose mapping
+        is exhaustive has nothing a probe could reveal, so it never pays for one.
+        """
         task = make_task(tmp_path)
         task.dst.parent.mkdir(parents=True)
         probes = spy_on_probe(monkeypatch, [])
 
-        convert_one(MKV_TO_MP4, task, TOOLS, overwrite=False)
+        result = convert_one(exhaustive_job(), task, TOOLS, overwrite=False)
 
+        assert result.outcome is Outcome.CONVERTED
         assert probes == []
 
     def test_probe_does_run_once_the_first_attempt_fails(self, tmp_path, fake_ffmpeg, monkeypatch):
@@ -191,6 +226,91 @@ class TestConvertOne:
 
         assert result.outcome is Outcome.FAILED
         assert "kaboom" in result.error
+
+
+class TestPartialCheapAttemptVerification:
+    """The success-side probe: a silent drop must never read as a plain success.
+
+    Every test here drives the *cheap-attempt-succeeds* path -- `exit_codes` stays
+    at its default `[0]` -- rather than calling `.retries()` directly, because
+    that path is the one that used to report `converted` with no note at all.
+    """
+
+    def test_a_dropped_attachment_is_named_on_a_successful_remux(self, tmp_path, fake_ffmpeg):
+        task = make_task(tmp_path)
+        task.dst.parent.mkdir(parents=True)
+        fake_ffmpeg.streams = [Stream(0, "video", "h264"), Stream(1, "attachment", "ttf")]
+
+        result = convert_one(MKV_TO_MP4, task, TOOLS, overwrite=False)
+
+        assert result.outcome is Outcome.CONVERTED
+        assert result.attempt == "remux"
+        assert len(fake_ffmpeg.calls) == 1
+        assert result.notes == ("attachment stream 1 (ttf) dropped: not supported by MP4",)
+
+    def test_a_dropped_surplus_audio_stream_is_named_on_a_successful_pcm_run(
+        self, tmp_path, fake_ffmpeg
+    ):
+        src = tmp_path / "two-tone.opus"
+        src.write_bytes(b"data")
+        task = Task(src, tmp_path / "out" / "two-tone.wav")
+        task.dst.parent.mkdir(parents=True)
+        fake_ffmpeg.streams = [Stream(0, "audio", "opus"), Stream(1, "audio", "opus")]
+
+        result = convert_one(OPUS_TO_WAV, task, TOOLS, overwrite=False)
+
+        assert result.outcome is Outcome.CONVERTED
+        assert result.attempt == "pcm_s16le"
+        assert len(fake_ffmpeg.calls) == 1
+        assert result.notes == ("audio stream 1 (opus) dropped: WAV holds 1 audio stream",)
+
+    def test_a_source_the_cheap_attempt_fully_maps_still_gets_no_note(self, tmp_path, fake_ffmpeg):
+        """The probe is spent, but it must not invent a loss that did not happen."""
+        task = make_task(tmp_path)
+        task.dst.parent.mkdir(parents=True)
+        fake_ffmpeg.streams = [Stream(0, "video", "h264"), Stream(1, "audio", "aac")]
+
+        result = convert_one(MKV_TO_MP4, task, TOOLS, overwrite=False)
+
+        assert result.outcome is Outcome.CONVERTED
+        assert result.notes == ()
+
+    def test_a_codec_the_copy_mask_misses_is_not_reported_as_re_encoded(
+        self, tmp_path, fake_ffmpeg
+    ):
+        """ffmpeg exited 0, so it copied the stream; claiming a re-encode that
+        never ran would swap one dishonest report for another."""
+        task = make_task(tmp_path)
+        task.dst.parent.mkdir(parents=True)
+        fake_ffmpeg.streams = [Stream(0, "video", "ffv1")]
+
+        result = convert_one(MKV_TO_MP4, task, TOOLS, overwrite=False)
+
+        assert result.notes == ()
+
+    def test_an_unreadable_source_is_not_reported_as_a_plain_success(self, tmp_path, fake_ffmpeg):
+        task = make_task(tmp_path)
+        task.dst.parent.mkdir(parents=True)
+        fake_ffmpeg.probe_error = "unreadable"
+
+        result = convert_one(MKV_TO_MP4, task, TOOLS, overwrite=False)
+
+        assert result.outcome is Outcome.CONVERTED
+        assert result.notes == ("could not verify which source streams were kept: unreadable",)
+
+    def test_a_later_rung_is_not_verified_a_second_time(self, tmp_path, fake_ffmpeg, monkeypatch):
+        """The selective rung was built from the stream list itself, so its own
+        notes are already accurate and a second probe would buy nothing."""
+        task = make_task(tmp_path)
+        task.dst.parent.mkdir(parents=True)
+        fake_ffmpeg.exit_codes = [1, 0]
+        probes = spy_on_probe(monkeypatch, [Stream(0, "video", "vp8")])
+
+        result = convert_one(MKV_TO_MP4, task, TOOLS, overwrite=False)
+
+        assert result.attempt == "selective"
+        assert len(probes) == 1
+        assert result.notes == ("video stream 0 (vp8) re-encoded to h264",)
 
 
 class TestRunBatch:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -236,16 +236,23 @@ class TestPartialCheapAttemptVerification:
     that path is the one that used to report `converted` with no note at all.
     """
 
-    def test_a_dropped_attachment_is_named_on_a_successful_remux(self, tmp_path, fake_ffmpeg):
+    def test_a_dropped_attachment_is_named_on_a_successful_remux(
+        self, tmp_path, fake_ffmpeg, monkeypatch
+    ):
         task = make_task(tmp_path)
         task.dst.parent.mkdir(parents=True)
-        fake_ffmpeg.streams = [Stream(0, "video", "h264"), Stream(1, "attachment", "ttf")]
+        probes = spy_on_probe(
+            monkeypatch, [Stream(0, "video", "h264"), Stream(1, "attachment", "ttf")]
+        )
 
         result = convert_one(MKV_TO_MP4, task, TOOLS, overwrite=False)
 
         assert result.outcome is Outcome.CONVERTED
         assert result.attempt == "remux"
         assert len(fake_ffmpeg.calls) == 1
+        # The other half of "at most one probe per file": the success side pays
+        # for exactly one, never one per rung and never a second on the way out.
+        assert probes == [task.src]
         assert result.notes == ("attachment stream 1 (ttf) dropped: not supported by MP4",)
 
     def test_a_dropped_surplus_audio_stream_is_named_on_a_successful_pcm_run(

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -54,6 +54,11 @@ class TestMp4Profile:
     def test_cheap_attempt_selects_streams_blindly(self):
         assert MP4.explicit_streams is False
 
+    def test_cheap_attempt_is_declared_partial(self):
+        """`-map 0:v? -map 0:a? -map 0:s?` selects no attachment and no data
+        stream, so a source carrying one loses it without ffmpeg complaining."""
+        assert MP4.partial_mapping is True
+
     def test_last_resort_excludes_container_options_too(self):
         assert MP4.last_resort is not None
         assert MP4.last_resort.label == "re-encode"
@@ -88,6 +93,11 @@ class TestWavProfile:
     def test_cheap_attempt_selects_streams_explicitly(self):
         assert WAV.explicit_streams is True
         assert WAV.cheap_attempt.options == ("-map", "0:a:0", "-c:a", "pcm_s16le")
+
+    def test_cheap_attempt_is_declared_partial(self):
+        """One index is named and nothing else is, so a second audio stream or
+        an embedded cover image is left behind."""
+        assert WAV.partial_mapping is True
 
     def test_declares_no_last_resort(self):
         assert WAV.last_resort is None
@@ -140,6 +150,7 @@ class TestValueTypesAreFrozen:
             "container_options",
             "cheap_attempt",
             "explicit_streams",
+            "partial_mapping",
             "rules",
             "last_resort",
         }

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -3,11 +3,60 @@
 import ast
 import dataclasses
 import inspect
+import itertools
 
 import pytest
 
 from converter import profiles
 from converter.profiles import MP4, WAV, Attempt, Profile, StreamRule, flags
+
+#: ffmpeg's stream-specifier letters, as `docs/design/degradation-ladder.md` uses them.
+MAP_LETTERS = {"v": "video", "a": "audio", "s": "subtitle", "t": "attachment", "d": "data"}
+
+#: Every profile the registry ships. A new one joins the invariant checks here.
+SHIPPED = [MP4, WAV]
+
+
+def mapped_types(profile: Profile) -> dict[str, bool]:
+    """Stream types the cheap attempt maps -> whether it maps them *blindly*.
+
+    Reading the option list is the point here and forbidden in the engine: this
+    check exists precisely to catch a profile whose declared mapping and declared
+    rules disagree, which needs both readings side by side.
+    """
+    options = profile.cheap_attempt.options
+    mapped: dict[str, bool] = {}
+    for flag, value in itertools.pairwise(options):
+        if flag != "-map" or not value.startswith("0:"):
+            continue
+        selector = value[2:].removesuffix("?")
+        letter = selector.split(":")[0]
+        if letter in MAP_LETTERS:
+            # "0:a?" selects every audio stream; "0:a:0" names exactly one.
+            mapped[MAP_LETTERS[letter]] = ":" not in selector
+    return mapped
+
+
+@pytest.mark.parametrize("profile", SHIPPED, ids=lambda profile: profile.label)
+class TestPartialMappingInvariant:
+    """What `degradation-ladder.md` says a `partial_mapping` profile owes.
+
+    The success-side verification reads the declared rules instead of the option
+    list, which is sound only while the two agree. Checked per profile rather
+    than left to review, because the profile that breaks it is by definition one
+    nobody has written yet.
+    """
+
+    def test_every_stream_type_the_cheap_attempt_maps_has_a_rule(self, profile):
+        """Otherwise a stream the attempt faithfully copied is announced as lost."""
+        assert set(mapped_types(profile)) <= set(profile.rules)
+
+    def test_no_blindly_mapped_type_carries_a_stream_limit(self, profile):
+        """A blind selector maps every stream of its type, so a limit it does not
+        enforce would have the verification report drops the output disproves."""
+        blind = [kind for kind, is_blind in mapped_types(profile).items() if is_blind]
+
+        assert all(profile.rules[kind].stream_limit is None for kind in blind)
 
 
 class TestLeafModule:


### PR DESCRIPTION
Closes #18

## What was wrong

MP4's cheap attempt maps blindly (`-map 0:v? -map 0:a? -map 0:s?`) and reaches
no attachment; WAV's maps a single index (`-map 0:a:0`) and reaches no second
audio stream. Both exit 0 on such a source, and the run was reported as a plain
`1 converted, 0 failed` with **no note** — the degradation notes only ever lived
on the engine-built selective rung, which `batch.py` builds after the cheap
attempt has already *failed*.

## The design fork, and how it was settled

Naming a dropped stream's index and codec requires the source's stream list, and
`docs/constitution.md` said `ffprobe` never runs on the happy path while also
saying never report success for a conversion that silently dropped something.
Issue #18 escalated this; the planning gate resolved it as **option 1 — narrow
the happy-path rule**, and this PR implements exactly that:

- `ffprobe` stays off the happy path of a cheap attempt whose mapping is
  **exhaustive**.
- A cheap attempt that is **partial by construction** is verified by a probe on
  success, so a silent drop is never a plain success.
- Still at most one probe per file: the success-side and failure-side probes are
  mutually exclusive, and a later rung — built from the stream list itself — is
  never verified a second time.

## The change

- `Profile.partial_mapping` — declared data with **no default**, not inferred.
  Inferring it would mean parsing ffmpeg option syntax inside the engine, which
  is the same reason `explicit_streams` is declared. No default means every
  future target profile has to answer the question.
- `jobs.make_verifier(profile)` returns the success-side note builder, or `None`
  for an exhaustive profile — which is how `batch.py` knows whether to probe at
  all without reading a profile field for a conversion decision.
- The verification consults only the profile's **structural** verdicts (no rule
  declared for the stream's type; the container already holding as many of that
  type as it can), never a codec-level one. ffmpeg exited 0, so whatever it did
  with a codec worked, and announcing a re-encode that never ran would trade one
  dishonest report for another. `_structural_drop` is shared with
  `_decide_stream` so the two readings of D1/D2 cannot drift.
- A verification probe that itself fails does not fail the conversion, but the
  run reports `could not verify which source streams were kept: <error>` rather
  than a plain success.

## Docs moved together

All restatements of the old rule, per the escalation comment — plus a fifth one
found in code:

- `docs/constitution.md` (Architecture principles)
- `docs/architecture.md` (Key flows §1, plus the two component rows)
- `docs/design.md` (the cost-marker rule)
- `docs/design/degradation-ladder.md` (the diagram gains a success-side probe
  node; two rules rewritten)
- `docs/specs/spec-profile-registry.md` (four **Decision log** entries with the
  rationale, the stale Constraints line, one new Verification item)
- `converter/ffmpegtool.probe_streams`'s docstring

## Verification

Verify green (ruff check, ruff format --check, pytest — 188 tests, +13).

Machine tests for both symptoms drive the *cheap-attempt-succeeds* path, not
`.retries()` directly (`TestPartialCheapAttemptVerification` in
`tests/test_batch.py`), plus `TestSuccessSideVerification` in
`tests/test_argv.py` for the engine API. The exhaustive-profile half of the rule
needed a test-double profile, since neither shipped profile is exhaustive.

Real ffmpeg 9.0 through the CLI with absolute `--ffmpeg` / `--ffprobe`:

```text
note    attached.mkv: attachment stream 1 (ttf) dropped: not supported by MP4
2 converted, 0 skipped, 0 failed (of 2)          # exit 0

note    two-tone.opus: audio stream 1 (opus) dropped: WAV holds 1 audio stream
2 converted, 0 skipped, 0 failed (of 2)          # exit 0
```

`clip.mkv` and `tone.opus` lose nothing and still emit no note; a second run
reports `0 converted, 2 skipped, 0 failed`, exit 0; the vp8 ladder fixture still
emits exactly `video stream 0 (vp8) re-encoded to h264` and nothing extra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pdnJyntsFJyawGBSGj4cV
