### PR TITLE
feat(paths): the source-selection predicates

### DIFF
--- a/converter/paths.py
+++ b/converter/paths.py
@@ -20,11 +20,46 @@ def normalise_suffixes(suffixes: Iterable[str]) -> frozenset[str]:
     return frozenset(normalised)
 
 
+def _resolved_key(path: str | os.PathLike[str]) -> str:
+    """Return a case-folded string of *path*, resolved, for identity comparisons.
+
+    Resolving first -- rather than comparing the paths as given -- is what
+    catches a ``--mirror-to`` self-write or hazard: the output root is derived
+    from a resolved input path while discovery returns paths built from the
+    root as typed, so two paths that name the same file can look different
+    until both sides are resolved.
+    """
+    return os.path.normcase(os.fspath(Path(path).resolve()))
+
+
+def _is_within(path: Path, ancestor: Path) -> bool:
+    """Return whether *path* lies strictly inside *ancestor* (both already resolved)."""
+    ancestor_text = os.fspath(ancestor)
+    prefix = ancestor_text if ancestor_text.endswith(os.sep) else ancestor_text + os.sep
+    return os.path.normcase(os.fspath(path)).startswith(os.path.normcase(prefix))
+
+
+def _excluded_subtree(root: Path, exclude: str | os.PathLike[str] | None) -> Path | None:
+    """Resolve *exclude* against *root*, keeping it only if it is a strict descendant.
+
+    An output root that is an ancestor or a sibling of *root* is already
+    outside the walk, and one equal to *root* is the self-write guard's job --
+    see ``docs/design/source-selection.md``'s OWN node for why only the
+    strict-descendant shape is excluded here.
+    """
+    if exclude is None:
+        return None
+    resolved_root = root.resolve()
+    resolved_exclude = Path(exclude).resolve()
+    return resolved_exclude if _is_within(resolved_exclude, resolved_root) else None
+
+
 def find_sources(
     root: str | os.PathLike[str],
     suffixes: Iterable[str],
     *,
     recursive: bool = False,
+    exclude: str | os.PathLike[str] | None = None,
 ) -> list[Path]:
     """Collect the files under *root* whose suffix is in *suffixes*.
 
@@ -32,13 +67,25 @@ def find_sources(
     ``Movie.MKV`` without a word -- and directories are excluded, so a folder
     named ``season.mkv`` is no longer handed to ffmpeg as an input file.
     Results are sorted so runs are reproducible.
+
+    *exclude*, when given, is a subtree to skip -- meant for an output root
+    nested inside *root*, so a converted tree is never rediscovered as input on
+    the next run. It only takes effect when it actually is a strict descendant
+    of *root* once both are resolved; see ``_excluded_subtree``.
     """
     wanted = normalise_suffixes(suffixes)
     root = Path(root)
     if not root.is_dir():
         raise NotADirectoryError(f"input directory does not exist: {root}")
+    excluded = _excluded_subtree(root, exclude)
     candidates = root.rglob("*") if recursive else root.glob("*")
-    return sorted(p for p in candidates if p.suffix.lower() in wanted and p.is_file())
+    return sorted(
+        p
+        for p in candidates
+        if p.suffix.lower() in wanted
+        and p.is_file()
+        and (excluded is None or not _is_within(p.resolve(), excluded))
+    )
 
 
 def output_for(
@@ -142,7 +189,11 @@ def find_collisions(pairs: Iterable[tuple[Path, Path]]) -> dict[Path, list[Path]
     """Return output paths that more than one input would write to.
 
     ``os.path.normcase`` is used for the comparison because Windows would let
-    two differently-cased outputs silently overwrite each other.
+    two differently-cased outputs silently overwrite each other. A
+    self-writing source (see ``is_self_write``) should be filtered out of
+    *pairs* by the caller first: it produces no conversion, so it cannot
+    contend for its own path -- per ``docs/design/source-selection.md``'s COLL
+    node.
     """
     seen: dict[str, tuple[Path, list[Path]]] = {}
     for src, dst in pairs:
@@ -152,3 +203,46 @@ def find_collisions(pairs: Iterable[tuple[Path, Path]]) -> dict[Path, list[Path]
         else:
             seen[key] = (dst, [src])
     return {dst: sources for dst, sources in seen.values() if len(sources) > 1}
+
+
+def is_self_write(src: str | os.PathLike[str], dst: str | os.PathLike[str]) -> bool:
+    """Return whether writing *dst* would overwrite *src* itself.
+
+    Both paths are resolved before comparison, then compared case-folded --
+    unlike ``find_collisions``, which case-folds the paths as given. The
+    difference is load-bearing under ``--mirror-to``: the output root is
+    derived from a resolved input path while discovery returns paths built
+    from the root as typed, so comparing as given would miss the self-write.
+    Per ``docs/design/source-selection.md``'s SELF node, a true self-write is
+    reported as a counted skip, never silently dropped, and never refuses the
+    run by itself.
+    """
+    return _resolved_key(src) == _resolved_key(dst)
+
+
+def find_overwrite_hazards(pairs: Iterable[tuple[Path, Path]]) -> list[tuple[Path, Path]]:
+    """Return (victim, writer) pairs where *writer*'s output would destroy *victim*.
+
+    *victim* is a different selected source whose own input path *writer*'s
+    output resolves to. Every selected source is a potential victim,
+    self-writers included -- the motivating case is exactly a self-writer
+    (``a.mp4``) being overwritten by a sibling (``a.mkv``) -- which is why
+    this is its own two-pass check over *pairs*, like ``find_collisions``,
+    rather than a filter on top of it: the first pass indexes every source by
+    its resolved, case-folded path, the second asks whether each output
+    resolves to a *different* source's entry. Per
+    ``docs/design/source-selection.md``'s HAZ node, both sides are resolved
+    before comparison, and this check is meant to fire only under
+    ``--overwrite``, which is the caller's decision, not this function's.
+    """
+    resolved = [(src, _resolved_key(src), dst, _resolved_key(dst)) for src, dst in pairs]
+    victims_by_key: dict[str, Path] = {}
+    for entry_src, entry_src_key, _entry_dst, _entry_dst_key in resolved:
+        victims_by_key[entry_src_key] = entry_src
+
+    hazards = []
+    for src, src_key, _dst, dst_key in resolved:
+        victim = victims_by_key.get(dst_key)
+        if victim is not None and dst_key != src_key:
+            hazards.append((victim, src))
+    return hazards

--- a/docs/specs/spec-target-driven-cli.md
+++ b/docs/specs/spec-target-driven-cli.md
@@ -341,3 +341,24 @@ reusing the fixtures the phase-1 gate synthesises:
   existing pattern of raising `ValueError` for a usage problem that `cli.py`
   (issue #15) turns into its exit-2 `UsageError` — `profiles.py` cannot import
   `UsageError` itself without breaking the leaf-module constraint.
+- 2026-08-26 (#13): `find_sources` gains `exclude: Path | None` rather than a
+  separate "is this a nested output root" predicate the caller must consult
+  first. `_excluded_subtree` resolves both `root` and `exclude` and applies
+  the strict-descendant test itself, so a future `cli.py` can pass the output
+  root unconditionally and get the OWN node's exact behaviour (ancestor,
+  sibling and equal-root shapes left untouched) without duplicating the test.
+- 2026-08-26 (#13): The self-write guard and the overwrite hazard share one
+  private helper, `_resolved_key`, rather than each re-deriving
+  resolve-then-normcase. `is_self_write(src, dst)` is the SELF predicate
+  directly; `find_overwrite_hazards(pairs)` is the whole-set HAZ pass,
+  returning `(victim, writer)` tuples so the caller can name both files in the
+  exit-2 message. Both stay pure path logic with no `--overwrite` awareness —
+  firing the hazard check only under `--overwrite` is left to the caller
+  (`cli.py`, issue #15), matching how `find_collisions` already has no opinion
+  on when it is invoked.
+- 2026-08-26 (#13): The COLL exclusion of self-writing sources (the third
+  predicate the issue lists) is not a new function: `find_collisions` is
+  unchanged, and a caller filters `is_self_write` pairs out before calling it
+  — the same shape `tests/test_paths.py`'s `select()` helper uses to simulate
+  the full per-file flow. A wrapper would just be `find_collisions(p for p in
+  pairs if not is_self_write(*p))` with no logic of its own.

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -11,7 +11,9 @@ from converter.paths import (
     _may_be_a_length_problem,
     ensure_directory,
     find_collisions,
+    find_overwrite_hazards,
     find_sources,
+    is_self_write,
     list_directories,
     mirror_to_drive,
     normalise_suffixes,
@@ -25,6 +27,44 @@ def touch(path: Path) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(b"")
     return path
+
+
+def select(
+    input_root: Path,
+    output_root: Path,
+    suffixes: list[str],
+    target_suffix: str,
+    *,
+    recursive: bool = True,
+    overwrite: bool = False,
+) -> tuple[list[Path], list[Path], list[tuple[Path, Path]]]:
+    """Run the whole selection pipeline `docs/design/source-selection.md` draws.
+
+    Composes the paths.py predicates the way a future caller (cli.py, #15)
+    will, so this test file can exercise the design's per-file flow --
+    candidate -> self-write / collision / hazard / exists -- without any
+    ffmpeg or profile involved. Returns (converted, skipped, hazards): the
+    hazards list is non-empty exactly when the whole run would be refused.
+    """
+    sources = find_sources(input_root, suffixes, recursive=recursive, exclude=output_root)
+    pairs = [(src, output_for(src, input_root, output_root, target_suffix)) for src in sources]
+
+    if overwrite:
+        hazards = find_overwrite_hazards(pairs)
+        if hazards:
+            return [], [], hazards
+
+    convertible = [(src, dst) for src, dst in pairs if not is_self_write(src, dst)]
+    if find_collisions(convertible):
+        raise AssertionError("selection produced a collision the test did not expect")
+
+    converted, skipped = [], []
+    for src, dst in pairs:
+        if is_self_write(src, dst) or (dst.exists() and not overwrite):
+            skipped.append(src)
+        else:
+            converted.append(src)
+    return converted, skipped, []
 
 
 class TestNormaliseSuffixes:
@@ -288,3 +328,215 @@ class TestFindCollisions:
         ]
 
         assert len(find_collisions(pairs)) == 1
+
+
+class TestIsSelfWrite:
+    def test_true_when_resolved_paths_match(self, tmp_path):
+        touch(tmp_path / "a.mp4")
+
+        assert is_self_write(tmp_path / "a.mp4", tmp_path / "a.mp4") is True
+
+    def test_false_for_different_files(self, tmp_path):
+        touch(tmp_path / "a.mp4")
+        touch(tmp_path / "b.mp4")
+
+        assert is_self_write(tmp_path / "a.mp4", tmp_path / "b.mp4") is False
+
+    def test_resolves_before_comparing(self, tmp_path):
+        """A ``..`` segment must not hide a self-write -- the --mirror-to case,
+        where discovery returns the root as typed but the output root is
+        derived from a resolved input path, so comparing as given would miss it."""
+        touch(tmp_path / "a.mp4")
+        typed_src = tmp_path / "sub" / ".." / "a.mp4"
+
+        assert is_self_write(typed_src, tmp_path / "a.mp4") is True
+
+    @on_windows
+    def test_case_folded(self, tmp_path):
+        touch(tmp_path / "a.mp4")
+
+        upper = Path(str(tmp_path).upper()) / "A.MP4"
+        assert is_self_write(tmp_path / "a.mp4", upper) is True
+
+
+class TestFindSourcesExcludesSubtree:
+    def test_excludes_a_nested_output_root(self, tmp_path):
+        touch(tmp_path / "top.mkv")
+        touch(tmp_path / "converted" / "done.mkv")
+
+        found = find_sources(tmp_path, [".mkv"], recursive=True, exclude=tmp_path / "converted")
+
+        assert [p.name for p in found] == ["top.mkv"]
+
+    def test_ancestor_output_root_is_not_excluded(self, tmp_path):
+        """An ancestor output root is already outside the walk: excluding
+        "lies under it" without the strict-descendant clause would drop every
+        candidate here and report a successful run that did nothing."""
+        sub = tmp_path / "Sub"
+        touch(sub / "a.mkv")
+
+        found = find_sources(sub, [".mkv"], recursive=True, exclude=tmp_path)
+
+        assert [p.name for p in found] == ["a.mkv"]
+
+    def test_sibling_output_root_is_not_excluded(self, tmp_path):
+        input_root = tmp_path / "in"
+        sibling = tmp_path / "out"
+        touch(input_root / "a.mkv")
+
+        found = find_sources(input_root, [".mkv"], recursive=True, exclude=sibling)
+
+        assert [p.name for p in found] == ["a.mkv"]
+
+    def test_output_root_equal_to_input_root_is_not_excluded(self, tmp_path):
+        """Equal roots are the self-write guard's job, not this exclusion."""
+        touch(tmp_path / "a.mkv")
+
+        found = find_sources(tmp_path, [".mkv"], recursive=True, exclude=tmp_path)
+
+        assert [p.name for p in found] == ["a.mkv"]
+
+    def test_no_exclude_means_no_filtering(self, tmp_path):
+        touch(tmp_path / "a.mkv")
+
+        assert find_sources(tmp_path, [".mkv"], recursive=True) == [tmp_path / "a.mkv"]
+
+
+class TestFindOverwriteHazards:
+    def test_detects_a_sibling_overwriting_a_self_writer(self):
+        """The motivating case: a.mp4 self-writes and would be skipped, and
+        a.mkv's output would then overwrite it under --overwrite."""
+        pairs = [
+            (Path("a.mp4"), Path("a.mp4")),
+            (Path("a.mkv"), Path("a.mp4")),
+        ]
+
+        hazards = find_overwrite_hazards(pairs)
+
+        assert hazards == [(Path("a.mp4"), Path("a.mkv"))]
+
+    def test_a_files_own_self_write_is_not_its_own_hazard(self):
+        pairs = [(Path("a.mp4"), Path("a.mp4"))]
+
+        assert find_overwrite_hazards(pairs) == []
+
+    def test_no_hazard_when_outputs_do_not_collide_with_a_source(self):
+        pairs = [(Path("a.mkv"), Path("out/a.mp4")), (Path("b.mkv"), Path("out/b.mp4"))]
+
+        assert find_overwrite_hazards(pairs) == []
+
+    def test_resolves_before_comparing(self, tmp_path):
+        """The --mirror-to shape: the victim's source path is typed with a
+        ``..`` segment, so only a resolved comparison catches the hazard."""
+        victim_typed = tmp_path / "sub" / ".." / "a.mp4"
+        pairs = [
+            (victim_typed, tmp_path / "a.mp4"),
+            (tmp_path / "a.mkv", tmp_path / "a.mp4"),
+        ]
+
+        hazards = find_overwrite_hazards(pairs)
+
+        assert hazards == [(victim_typed, tmp_path / "a.mkv")]
+
+
+class TestSourceSelectionScenarios:
+    """End-to-end per `docs/design/source-selection.md`, composing the
+    paths.py predicates the way a future cli.py (issue #15) will -- no ffmpeg
+    or profile involved, matching the design's claim that selection finishes
+    before any subprocess call.
+    """
+
+    def test_nested_output_root_converges_on_the_second_run(self, tmp_path):
+        """`-r IN IN\\converted` must not grow a `converted\\converted\\...`
+        generation on every run."""
+        input_root = tmp_path / "Media"
+        output_root = input_root / "converted"
+        touch(input_root / "a.mkv")
+
+        converted, _skipped, hazards = select(input_root, output_root, [".mkv"], ".mp4")
+        assert [p.name for p in converted] == ["a.mkv"]
+        assert hazards == []
+        for src in converted:
+            touch(output_for(src, input_root, output_root, ".mp4"))
+
+        converted2, _skipped2, _hazards2 = select(input_root, output_root, [".mkv"], ".mp4")
+        assert converted2 == []
+
+    def test_ancestor_output_root_converts_and_stays_idempotent(self, tmp_path):
+        """`-r IN\\Sub IN` writes one level up; a rule written as "lies under
+        the output root" alone would exclude the candidate and report a
+        successful run that did nothing."""
+        input_root = tmp_path / "Media" / "Sub"
+        output_root = tmp_path / "Media"
+        touch(input_root / "a.mkv")
+
+        converted, _skipped, hazards = select(input_root, output_root, [".mkv"], ".mp4")
+        assert [p.name for p in converted] == ["a.mkv"]
+        assert hazards == []
+        for src in converted:
+            touch(output_for(src, input_root, output_root, ".mp4"))
+
+        converted2, _skipped2, _hazards2 = select(input_root, output_root, [".mkv"], ".mp4")
+        assert converted2 == []
+
+    def test_overwrite_pair_without_overwrite_reports_two_skipped(self, tmp_path):
+        """a.mp4 self-writes and is skipped; a.mkv sees an existing output and
+        is skipped too. Nothing is at risk, so the run stays harmless."""
+        touch(tmp_path / "a.mkv")
+        touch(tmp_path / "a.mp4")
+
+        converted, skipped, hazards = select(
+            tmp_path, tmp_path, [".mkv", ".mp4"], ".mp4", overwrite=False
+        )
+
+        assert converted == []
+        assert {p.name for p in skipped} == {"a.mkv", "a.mp4"}
+        assert hazards == []
+
+    def test_overwrite_pair_with_overwrite_refuses_the_run(self, tmp_path):
+        """With --overwrite, a.mkv would destroy a.mp4 -- a file the run would
+        otherwise have reported as kept -- so the whole run is refused,
+        naming both files."""
+        touch(tmp_path / "a.mkv")
+        touch(tmp_path / "a.mp4")
+
+        _converted, _skipped, hazards = select(
+            tmp_path, tmp_path, [".mkv", ".mp4"], ".mp4", overwrite=True
+        )
+
+        assert [(v.name, w.name) for v, w in hazards] == [("a.mp4", "a.mkv")]
+
+    def test_mirror_to_self_write_is_still_caught(self, tmp_path):
+        """Under --mirror-to the output root is derived from a *resolved*
+        input path while discovery returns paths built from the root as
+        typed -- simulated here with a `..` segment standing in for a second
+        drive, since comparing as given would miss this self-write."""
+        real_input = tmp_path / "Media"
+        touch(real_input / "a.mp4")
+        typed_input = tmp_path / "Media" / "x" / ".."
+
+        src = typed_input / "a.mp4"
+        dst = output_for(src, typed_input, real_input.resolve(), ".mp4")
+
+        assert is_self_write(src, dst) is True
+
+    def test_mirror_to_overwrite_hazard_is_still_caught(self, tmp_path):
+        """The same typed-vs-resolved mismatch, now for the hazard guard:
+        the one-directory test above cannot tell "compares as given" and
+        "compares resolved" apart, this one can."""
+        real_input = tmp_path / "Media"
+        touch(real_input / "a.mp4")
+        touch(real_input / "a.mkv")
+        typed_input = tmp_path / "Media" / "x" / ".."
+
+        pairs = [
+            (src, output_for(src, typed_input, real_input.resolve(), ".mp4"))
+            for src in (typed_input / "a.mp4", typed_input / "a.mkv")
+        ]
+
+        hazards = find_overwrite_hazards(pairs)
+
+        assert len(hazards) == 1
+        victim, writer = hazards[0]
+        assert victim.name == "a.mp4"
+        assert writer.name == "a.mkv"


### PR DESCRIPTION
## Summary

Implements the four source-selection predicates from `docs/design/source-selection.md` as pure path logic in `converter/paths.py`, beside `find_collisions`:

- **Output-tree exclusion**: `find_sources(..., exclude=...)` skips a subtree, but only when `exclude` resolves to a **strict descendant** of `root`. An ancestor, sibling or equal output root is left untouched — the caller can pass the output root unconditionally and get the design's OWN node exactly.
- **Self-write guard**: `is_self_write(src, dst)` resolves both paths, then compares case-folded — catches a `--mirror-to` self-write where the output root is derived from a resolved input path but discovery still returns paths built from the root as typed.
- **Collision check**: `find_collisions` itself is unchanged; excluding self-writing sources from it is a filter the caller applies (`find_collisions(p for p in pairs if not is_self_write(*p))`), not new logic.
- **Overwrite hazard**: `find_overwrite_hazards(pairs)` is a whole-set, two-pass check like `find_collisions` — every selected source is a potential victim, self-writers included, so a sibling that would destroy an already-skipped self-write is named before any conversion runs. Both sides are resolved before comparing.

`paths.py` stays ignorant of ffmpeg and profiles; no diff in `cli.py` or `batch.py` (both owned by later issues in this milestone).

Decisions (naming, the `_excluded_subtree`/`_resolved_key` split, why COLL isn't a new function) are recorded in `docs/specs/spec-target-driven-cli.md`'s Decision log on this branch.

## Verification

- `.venv\Scripts\python.exe scripts\verify.py` — ruff check, ruff format --check, pytest — all green (225 passed).
- New tests in `tests/test_paths.py`: unit tests for `is_self_write`, `find_sources(exclude=...)` and `find_overwrite_hazards`, plus `TestSourceSelectionScenarios`, which composes the predicates the way a future `cli.py` will to exercise the design's per-file flow end to end (nested output root converges on a second run, ancestor output root converts and stays idempotent, the overwrite pair with and without `--overwrite`, and `--mirror-to` variants of the self-write and hazard guards using a typed-vs-resolved path mismatch).

Closes #13