### PR TITLE
feat(profiles): registry lookup, target identity and source-suffix set

### DIFF
--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -1,10 +1,16 @@
-"""Declarative target-format profiles: value types plus the MP4 and WAV entries.
+"""Declarative target-format profiles: value types, the registry, and lookup.
 
 A leaf module by design (`docs/architecture.md`): it holds no ``from converter``
 or ``import converter`` statement at all, so a target format can only ever be
 data, never new logic. That is also why ``flags()`` and ``Attempt`` live here
 instead of being imported from ``jobs.py`` -- importing them would break the
 leaf property in the other direction.
+
+``PROFILES`` is the target-name -> profile registry a target-driven CLI needs,
+``resolve_target`` is how it looks a target up, and ``SOURCE_SUFFIXES`` is the
+curated set of suffixes discovery walks (`docs/design/source-selection.md`) --
+curated by hand for the same reason a profile's copy mask is: ffmpeg can be
+asked what a file contains, never what it will accept as an input.
 
 See ``docs/design/degradation-ladder.md`` for how the engine in ``jobs.py``
 turns one profile into an ordered ladder of attempts, and
@@ -72,9 +78,16 @@ class Profile:
     even when its cheap attempt exits 0, so a stream that attempt silently left
     behind is named rather than reported as a plain success
     (``docs/design/degradation-ladder.md``).
+
+    ``name`` is the registry key and the ``--to`` token (``"mp4"``); ``label``
+    stays the display form ``--list-formats`` and progress bars print
+    (``"MP4"``). ``description`` is the one-line explanation
+    ``--list-formats`` and the interactive prompt print next to ``name``.
     """
 
     label: str
+    name: str
+    description: str
     target_suffix: str
     container_options: tuple[str, ...]
     cheap_attempt: Attempt
@@ -95,6 +108,8 @@ TEXT_SUBTITLE_CODECS = frozenset({"subrip", "srt", "ass", "ssa", "mov_text", "we
 
 MP4 = Profile(
     label="MP4",
+    name="mp4",
+    description="Video: copies compatible streams, re-encodes the rest to h264/aac",
     target_suffix=".mp4",
     container_options=FASTSTART,
     # Deliberately not "-map 0": that also selects MKV attachments (font files
@@ -147,6 +162,8 @@ MP4 = Profile(
 
 WAV = Profile(
     label="WAV",
+    name="wav",
+    description="Audio: single stream, uncompressed 16-bit PCM",
     target_suffix=".wav",
     container_options=(),
     # The stream is selected explicitly rather than left to ffmpeg's implicit
@@ -172,3 +189,35 @@ WAV = Profile(
         ),
     },
 )
+
+#: Target name -> profile. Built from each profile's own ``name`` rather than
+#: repeating it as a literal key, so the two can never drift apart.
+PROFILES: dict[str, Profile] = {profile.name: profile for profile in (MP4, WAV)}
+
+#: The curated set of suffixes discovery walks (`docs/design/source-selection.md`):
+#: a file is a candidate only if its suffix is in this set, never discovered from
+#: what ffmpeg happens to accept. Phase 2 seeds it with exactly what the old
+#: ``video``/``audio`` sub-commands read (``.mkv``, ``.opus``) plus each shipped
+#: profile's own target suffix (``.mp4``, ``.wav``) -- the latter is what lets a
+#: source that already carries the target suffix take part in selection at all
+#: (the self-write and existing-output-skip cases `source-selection.md` and this
+#: phase's QA gate both need). Later phases extend this set as they add profiles.
+SOURCE_SUFFIXES: frozenset[str] = frozenset({".mkv", ".mp4", ".opus", ".wav"})
+
+
+def resolve_target(target: str) -> Profile:
+    """Look up *target* in ``PROFILES``, accepting a name or a dotted suffix.
+
+    ``mp4``, ``MP4`` and ``.mp4`` all resolve to the same profile (Prior
+    decisions, ``spec-target-driven-cli.md``). An unknown target is a usage
+    error, not a conversion failure -- the same shape as ``--jobs`` being out
+    of range -- so it is raised as a plain ``ValueError`` for ``cli.py`` to
+    turn into its exit-2 ``UsageError``, with a message that lists every
+    target actually available rather than just naming the typo.
+    """
+    name = target.lower().removeprefix(".")
+    try:
+        return PROFILES[name]
+    except KeyError:
+        available = ", ".join(sorted(PROFILES))
+        raise ValueError(f"unknown target {target!r}; available targets: {available}") from None

--- a/docs/specs/spec-target-driven-cli.md
+++ b/docs/specs/spec-target-driven-cli.md
@@ -325,3 +325,19 @@ reusing the fixtures the phase-1 gate synthesises:
   alone, no `--from` filter. The filter would have bought a saving on repeated
   probe cost with a flag every later phase must keep working; the outcome already
   reports that cost honestly. Recorded as revisitable if the cost bites.
+- 2026-08-26 (#12): `SOURCE_SUFFIXES` seeded with exactly `.mkv`, `.mp4`, `.opus`,
+  `.wav` — the old `video`/`audio` sub-commands' suffixes plus each shipped
+  profile's own target suffix. `docs/specs/spec-video-formats.md` (phase 4, not
+  yet merged) attributes `.mp4` to phase 3 instead, but this phase's own
+  Verification list requires a source with the target's suffix to be a
+  candidate ("a source with the target's suffix but a different output root
+  **is** converted"), and the milestone-QA gate requires an already-existing
+  `.mp4` file under `--to mp4` to be reported as `skipped` rather than passed
+  over in silence — both only possible if `.mp4` is in the set from this phase
+  on. Treated as the later spec's drafting error, not a fork with this one:
+  phase 4 can drop `.mp4` from its own "newly added" list once it reads this.
+- 2026-08-26 (#12): `resolve_target`'s unknown-target error is a plain
+  `ValueError`, not a new exception type, matching `paths.mirror_to_drive`'s
+  existing pattern of raising `ValueError` for a usage problem that `cli.py`
+  (issue #15) turns into its exit-2 `UsageError` — `profiles.py` cannot import
+  `UsageError` itself without breaking the leaf-module constraint.

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -23,6 +23,8 @@ def exhaustive_job() -> Job:
     """
     profile = Profile(
         label="EXH",
+        name="exh",
+        description="a test double, not a shipped format",
         target_suffix=".exh",
         container_options=(),
         cheap_attempt=Attempt(label="copy-all", options=flags("-c copy")),

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -8,7 +8,17 @@ import itertools
 import pytest
 
 from converter import profiles
-from converter.profiles import MP4, WAV, Attempt, Profile, StreamRule, flags
+from converter.profiles import (
+    MP4,
+    PROFILES,
+    SOURCE_SUFFIXES,
+    WAV,
+    Attempt,
+    Profile,
+    StreamRule,
+    flags,
+    resolve_target,
+)
 
 #: ffmpeg's stream-specifier letters, as `docs/design/degradation-ladder.md` uses them.
 MAP_LETTERS = {"v": "video", "a": "audio", "s": "subtitle", "t": "attachment", "d": "data"}
@@ -90,6 +100,10 @@ class TestMp4Profile:
         assert MP4.label == "MP4"
         assert MP4.target_suffix == ".mp4"
 
+    def test_name_and_description(self):
+        assert MP4.name == "mp4"
+        assert MP4.description
+
     def test_container_options_carry_faststart_once(self):
         assert MP4.container_options == ("-movflags", "+faststart")
 
@@ -136,6 +150,10 @@ class TestWavProfile:
         assert WAV.label == "WAV"
         assert WAV.target_suffix == ".wav"
 
+    def test_name_and_description(self):
+        assert WAV.name == "wav"
+        assert WAV.description
+
     def test_no_container_options(self):
         assert WAV.container_options == ()
 
@@ -172,6 +190,36 @@ class TestWavProfile:
         assert WAV.rules["audio"].stream_limit == 1
 
 
+class TestRegistry:
+    def test_keys_are_each_profile_s_own_name(self):
+        assert PROFILES == {"mp4": MP4, "wav": WAV}
+
+
+class TestResolveTarget:
+    @pytest.mark.parametrize("target", ["mp4", "MP4", ".mp4", ".MP4", "Mp4"])
+    def test_accepts_name_case_and_dot_variants(self, target):
+        assert resolve_target(target) is MP4
+
+    def test_resolves_wav_too(self):
+        assert resolve_target("wav") is WAV
+
+    def test_unknown_target_raises_value_error_listing_available_targets(self):
+        with pytest.raises(ValueError, match=r"mkv.*available targets: mp4, wav"):
+            resolve_target("mkv")
+
+
+class TestSourceSuffixes:
+    def test_holds_the_old_job_suffixes_and_each_shipped_profile_s_own_suffix(self):
+        """`.mkv`/`.opus` are what the old sub-commands read; `.mp4`/`.wav` are
+        what let a source already carrying the target suffix take part in
+        selection (the self-write and existing-output cases,
+        `docs/design/source-selection.md`)."""
+        assert {".mkv", ".mp4", ".opus", ".wav"} == SOURCE_SUFFIXES
+
+    def test_every_shipped_profile_s_target_suffix_is_a_source_suffix(self):
+        assert all(profile.target_suffix in SOURCE_SUFFIXES for profile in SHIPPED)
+
+
 class TestValueTypesAreFrozen:
     def test_attempt_is_frozen(self):
         attempt = Attempt(label="x", options=())
@@ -195,6 +243,8 @@ class TestValueTypesAreFrozen:
 
         assert fields == {
             "label",
+            "name",
+            "description",
             "target_suffix",
             "container_options",
             "cheap_attempt",


### PR DESCRIPTION
## Summary

Gives `converter/profiles.py` the identity and lookup a target-driven CLI needs, per issue #12:

- `Profile` gains `name` (the `--to` token, e.g. `"mp4"`) and a one-line `description`, filled for MP4 and WAV.
- `PROFILES: dict[str, Profile]` — the target-name -> profile registry, built from each profile's own `name` so the two can never drift apart.
- `resolve_target(target)` — looks a target up accepting `mp4`, `MP4` and `.mp4` alike; an unknown target raises a `ValueError` listing the available targets, the same "usage error" shape `paths.mirror_to_drive` already uses for `cli.py` (issue #15) to turn into its exit-2 `UsageError`. `profiles.py` cannot import `cli.UsageError` itself without breaking the leaf-module rule.
- `SOURCE_SUFFIXES` — the curated set of suffixes discovery will walk, seeded with `.mkv`, `.mp4`, `.opus`, `.wav`: the old `video`/`audio` sub-commands' suffixes plus each shipped profile's own target suffix.

`converter/profiles.py` still holds no `from converter` / `import converter` statement (pinned by the existing `TestLeafModule` test).

### A decision worth flagging

`SOURCE_SUFFIXES` includes `.mp4` starting this phase. `docs/specs/spec-video-formats.md` (phase 4, not yet merged) attributes `.mp4` to phase 3 instead, but this phase's own spec (`spec-target-driven-cli.md`) requires it from phase 2: the Verification list needs "a source with the target's suffix but a different output root **is** converted", and the milestone-QA gate needs an already-existing `.mp4` file under `--to mp4` to be reported as `skipped` rather than passed over in silence — both only possible if `.mp4` is a candidate suffix now. Treated this as a drafting inconsistency in the later, unmerged spec rather than a fork with this phase's own spec, and recorded it in the Decision log so phase 4's implementer sees it before reusing that "newly added" list.

## Verification

- `.venv/Scripts/python.exe scripts/verify.py` — `ruff check .`, `ruff format --check .`, `pytest` all green (206 passed).
- New tests: `PROFILES` keys match each profile's own `name`; `resolve_target` accepts `mp4`/`MP4`/`.mp4`/`.MP4` and raises `ValueError` listing available targets on a miss; `SOURCE_SUFFIXES` holds exactly the four expected suffixes and includes every shipped profile's own target suffix.
- Updated the one existing `Profile(...)` construction in `tests/test_batch.py` for the two new required fields.

Closes #12