### PR TITLE
feat(batch): the unsupported outcome, and batch driven by a profile

### DIFF
--- a/converter/batch.py
+++ b/converter/batch.py
@@ -24,6 +24,9 @@ from pathlib import Path
 from tqdm import tqdm
 
 from converter import ffmpegtool
+
+# Aliased: run_batch's own `jobs` keyword (parallelism count) would otherwise
+# shadow the module name inside this file.
 from converter import jobs as engine
 from converter.ffmpegtool import ProbeError, Tools
 from converter.paths import ensure_directory

--- a/converter/batch.py
+++ b/converter/batch.py
@@ -1,4 +1,5 @@
-"""Bounded parallel execution of a job over many files, with honest reporting.
+"""Bounded parallel execution of a target profile over many files, with honest
+reporting.
 
 Two deliberate departures from the code this replaces:
 
@@ -23,9 +24,10 @@ from pathlib import Path
 from tqdm import tqdm
 
 from converter import ffmpegtool
+from converter import jobs as engine
 from converter.ffmpegtool import ProbeError, Tools
-from converter.jobs import Job
 from converter.paths import ensure_directory
+from converter.profiles import Profile
 
 
 def default_jobs() -> int:
@@ -37,6 +39,11 @@ class Outcome(enum.StrEnum):
     CONVERTED = "converted"
     SKIPPED = "skipped"
     FAILED = "failed"
+    #: The source carries no stream of any type the target profile has a rule
+    #: for at all -- distinct from FAILED, which still sets the exit code
+    #: (docs/specs/spec-target-driven-cli.md). Its discriminator is decided by
+    #: the engine (converter.jobs.describe_unsupported), never here.
+    UNSUPPORTED = "unsupported"
 
 
 @dataclass(frozen=True)
@@ -66,15 +73,15 @@ def _discard_partial_output(dst: Path, *, existed: bool) -> None:
         dst.unlink(missing_ok=True)
 
 
-def _verify_cheap_attempt(job: Job, task: Task, tools: Tools) -> tuple[str, ...]:
+def _verify_cheap_attempt(profile: Profile, task: Task, tools: Tools) -> tuple[str, ...]:
     """Name whatever a structurally partial cheap attempt left behind.
 
-    The one place ffprobe runs after an attempt has *succeeded*. A job whose
-    cheap attempt maps the source exhaustively declares no verifier and never
-    gets here, so the common case keeps its probe-free happy path
+    The one place ffprobe runs after an attempt has *succeeded*. A profile
+    whose cheap attempt maps the source exhaustively needs no verification and
+    never gets here, so the common case keeps its probe-free happy path
     (``docs/design/degradation-ladder.md``).
     """
-    if job.verify_success is None:
+    if not engine.needs_verification(profile):
         return ()
     try:
         streams = ffmpegtool.probe_streams(tools, task.src)
@@ -82,10 +89,10 @@ def _verify_cheap_attempt(job: Job, task: Task, tools: Tools) -> tuple[str, ...]
         # A run whose completeness could not be established must not read as a
         # plain success either (``docs/constitution.md``).
         return (f"could not verify which source streams were kept: {exc}",)
-    return job.verify_success(streams)
+    return engine.verify_success(profile, streams)
 
 
-def _attempt_conversion(job: Job, task: Task, tools: Tools, *, overwrite: bool) -> Result:
+def _attempt_conversion(profile: Profile, task: Task, tools: Tools, *, overwrite: bool) -> Result:
     existed = task.dst.exists()
     if existed and not overwrite:
         return Result(
@@ -94,7 +101,7 @@ def _attempt_conversion(job: Job, task: Task, tools: Tools, *, overwrite: bool) 
             notes=("output already exists; pass --overwrite to replace it",),
         )
 
-    pending = [job.first_attempt()]
+    pending = [engine.first_attempt(profile)]
     errors: list[str] = []
     probed = False
 
@@ -106,7 +113,7 @@ def _attempt_conversion(job: Job, task: Task, tools: Tools, *, overwrite: bool) 
             # `probed` still being false means this was the cheap attempt: every
             # later rung was built from the stream list itself and already
             # carries accurate notes, so only this one needs verifying.
-            extra = () if probed else _verify_cheap_attempt(job, task, tools)
+            extra = () if probed else _verify_cheap_attempt(profile, task, tools)
             return Result(task, Outcome.CONVERTED, attempt.label, (*attempt.notes, *extra))
 
         errors.append(f"[{attempt.label}] {result.stderr or f'exit code {result.returncode}'}")
@@ -119,22 +126,30 @@ def _attempt_conversion(job: Job, task: Task, tools: Tools, *, overwrite: bool) 
             except ProbeError as exc:
                 errors.append(f"[probe] {exc}")
             else:
-                pending.extend(job.retries(streams))
+                # The engine's own signal, read once: a source with no stream
+                # of any type the profile has a rule for can never climb the
+                # rest of the ladder, so spending further ffmpeg attempts on it
+                # would only reconfirm a foregone conclusion.
+                unsupported = engine.describe_unsupported(profile, streams)
+                if unsupported is not None:
+                    _discard_partial_output(task.dst, existed=existed)
+                    return Result(task, Outcome.UNSUPPORTED, notes=unsupported)
+                pending.extend(engine.retries(profile, streams))
 
     _discard_partial_output(task.dst, existed=existed)
     return Result(task, Outcome.FAILED, error=" | ".join(errors))
 
 
-def convert_one(job: Job, task: Task, tools: Tools, *, overwrite: bool) -> Result:
+def convert_one(profile: Profile, task: Task, tools: Tools, *, overwrite: bool) -> Result:
     """Convert a single file, never raising: a bad file must not kill the batch."""
     try:
-        return _attempt_conversion(job, task, tools, overwrite=overwrite)
+        return _attempt_conversion(profile, task, tools, overwrite=overwrite)
     except Exception as exc:  # one broken file must not abort the whole run
         return Result(task, Outcome.FAILED, error=f"{type(exc).__name__}: {exc}")
 
 
 def _interruptible(
-    job: Job,
+    profile: Profile,
     tools: Tools,
     *,
     overwrite: bool,
@@ -159,7 +174,7 @@ def _interruptible(
             # aborts the batch for the right reason.
             raise KeyboardInterrupt
         try:
-            return convert_one(job, task, tools, overwrite=overwrite)
+            return convert_one(profile, task, tools, overwrite=overwrite)
         except KeyboardInterrupt:
             interrupted.set()
             raise
@@ -168,7 +183,7 @@ def _interruptible(
 
 
 def run_batch(
-    job: Job,
+    profile: Profile,
     tasks: Sequence[Task],
     tools: Tools,
     *,
@@ -176,7 +191,7 @@ def run_batch(
     overwrite: bool = False,
     progress: bool = True,
 ) -> list[Result]:
-    """Run *job* over *tasks* with at most *jobs* conversions in flight."""
+    """Run *tasks* through *profile* with at most *jobs* conversions in flight."""
     tasks = list(tasks)
     workers = max(1, jobs or default_jobs())
 
@@ -187,14 +202,14 @@ def run_batch(
         ensure_directory(task.dst.parent)
 
     results: list[Result] = []
-    work = _interruptible(job, tools, overwrite=overwrite, interrupted=threading.Event())
+    work = _interruptible(profile, tools, overwrite=overwrite, interrupted=threading.Event())
 
     # Not ThreadPoolExecutor's own context manager: its __exit__ shuts down with
     # wait=True and no cancellation, so after Ctrl+C every queued file would
     # still be converted before the interrupt was ever noticed.
     pool = ThreadPoolExecutor(max_workers=workers)
     try:
-        with tqdm(total=len(tasks), desc=job.name, unit="file", disable=not progress) as bar:
+        with tqdm(total=len(tasks), desc=profile.label, unit="file", disable=not progress) as bar:
             futures = [pool.submit(work, task) for task in tasks]
             try:
                 # as_completed, so the bar advances when a file is actually done
@@ -232,26 +247,35 @@ class Summary:
     converted: int = 0
     skipped: int = 0
     failed: int = 0
+    unsupported: int = 0
     failures: tuple[Result, ...] = field(default_factory=tuple)
 
     @property
     def total(self) -> int:
-        return self.converted + self.skipped + self.failed
+        return self.converted + self.skipped + self.failed + self.unsupported
 
     @property
     def exit_code(self) -> int:
+        # `unsupported` never sets the exit code (docs/specs/spec-target-driven-cli.md):
+        # a source the target cannot produce at all is reported honestly, not
+        # treated as a run failure -- that is the whole point of the outcome.
         return 1 if self.failed else 0
 
     def describe(self) -> str:
         return (
             f"{self.converted} converted, {self.skipped} skipped, "
-            f"{self.failed} failed (of {self.total})"
+            f"{self.failed} failed, {self.unsupported} unsupported (of {self.total})"
         )
 
 
 def summarise(results: Iterable[Result]) -> Summary:
     """Fold results into a Summary; the exit code is derived, never assumed."""
-    counts = {Outcome.CONVERTED: 0, Outcome.SKIPPED: 0, Outcome.FAILED: 0}
+    counts = {
+        Outcome.CONVERTED: 0,
+        Outcome.SKIPPED: 0,
+        Outcome.FAILED: 0,
+        Outcome.UNSUPPORTED: 0,
+    }
     failures: list[Result] = []
     for result in results:
         counts[result.outcome] += 1
@@ -261,5 +285,6 @@ def summarise(results: Iterable[Result]) -> Summary:
         converted=counts[Outcome.CONVERTED],
         skipped=counts[Outcome.SKIPPED],
         failed=counts[Outcome.FAILED],
+        unsupported=counts[Outcome.UNSUPPORTED],
         failures=tuple(failures),
     )

--- a/converter/cli.py
+++ b/converter/cli.py
@@ -9,18 +9,46 @@ single code path to reason about and to test.
 import argparse
 import sys
 from collections.abc import Sequence
+from dataclasses import dataclass
 from pathlib import Path
 
 from converter import __version__, ffmpegtool, paths
 from converter.batch import Task, default_jobs, run_batch, summarise
-from converter.jobs import JOBS, Job
+from converter.profiles import MP4, WAV, Profile
 
 
 class UsageError(Exception):
     """Bad combination of otherwise valid arguments."""
 
 
-def _add_convert_arguments(sub: argparse.ArgumentParser, job: Job) -> None:
+@dataclass(frozen=True)
+class _Binding:
+    """A sub-command's CLI-visible name plus which source suffixes feed which
+    target profile. Phase-2 scaffolding (``docs/specs/spec-target-driven-cli.md``):
+    replaced once ``--to`` takes over from the ``video``/``audio`` sub-commands.
+    """
+
+    description: str
+    suffixes: tuple[str, ...]
+    profile: Profile
+
+
+#: Sub-command name -> binding. See :class:`_Binding`.
+_BINDINGS: dict[str, _Binding] = {
+    "video": _Binding(
+        description="Convert .mkv files to .mp4 (stream copy where possible)",
+        suffixes=(".mkv",),
+        profile=MP4,
+    ),
+    "audio": _Binding(
+        description="Convert .opus files to uncompressed .wav",
+        suffixes=(".opus",),
+        profile=WAV,
+    ),
+}
+
+
+def _add_convert_arguments(sub: argparse.ArgumentParser, binding: _Binding) -> None:
     sub.add_argument("input_dir", type=Path, help="directory containing the input files")
     sub.add_argument(
         "output_dir",
@@ -58,7 +86,7 @@ def _add_convert_arguments(sub: argparse.ArgumentParser, job: Job) -> None:
     sub.add_argument("-q", "--quiet", action="store_true", help="hide the progress bar")
     sub.add_argument("--ffmpeg", default=None, help="path to the ffmpeg executable")
     sub.add_argument("--ffprobe", default=None, help="path to the ffprobe executable")
-    sub.set_defaults(job=job, handler=convert_command)
+    sub.set_defaults(binding=binding, handler=convert_command)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -69,9 +97,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--version", action="version", version=f"converter {__version__}")
     subparsers = parser.add_subparsers(dest="command", metavar="COMMAND")
 
-    for name, job in JOBS.items():
-        sub = subparsers.add_parser(name, help=job.description, description=job.description)
-        _add_convert_arguments(sub, job)
+    for name, binding in _BINDINGS.items():
+        sub = subparsers.add_parser(name, help=binding.description, description=binding.description)
+        _add_convert_arguments(sub, binding)
 
     mirror = subparsers.add_parser(
         "mirror",
@@ -108,26 +136,26 @@ def _resolve_output_root(args: argparse.Namespace) -> Path:
 
 
 def convert_command(args: argparse.Namespace) -> int:
-    job: Job = args.job
+    binding: _Binding = args.binding
     if args.jobs is not None and args.jobs < 1:
         raise UsageError(f"--jobs must be 1 or more, got {args.jobs}")
     output_root = _resolve_output_root(args)
 
     try:
-        sources = paths.find_sources(args.input_dir, job.suffixes, recursive=args.recursive)
+        sources = paths.find_sources(args.input_dir, binding.suffixes, recursive=args.recursive)
     except NotADirectoryError as exc:
         # A bad path is a usage error, not a conversion failure.
         raise UsageError(str(exc)) from exc
     if not sources:
         hint = "" if args.recursive else " (pass --recursive to include sub-directories)"
         print(
-            f"No {' / '.join(job.suffixes)} files found in {args.input_dir}{hint}.",
+            f"No {' / '.join(binding.suffixes)} files found in {args.input_dir}{hint}.",
             file=sys.stderr,
         )
         return 0
 
     tasks = [
-        Task(src, paths.output_for(src, args.input_dir, output_root, job.target_suffix))
+        Task(src, paths.output_for(src, args.input_dir, output_root, binding.profile.target_suffix))
         for src in sources
     ]
 
@@ -151,7 +179,7 @@ def convert_command(args: argparse.Namespace) -> int:
         print(f"Using {ffmpegtool.version(tools)}")
 
     results = run_batch(
-        job,
+        binding.profile,
         tasks,
         tools,
         jobs=args.jobs,

--- a/converter/jobs.py
+++ b/converter/jobs.py
@@ -188,11 +188,27 @@ def describe_unsupported(profile: Profile, streams: Sequence[Stream]) -> tuple[s
     ``None`` means the source carries at least one stream type *profile* has a
     rule for -- that stream may still be dropped for shape or codec reasons, but
     that is a genuine ``failed``, not this (``docs/specs/spec-target-driven-cli.md``).
-    Otherwise returns one drop note per stream, reusing D1 of
+    ``None`` also for an *empty* stream list: that is the fingerprint of a probe
+    that could not find anything to work with -- typically a corrupt or
+    truncated source -- not positive evidence that the format holds nothing the
+    profile could use, so it stays a genuine ``failed`` with ffmpeg's stderr
+    rather than being reported as a silent, note-less ``unsupported``. Otherwise
+    returns one drop note per stream, reusing D1 of
     ``docs/design/stream-decision.md`` so the reporting stays identical to an
     ordinary unsupported-type drop. Derived entirely from the probe, never from
     ffmpeg's stderr (``docs/constitution.md``).
     """
-    if any(stream.codec_type in profile.rules for stream in streams):
+    if not streams or any(stream.codec_type in profile.rules for stream in streams):
         return None
     return tuple(_drop_note(stream, f"not supported by {profile.label}") for stream in streams)
+
+
+# Invariant this discriminator leans on, and does not itself check: a profile's
+# `last_resort` must never map a stream type it declares no rule for, or the
+# short-circuit in `batch._attempt_conversion` -- which reports `unsupported`
+# and never calls `retries()` -- would skip a rung that could have succeeded.
+# Both shipped profiles satisfy this by construction (MP4's last resort maps
+# only the video/audio types its own rules cover; WAV declares none at all),
+# the same way `docs/design/degradation-ladder.md` already asks
+# `partial_mapping` profiles to keep their rules and their cheap attempt in
+# agreement.

--- a/converter/jobs.py
+++ b/converter/jobs.py
@@ -3,45 +3,22 @@
 The engine holds no format-specific fact -- no codec name, no container option,
 no degradation-note wording. Every such fact lives in the ``Profile`` it is
 handed (``converter/profiles.py``) and is read out of that data, never written
-here. The two exceptions are ``Job`` -- the public shape ``cli.py`` and
-``batch.py`` already depend on -- and ``JOB_BINDINGS`` below it, which is CLI
-wiring (source suffixes, sub-command name, progress-bar label) rather than
-target-format knowledge, and is marked as phase-2 scaffolding: it disappears
-once ``--to`` replaces the ``video``/``audio`` sub-commands
-(``docs/specs/spec-profile-registry.md``).
+here. ``batch.py`` calls this module's entry points directly and never reads a
+profile's rules itself -- the boundary ``docs/architecture.md`` draws between
+"carries a profile" and "decides with one".
 
 See ``docs/design/degradation-ladder.md`` for the order of attempts this module
-builds, and ``docs/design/stream-decision.md`` for how one stream's fate is
-decided inside the engine-built rung.
+builds, ``docs/design/stream-decision.md`` for how one stream's fate is decided
+inside the engine-built rung, and
+``docs/specs/spec-target-driven-cli.md`` for the ``unsupported`` discriminator
+:func:`describe_unsupported` implements.
 """
 
-from collections.abc import Callable, Sequence
-from dataclasses import dataclass, field, replace
+from collections.abc import Sequence
+from dataclasses import replace
 
 from converter.ffmpegtool import Stream
-from converter.profiles import MP4, WAV, Attempt, Profile
-
-
-@dataclass(frozen=True)
-class Job:
-    """A source suffix, a target suffix, and how to get from one to the other.
-
-    ``verify_success`` turns the source's stream list into the notes the *cheap*
-    attempt owes once it has already succeeded, and is ``None`` for a cheap
-    attempt whose mapping is exhaustive -- which is how ``batch.py`` knows
-    whether that success is worth an ffprobe round-trip at all
-    (``docs/design/degradation-ladder.md``).
-    """
-
-    name: str
-    description: str
-    suffixes: tuple[str, ...]
-    target_suffix: str
-    first_attempt: Callable[[], Attempt] = field(repr=False)
-    retries: Callable[[Sequence[Stream]], list[Attempt]] = field(repr=False)
-    verify_success: Callable[[Sequence[Stream]], tuple[str, ...]] | None = field(
-        default=None, repr=False
-    )
+from converter.profiles import Attempt, Profile
 
 
 def _with_container_options(attempt: Attempt, profile: Profile) -> Attempt:
@@ -172,89 +149,50 @@ def _build_selective(profile: Profile, streams: Sequence[Stream]) -> Attempt | N
     return Attempt("selective", (*maps, *codecs), tuple(notes))
 
 
-def make_attempts(
-    profile: Profile,
-) -> tuple[Callable[[], Attempt], Callable[[Sequence[Stream]], list[Attempt]]]:
-    """Build the ``(first_attempt, retries)`` pair degradation-ladder.md needs."""
-
-    def first_attempt() -> Attempt:
-        return _with_container_options(profile.cheap_attempt, profile)
-
-    def retries(streams: Sequence[Stream]) -> list[Attempt]:
-        attempts: list[Attempt] = []
-        selective = _build_selective(profile, streams)
-        if selective is not None:
-            attempts.append(_with_container_options(selective, profile))
-        if profile.last_resort is not None:
-            attempts.append(_with_container_options(profile.last_resort, profile))
-        return attempts
-
-    return first_attempt, retries
+def first_attempt(profile: Profile) -> Attempt:
+    """Rung 1 of degradation-ladder.md: *profile*'s own cheap attempt."""
+    return _with_container_options(profile.cheap_attempt, profile)
 
 
-def make_verifier(profile: Profile) -> Callable[[Sequence[Stream]], tuple[str, ...]] | None:
-    """Build the success-side verifier of degradation-ladder.md, if one is owed.
+def retries(profile: Profile, streams: Sequence[Stream]) -> list[Attempt]:
+    """The rest of the ladder, built from the source's probed *streams*."""
+    attempts: list[Attempt] = []
+    selective = _build_selective(profile, streams)
+    if selective is not None:
+        attempts.append(_with_container_options(selective, profile))
+    if profile.last_resort is not None:
+        attempts.append(_with_container_options(profile.last_resort, profile))
+    return attempts
 
-    A profile whose cheap attempt maps the source exhaustively gets ``None``, and
-    its happy path then still costs no ffprobe round-trip -- the narrowed form of
-    the rule in ``docs/constitution.md``.
+
+def needs_verification(profile: Profile) -> bool:
+    """Whether a successful cheap attempt is worth an ffprobe round-trip.
+
+    True only for a profile whose cheap attempt is declared partial by
+    construction (``docs/design/degradation-ladder.md``) -- the narrowed happy
+    path in ``docs/constitution.md`` keeps every other profile's success
+    probe-free.
     """
-    if not profile.partial_mapping:
+    return profile.partial_mapping
+
+
+def verify_success(profile: Profile, streams: Sequence[Stream]) -> tuple[str, ...]:
+    """The success-side verifier of degradation-ladder.md: what a partial cheap
+    attempt's mapping could not have carried over, named per stream."""
+    return _unmapped_notes(profile, streams)
+
+
+def describe_unsupported(profile: Profile, streams: Sequence[Stream]) -> tuple[str, ...] | None:
+    """The ``unsupported`` discriminator: "no rule matches any present stream".
+
+    ``None`` means the source carries at least one stream type *profile* has a
+    rule for -- that stream may still be dropped for shape or codec reasons, but
+    that is a genuine ``failed``, not this (``docs/specs/spec-target-driven-cli.md``).
+    Otherwise returns one drop note per stream, reusing D1 of
+    ``docs/design/stream-decision.md`` so the reporting stays identical to an
+    ordinary unsupported-type drop. Derived entirely from the probe, never from
+    ffmpeg's stderr (``docs/constitution.md``).
+    """
+    if any(stream.codec_type in profile.rules for stream in streams):
         return None
-
-    def verify(streams: Sequence[Stream]) -> tuple[str, ...]:
-        return _unmapped_notes(profile, streams)
-
-    return verify
-
-
-@dataclass(frozen=True)
-class _Binding:
-    """A source-pair binding: CLI-visible name plus which suffixes feed which
-    profile. This is CLI wiring, not target-format knowledge -- the exemption
-    the module docstring describes -- and is phase-2 scaffolding, removed once
-    ``--to`` replaces the ``video``/``audio`` sub-commands.
-    """
-
-    name: str
-    description: str
-    suffixes: tuple[str, ...]
-    profile: Profile
-
-
-#: Phase-2 scaffolding (see the module docstring and ``_Binding``).
-JOB_BINDINGS: dict[str, _Binding] = {
-    "video": _Binding(
-        name="mkv-to-mp4",
-        description="Convert .mkv files to .mp4 (stream copy where possible)",
-        suffixes=(".mkv",),
-        profile=MP4,
-    ),
-    "audio": _Binding(
-        name="opus-to-wav",
-        description="Convert .opus files to uncompressed .wav",
-        suffixes=(".opus",),
-        profile=WAV,
-    ),
-}
-
-
-def _job_from_binding(binding: _Binding) -> Job:
-    """The factory the issue asks for: wire the generic engine to one profile."""
-    first_attempt, retries = make_attempts(binding.profile)
-    return Job(
-        name=binding.name,
-        description=binding.description,
-        suffixes=binding.suffixes,
-        target_suffix=binding.profile.target_suffix,
-        first_attempt=first_attempt,
-        retries=retries,
-        verify_success=make_verifier(binding.profile),
-    )
-
-
-MKV_TO_MP4 = _job_from_binding(JOB_BINDINGS["video"])
-OPUS_TO_WAV = _job_from_binding(JOB_BINDINGS["audio"])
-
-#: Sub-command name -> job.
-JOBS: dict[str, Job] = {"video": MKV_TO_MP4, "audio": OPUS_TO_WAV}
+    return tuple(_drop_note(stream, f"not supported by {profile.label}") for stream in streams)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,6 +79,14 @@ The internal import graph is acyclic today and must stay that way:
 4. **Failure.** The partially written output is removed, the file is recorded as
    `failed` with ffmpeg's stderr, the batch keeps going for every other file, and
    the process exits 1 at the end.
+5. **Unsupported.** Reached only from the failure-side probe of step 2: when the
+   source carries no stream of any type the target profile has a rule for at
+   all, `jobs.py` reports that as a distinguishable signal instead of climbing
+   the rest of the ladder, `batch.py` maps it onto a counted `unsupported`
+   outcome, and the partially written output is removed the same way a
+   `failed` one is -- but the outcome does not set the exit code, so a re-run
+   over a mixed tree reports the same thing rather than failing forever
+   (`docs/specs/spec-target-driven-cli.md`).
 
 ## Where new code goes
 

--- a/docs/specs/spec-target-driven-cli.md
+++ b/docs/specs/spec-target-driven-cli.md
@@ -373,3 +373,11 @@ reusing the fixtures the phase-1 gate synthesises:
   inserting `unsupported` in the middle — existing tests and the vision's
   `0 converted, 0 failed` phrasing both check substrings, so appending keeps
   every one of them true unchanged instead of requiring a coordinated update.
+- 2026-08-26 (#14, review round 1): `jobs.describe_unsupported` returned a
+  non-`None` empty tuple for an *empty* probed-stream list, so a corrupt or
+  truncated source (a probe that succeeds but finds nothing) was reported as
+  `unsupported` with no notes and no error text — losing ffmpeg's stderr that
+  a plain `failed` used to carry, and quietly relabelling exactly the case this
+  spec's own mixed-tree write-up warns against. Fixed: an empty stream list now
+  returns `None` too, so the source falls through to the ordinary ladder and
+  ends up `failed` with its stderr kept, same as before this issue.

--- a/docs/specs/spec-target-driven-cli.md
+++ b/docs/specs/spec-target-driven-cli.md
@@ -341,3 +341,35 @@ reusing the fixtures the phase-1 gate synthesises:
   existing pattern of raising `ValueError` for a usage problem that `cli.py`
   (issue #15) turns into its exit-2 `UsageError` — `profiles.py` cannot import
   `UsageError` itself without breaking the leaf-module constraint.
+- 2026-08-26 (#14): Beyond `jobs.first_attempt(profile)` and
+  `jobs.retries(profile, streams)`, which this spec already named, three more
+  entry points were needed and were left to this issue to establish:
+  `jobs.needs_verification(profile)` and `jobs.verify_success(profile, streams)`
+  replace the old `make_verifier`-built closure, and `jobs.describe_unsupported(
+  profile, streams)` is the `unsupported` discriminator itself. It returns
+  `None` when the source carries at least one stream type the profile has a
+  rule for, else a tuple of per-stream drop notes (reusing D1 of
+  `docs/design/stream-decision.md` so an unsupported source is reported exactly
+  like an ordinary unsupported-type drop) — never a bare boolean, so `batch.py`
+  gets the notes it reports for free rather than having to invent wording of
+  its own.
+- 2026-08-26 (#14): The discriminator is applied right after the failure-side
+  probe, before `jobs.retries` is ever called, and short-circuits straight to
+  the `unsupported` outcome. A source with no stream of any type the profile
+  declares a rule for cannot produce a non-empty `-map` list on any later rung
+  either, so climbing the rest of the ladder would only re-spend ffmpeg calls to
+  reconfirm what the probe already established — the "one ffmpeg attempt and
+  one ffprobe" cost this spec's mixed-tree write-up already promises, not more.
+- 2026-08-26 (#14): `Job`, `JOBS` and `JOB_BINDINGS` are deleted from
+  `jobs.py` outright, per this spec's decision log, rather than renamed or
+  moved there. The CLI-visible `video`/`audio` -> suffixes/profile wiring they
+  carried still has to live somewhere until issue #15 replaces the
+  sub-commands with `--to`, so it moved to a private `cli._Binding` /
+  `cli._BINDINGS` in `converter/cli.py` — the smallest change that keeps
+  `build_parser` and `convert_command` working without the deleted names, and
+  scaffolding issue #15 already plans to remove.
+- 2026-08-26 (#14): `Summary.describe()`'s format gained a fourth clause
+  (`"... {failed} failed, {unsupported} unsupported (of {total})"`) rather than
+  inserting `unsupported` in the middle — existing tests and the vision's
+  `0 converted, 0 failed` phrasing both check substrings, so appending keeps
+  every one of them true unchanged instead of requiring a coordinated update.

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -5,9 +5,8 @@ from dataclasses import replace
 
 import pytest
 
-from converter import ffmpegtool
+from converter import ffmpegtool, jobs
 from converter.ffmpegtool import Stream, build_argv, cli_path
-from converter.jobs import MKV_TO_MP4, OPUS_TO_WAV, make_verifier
 from converter.profiles import MP4, WAV
 
 
@@ -92,7 +91,7 @@ class TestRunIsShellFree:
 
 class TestWavJob:
     def test_first_attempt_is_pcm(self):
-        attempt = OPUS_TO_WAV.first_attempt()
+        attempt = jobs.first_attempt(WAV)
 
         assert attempt.options == ("-map", "0:a:0", "-c:a", "pcm_s16le")
         assert attempt.notes == ()
@@ -100,7 +99,7 @@ class TestWavJob:
     def test_single_audio_stream_needs_no_fallback(self):
         streams = [Stream(0, "audio", "opus")]
 
-        assert OPUS_TO_WAV.retries(streams) == []
+        assert jobs.retries(WAV, streams) == []
 
     def test_multiple_audio_streams_fall_back_to_a_selective_rung(self):
         """Deltas 2 and 3: the note names the dropped stream and its codec, and
@@ -108,7 +107,7 @@ class TestWavJob:
         'first-audio-stream'. The argv is unchanged."""
         streams = [Stream(0, "audio", "opus"), Stream(1, "audio", "opus")]
 
-        attempts = OPUS_TO_WAV.retries(streams)
+        attempts = jobs.retries(WAV, streams)
 
         assert len(attempts) == 1
         assert attempts[0].label == "selective"
@@ -120,16 +119,15 @@ class TestWavJob:
         all; it now reaches a selective rung that drops it with a note."""
         streams = [Stream(0, "audio", "opus"), Stream(1, "video", "mjpeg")]
 
-        attempts = OPUS_TO_WAV.retries(streams)
+        attempts = jobs.retries(WAV, streams)
 
         assert len(attempts) == 1
         assert attempts[0].label == "selective"
         assert attempts[0].options == ("-map", "0:0", "-c:a", "pcm_s16le")
         assert attempts[0].notes == ("video stream 1 (mjpeg) dropped: not supported by WAV",)
 
-    def test_job_metadata(self):
-        assert OPUS_TO_WAV.suffixes == (".opus",)
-        assert OPUS_TO_WAV.target_suffix == ".wav"
+    def test_target_suffix(self):
+        assert WAV.target_suffix == ".wav"
 
     def test_pcm_reencode_of_the_kept_stream_carries_no_note(self):
         """Decoding to PCM is WAV's own definition, not a loss (Verification,
@@ -138,7 +136,7 @@ class TestWavJob:
         Only the surplus stream's drop is reported."""
         streams = [Stream(0, "audio", "opus"), Stream(1, "audio", "opus")]
 
-        attempts = OPUS_TO_WAV.retries(streams)
+        attempts = jobs.retries(WAV, streams)
 
         assert len(attempts[0].notes) == 1
         assert not any("stream 0" in note for note in attempts[0].notes)
@@ -146,7 +144,7 @@ class TestWavJob:
 
 class TestMp4Remux:
     def test_stream_copies_and_converts_text_subtitles(self):
-        options = MKV_TO_MP4.first_attempt().options
+        options = jobs.first_attempt(MP4).options
 
         assert "-c" in options
         assert options[options.index("-c") + 1] == "copy"
@@ -156,16 +154,15 @@ class TestMp4Remux:
     def test_does_not_use_bare_map_zero(self):
         """'-map 0' also selects MKV attachments and data streams, which MP4
         cannot hold, so a remuxable file would fail for no good reason."""
-        options = list(MKV_TO_MP4.first_attempt().options)
+        options = list(jobs.first_attempt(MP4).options)
         mapped = [options[i + 1] for i, flag in enumerate(options) if flag == "-map"]
 
         assert "0" not in mapped
         assert mapped == ["0:v?", "0:a?", "0:s?"]
 
-    def test_job_metadata(self):
-        assert MKV_TO_MP4.suffixes == (".mkv",)
-        assert MKV_TO_MP4.target_suffix == ".mp4"
-        assert MKV_TO_MP4.first_attempt().options == (
+    def test_target_suffix(self):
+        assert MP4.target_suffix == ".mp4"
+        assert jobs.first_attempt(MP4).options == (
             "-map",
             "0:v?",
             "-map",
@@ -183,14 +180,14 @@ class TestMp4Remux:
 
 class TestMp4Retries:
     def test_ladder_ends_with_a_full_reencode(self):
-        attempts = MKV_TO_MP4.retries([Stream(0, "video", "h264")])
+        attempts = jobs.retries(MP4, [Stream(0, "video", "h264")])
 
         assert [a.label for a in attempts] == ["selective", "re-encode"]
 
     def test_selective_copies_compatible_streams(self):
         streams = [Stream(0, "video", "h264"), Stream(1, "audio", "aac")]
 
-        selective = MKV_TO_MP4.retries(streams)[0]
+        selective = jobs.retries(MP4, streams)[0]
 
         assert selective.options[:8] == (
             "-map",
@@ -207,7 +204,7 @@ class TestMp4Retries:
     def test_selective_reencodes_audio_mp4_cannot_hold(self):
         streams = [Stream(0, "video", "h264"), Stream(1, "audio", "pcm_s16le")]
 
-        selective = MKV_TO_MP4.retries(streams)[0]
+        selective = jobs.retries(MP4, streams)[0]
 
         assert "-c:a:0" in selective.options
         assert selective.options[selective.options.index("-c:a:0") + 1] == "aac"
@@ -220,7 +217,7 @@ class TestMp4Retries:
             Stream(2, "subtitle", "hdmv_pgs_subtitle"),
         ]
 
-        selective = MKV_TO_MP4.retries(streams)[0]
+        selective = jobs.retries(MP4, streams)[0]
 
         assert "-map" in selective.options
         assert "0:2" not in selective.options
@@ -229,7 +226,7 @@ class TestMp4Retries:
     def test_selective_keeps_text_subtitles_as_mov_text(self):
         streams = [Stream(0, "video", "h264"), Stream(1, "subtitle", "subrip")]
 
-        selective = MKV_TO_MP4.retries(streams)[0]
+        selective = jobs.retries(MP4, streams)[0]
 
         assert "-c:s:0" in selective.options
         assert selective.options[selective.options.index("-c:s:0") + 1] == "mov_text"
@@ -238,7 +235,7 @@ class TestMp4Retries:
         """Delta 1: the note now names the codec too."""
         streams = [Stream(0, "video", "h264"), Stream(1, "attachment", "ttf")]
 
-        selective = MKV_TO_MP4.retries(streams)[0]
+        selective = jobs.retries(MP4, streams)[0]
 
         assert "0:1" not in selective.options
         assert selective.notes == ("attachment stream 1 (ttf) dropped: not supported by MP4",)
@@ -252,7 +249,7 @@ class TestMp4Retries:
             Stream(3, "audio", "flac"),
         ]
 
-        selective = MKV_TO_MP4.retries(streams)[0]
+        selective = jobs.retries(MP4, streams)[0]
 
         assert "-c:a:0" in selective.options
         assert "-c:a:1" in selective.options
@@ -261,12 +258,12 @@ class TestMp4Retries:
         assert "-c:s:0" in selective.options
 
     def test_no_mappable_stream_skips_straight_to_reencode(self):
-        attempts = MKV_TO_MP4.retries([Stream(0, "attachment", "ttf")])
+        attempts = jobs.retries(MP4, [Stream(0, "attachment", "ttf")])
 
         assert [a.label for a in attempts] == ["re-encode"]
 
     def test_reencode_states_what_it_sacrifices(self):
-        reencode = MKV_TO_MP4.retries([])[-1]
+        reencode = jobs.retries(MP4, [])[-1]
 
         assert "libx264" in reencode.options
         assert "aac" in reencode.options
@@ -282,14 +279,14 @@ class TestMp4DegradationNotes:
     def test_video_reencode_note_is_exact(self):
         streams = [Stream(0, "video", "vp8"), Stream(1, "audio", "aac")]
 
-        selective = MKV_TO_MP4.retries(streams)[0]
+        selective = jobs.retries(MP4, streams)[0]
 
         assert selective.notes == ("video stream 0 (vp8) re-encoded to h264",)
 
     def test_audio_reencode_note_is_exact(self):
         streams = [Stream(0, "video", "h264"), Stream(1, "audio", "pcm_s16le")]
 
-        selective = MKV_TO_MP4.retries(streams)[0]
+        selective = jobs.retries(MP4, streams)[0]
 
         assert selective.notes == ("audio stream 1 (pcm_s16le) re-encoded to aac",)
 
@@ -300,7 +297,7 @@ class TestMp4DegradationNotes:
             Stream(2, "subtitle", "hdmv_pgs_subtitle"),
         ]
 
-        selective = MKV_TO_MP4.retries(streams)[0]
+        selective = jobs.retries(MP4, streams)[0]
 
         assert selective.notes == (
             "subtitle stream 2 (hdmv_pgs_subtitle) dropped: "
@@ -310,7 +307,7 @@ class TestMp4DegradationNotes:
     def test_last_resort_notes_are_pinned(self):
         """The two notes are the last-resort attempt's own data (Verification:
         'lossy re-encode; 10-bit/HDR reduced to 8-bit'), not engine wording."""
-        reencode = MKV_TO_MP4.retries([])[-1]
+        reencode = jobs.retries(MP4, [])[-1]
 
         assert reencode.notes == (
             "re-encoded to h264/aac (lossy); subtitles and extra video streams dropped",
@@ -324,7 +321,7 @@ class TestProfileArgvPinning:
 
     def test_mp4_copyable_source(self):
         streams = [Stream(0, "video", "h264"), Stream(1, "audio", "aac")]
-        selective = MKV_TO_MP4.retries(streams)[0]
+        selective = jobs.retries(MP4, streams)[0]
 
         argv = build_argv("ffmpeg", "in.mkv", selective.options, "out.mp4")
 
@@ -352,7 +349,7 @@ class TestProfileArgvPinning:
 
     def test_mp4_non_copyable_source(self):
         streams = [Stream(0, "video", "vp8"), Stream(1, "audio", "pcm_s16le")]
-        selective = MKV_TO_MP4.retries(streams)[0]
+        selective = jobs.retries(MP4, streams)[0]
 
         argv = build_argv("ffmpeg", "in.mkv", selective.options, "out.mp4")
 
@@ -383,7 +380,7 @@ class TestProfileArgvPinning:
         ]
 
     def test_wav_single_audio_source(self):
-        argv = build_argv("ffmpeg", "in.opus", OPUS_TO_WAV.first_attempt().options, "out.wav")
+        argv = build_argv("ffmpeg", "in.opus", jobs.first_attempt(WAV).options, "out.wav")
 
         assert argv == [
             "ffmpeg",
@@ -403,7 +400,7 @@ class TestProfileArgvPinning:
 
     def test_wav_two_audio_source(self):
         streams = [Stream(0, "audio", "opus"), Stream(1, "audio", "opus")]
-        selective = OPUS_TO_WAV.retries(streams)[0]
+        selective = jobs.retries(WAV, streams)[0]
 
         argv = build_argv("ffmpeg", "in.opus", selective.options, "out.wav")
 
@@ -424,30 +421,54 @@ class TestProfileArgvPinning:
         ]
 
 
+class TestUnsupportedDiscriminator:
+    """`jobs.describe_unsupported`: "no rule matches any present stream"
+    (docs/specs/spec-target-driven-cli.md), derived from the probe alone."""
+
+    def test_a_type_with_no_rule_at_all_is_unsupported(self):
+        notes = jobs.describe_unsupported(WAV, [Stream(0, "video", "h264")])
+
+        assert notes == ("video stream 0 (h264) dropped: not supported by WAV",)
+
+    def test_a_type_the_profile_has_a_rule_for_is_supported(self):
+        """The codec itself may still be dropped or re-encoded later -- that is
+        a structural or codec-level verdict, not this one."""
+        assert jobs.describe_unsupported(WAV, [Stream(0, "audio", "opus")]) is None
+
+    def test_one_matching_stream_among_several_is_enough_to_be_supported(self):
+        streams = [Stream(0, "video", "h264"), Stream(1, "attachment", "ttf")]
+
+        assert jobs.describe_unsupported(MP4, streams) is None
+
+    def test_a_source_with_no_stream_the_profile_can_use_at_all_is_unsupported(self):
+        """MP4 declares no ``attachment`` rule, same as WAV declares no
+        ``video`` one -- the discriminator is type-level, not format-specific."""
+        notes = jobs.describe_unsupported(MP4, [Stream(0, "attachment", "ttf")])
+
+        assert notes == ("attachment stream 0 (ttf) dropped: not supported by MP4",)
+
+
 class TestSuccessSideVerification:
-    """`make_verifier`: what the engine owes a cheap attempt that already won."""
+    """`jobs.needs_verification` / `jobs.verify_success`: what the engine owes
+    a cheap attempt that already won."""
 
-    def test_a_partial_profile_gets_a_verifier(self):
-        assert make_verifier(MP4) is not None
-        assert make_verifier(WAV) is not None
+    def test_a_partial_profile_needs_verification(self):
+        assert jobs.needs_verification(MP4) is True
+        assert jobs.needs_verification(WAV) is True
 
-    def test_an_exhaustive_profile_gets_none(self):
-        """`None` is what keeps the probe off an exhaustive profile's happy path."""
-        assert make_verifier(replace(MP4, partial_mapping=False)) is None
+    def test_an_exhaustive_profile_does_not(self):
+        """`False` is what keeps the probe off an exhaustive profile's happy path."""
+        assert jobs.needs_verification(replace(MP4, partial_mapping=False)) is False
 
     def test_mp4_names_the_attachment_its_selectors_cannot_reach(self):
-        verify = make_verifier(MP4)
-        assert verify is not None
+        streams = [Stream(0, "video", "h264"), Stream(1, "attachment", "ttf")]
 
-        notes = verify([Stream(0, "video", "h264"), Stream(1, "attachment", "ttf")])
+        notes = jobs.verify_success(MP4, streams)
 
         assert notes == ("attachment stream 1 (ttf) dropped: not supported by MP4",)
 
     def test_wav_names_the_audio_stream_its_single_index_cannot_reach(self):
-        verify = make_verifier(WAV)
-        assert verify is not None
-
-        notes = verify([Stream(0, "audio", "opus"), Stream(1, "audio", "opus")])
+        notes = jobs.verify_success(WAV, [Stream(0, "audio", "opus"), Stream(1, "audio", "opus")])
 
         assert notes == ("audio stream 1 (opus) dropped: WAV holds 1 audio stream",)
 
@@ -455,25 +476,21 @@ class TestSuccessSideVerification:
     def test_no_profile_invents_a_loss_for_a_source_it_fully_maps(self, profile):
         """One stream of each type the profile declares a rule for, and never more
         than one, so nothing in this source can have been left behind."""
-        verify = make_verifier(profile)
-        assert verify is not None
-
         streams = [Stream(i, kind, "whatever") for i, kind in enumerate(profile.rules)]
 
-        assert verify(streams) == ()
+        assert jobs.verify_success(profile, streams) == ()
 
     def test_a_codec_outside_the_copy_mask_produces_no_note(self):
         """Codec-level verdicts are out of scope here: the attempt exited 0, so
         the stream was carried over whatever the copy mask says."""
-        verify = make_verifier(MP4)
-        assert verify is not None
+        streams = [Stream(0, "video", "vp8"), Stream(1, "subtitle", "dvd_subtitle")]
 
-        assert verify([Stream(0, "video", "vp8"), Stream(1, "subtitle", "dvd_subtitle")]) == ()
+        assert jobs.verify_success(MP4, streams) == ()
 
 
 @pytest.mark.parametrize(
     "attempt",
-    [MKV_TO_MP4.first_attempt(), *MKV_TO_MP4.retries([Stream(0, "video", "h264")])],
+    [jobs.first_attempt(MP4), *jobs.retries(MP4, [Stream(0, "video", "h264")])],
 )
 def test_every_attempt_produces_a_wellformed_command(attempt):
     argv = build_argv("ffmpeg", "in.mkv", attempt.options, "out.mp4")

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -447,6 +447,14 @@ class TestUnsupportedDiscriminator:
 
         assert notes == ("attachment stream 0 (ttf) dropped: not supported by MP4",)
 
+    def test_an_empty_stream_list_is_not_reported_as_unsupported(self):
+        """An empty probe result is the fingerprint of a corrupt or truncated
+        source, not positive evidence the format holds nothing usable -- it
+        must fall through to a genuine ``failed`` with ffmpeg's stderr kept,
+        rather than a silent, note-less ``unsupported``."""
+        assert jobs.describe_unsupported(MP4, []) is None
+        assert jobs.describe_unsupported(WAV, []) is None
+
 
 class TestSuccessSideVerification:
     """`jobs.needs_verification` / `jobs.verify_success`: what the engine owes

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -7,21 +7,20 @@ import pytest
 from converter import batch
 from converter.batch import Outcome, Result, Task, convert_one, run_batch, summarise
 from converter.ffmpegtool import CommandResult, ProbeError, Stream, Tools
-from converter.jobs import MKV_TO_MP4, OPUS_TO_WAV, Job, make_attempts, make_verifier
-from converter.profiles import Attempt, Profile, StreamRule, flags
+from converter.profiles import MP4, WAV, Attempt, Profile, StreamRule, flags
 
 TOOLS = Tools(ffmpeg="ffmpeg", ffprobe="ffprobe")
 
 
-def exhaustive_job() -> Job:
-    """A job whose cheap attempt maps everything its source can carry.
+def exhaustive_profile() -> Profile:
+    """A profile whose cheap attempt maps everything its source can carry.
 
     No shipped profile is exhaustive -- MP4's ``?``-selectors and WAV's single
     index are both partial by construction -- so the half of the narrowed
     happy-path rule that keeps an exhaustive cheap attempt probe-free needs a
     profile of its own before it can be asserted at all.
     """
-    profile = Profile(
+    return Profile(
         label="EXH",
         name="exh",
         description="a test double, not a shipped format",
@@ -31,16 +30,6 @@ def exhaustive_job() -> Job:
         explicit_streams=False,
         partial_mapping=False,
         rules={"video": StreamRule(frozenset({"h264"}), flags("-c:v copy"))},
-    )
-    first_attempt, retries = make_attempts(profile)
-    return Job(
-        name="exhaustive",
-        description="a test double, not a shipped format",
-        suffixes=(".mkv",),
-        target_suffix=profile.target_suffix,
-        first_attempt=first_attempt,
-        retries=retries,
-        verify_success=make_verifier(profile),
     )
 
 
@@ -103,7 +92,7 @@ class TestConvertOne:
         task = make_task(tmp_path)
         task.dst.parent.mkdir(parents=True)
 
-        result = convert_one(MKV_TO_MP4, task, TOOLS, overwrite=False)
+        result = convert_one(MP4, task, TOOLS, overwrite=False)
 
         assert result.outcome is Outcome.CONVERTED
         assert result.attempt == "remux"
@@ -114,7 +103,7 @@ class TestConvertOne:
         task.dst.parent.mkdir(parents=True)
         task.dst.write_bytes(b"already there")
 
-        result = convert_one(MKV_TO_MP4, task, TOOLS, overwrite=False)
+        result = convert_one(MP4, task, TOOLS, overwrite=False)
 
         assert result.outcome is Outcome.SKIPPED
         assert fake_ffmpeg.calls == []
@@ -125,7 +114,7 @@ class TestConvertOne:
         task.dst.parent.mkdir(parents=True)
         task.dst.write_bytes(b"already there")
 
-        result = convert_one(MKV_TO_MP4, task, TOOLS, overwrite=True)
+        result = convert_one(MP4, task, TOOLS, overwrite=True)
 
         assert result.outcome is Outcome.CONVERTED
         assert len(fake_ffmpeg.calls) == 1
@@ -136,7 +125,7 @@ class TestConvertOne:
         fake_ffmpeg.exit_codes = [1, 0]
         fake_ffmpeg.streams = [Stream(0, "video", "h264"), Stream(1, "audio", "pcm_s16le")]
 
-        result = convert_one(MKV_TO_MP4, task, TOOLS, overwrite=False)
+        result = convert_one(MP4, task, TOOLS, overwrite=False)
 
         assert result.outcome is Outcome.CONVERTED
         assert result.attempt == "selective"
@@ -155,7 +144,7 @@ class TestConvertOne:
         task.dst.parent.mkdir(parents=True)
         probes = spy_on_probe(monkeypatch, [])
 
-        result = convert_one(exhaustive_job(), task, TOOLS, overwrite=False)
+        result = convert_one(exhaustive_profile(), task, TOOLS, overwrite=False)
 
         assert result.outcome is Outcome.CONVERTED
         assert probes == []
@@ -167,7 +156,7 @@ class TestConvertOne:
         fake_ffmpeg.exit_codes = [1, 0]
         probes = spy_on_probe(monkeypatch, [Stream(0, "video", "h264")])
 
-        convert_one(MKV_TO_MP4, task, TOOLS, overwrite=False)
+        convert_one(MP4, task, TOOLS, overwrite=False)
 
         assert probes == [task.src]
 
@@ -177,7 +166,7 @@ class TestConvertOne:
         fake_ffmpeg.exit_codes = [1]
         fake_ffmpeg.streams = [Stream(0, "video", "h264")]
 
-        result = convert_one(MKV_TO_MP4, task, TOOLS, overwrite=False)
+        result = convert_one(MP4, task, TOOLS, overwrite=False)
 
         assert result.outcome is Outcome.FAILED
         assert "remux" in result.error
@@ -188,8 +177,11 @@ class TestConvertOne:
         task = make_task(tmp_path)
         task.dst.parent.mkdir(parents=True)
         fake_ffmpeg.exit_codes = [1]
+        # A stream MP4 has a rule for, so the whole ladder is climbed and
+        # exhausted -- a genuine failure, not the unsupported outcome.
+        fake_ffmpeg.streams = [Stream(0, "video", "h264")]
 
-        result = convert_one(MKV_TO_MP4, task, TOOLS, overwrite=False)
+        result = convert_one(MP4, task, TOOLS, overwrite=False)
 
         assert result.outcome is Outcome.FAILED
         assert not task.dst.exists()
@@ -201,7 +193,7 @@ class TestConvertOne:
         fake_ffmpeg.exit_codes = [1]
         fake_ffmpeg.creates_output = False
 
-        convert_one(MKV_TO_MP4, task, TOOLS, overwrite=True)
+        convert_one(MP4, task, TOOLS, overwrite=True)
 
         assert task.dst.read_bytes() == b"good older file"
 
@@ -211,7 +203,7 @@ class TestConvertOne:
         fake_ffmpeg.exit_codes = [1]
         fake_ffmpeg.probe_error = "unreadable"
 
-        result = convert_one(MKV_TO_MP4, task, TOOLS, overwrite=False)
+        result = convert_one(MP4, task, TOOLS, overwrite=False)
 
         assert result.outcome is Outcome.FAILED
         assert "unreadable" in result.error
@@ -224,7 +216,7 @@ class TestConvertOne:
 
         monkeypatch.setattr(batch.ffmpegtool, "run", explode)
 
-        result = convert_one(MKV_TO_MP4, task, TOOLS, overwrite=False)
+        result = convert_one(MP4, task, TOOLS, overwrite=False)
 
         assert result.outcome is Outcome.FAILED
         assert "kaboom" in result.error
@@ -247,7 +239,7 @@ class TestPartialCheapAttemptVerification:
             monkeypatch, [Stream(0, "video", "h264"), Stream(1, "attachment", "ttf")]
         )
 
-        result = convert_one(MKV_TO_MP4, task, TOOLS, overwrite=False)
+        result = convert_one(MP4, task, TOOLS, overwrite=False)
 
         assert result.outcome is Outcome.CONVERTED
         assert result.attempt == "remux"
@@ -266,7 +258,7 @@ class TestPartialCheapAttemptVerification:
         task.dst.parent.mkdir(parents=True)
         fake_ffmpeg.streams = [Stream(0, "audio", "opus"), Stream(1, "audio", "opus")]
 
-        result = convert_one(OPUS_TO_WAV, task, TOOLS, overwrite=False)
+        result = convert_one(WAV, task, TOOLS, overwrite=False)
 
         assert result.outcome is Outcome.CONVERTED
         assert result.attempt == "pcm_s16le"
@@ -279,7 +271,7 @@ class TestPartialCheapAttemptVerification:
         task.dst.parent.mkdir(parents=True)
         fake_ffmpeg.streams = [Stream(0, "video", "h264"), Stream(1, "audio", "aac")]
 
-        result = convert_one(MKV_TO_MP4, task, TOOLS, overwrite=False)
+        result = convert_one(MP4, task, TOOLS, overwrite=False)
 
         assert result.outcome is Outcome.CONVERTED
         assert result.notes == ()
@@ -293,7 +285,7 @@ class TestPartialCheapAttemptVerification:
         task.dst.parent.mkdir(parents=True)
         fake_ffmpeg.streams = [Stream(0, "video", "ffv1")]
 
-        result = convert_one(MKV_TO_MP4, task, TOOLS, overwrite=False)
+        result = convert_one(MP4, task, TOOLS, overwrite=False)
 
         assert result.notes == ()
 
@@ -302,7 +294,7 @@ class TestPartialCheapAttemptVerification:
         task.dst.parent.mkdir(parents=True)
         fake_ffmpeg.probe_error = "unreadable"
 
-        result = convert_one(MKV_TO_MP4, task, TOOLS, overwrite=False)
+        result = convert_one(MP4, task, TOOLS, overwrite=False)
 
         assert result.outcome is Outcome.CONVERTED
         assert result.notes == ("could not verify which source streams were kept: unreadable",)
@@ -315,11 +307,99 @@ class TestPartialCheapAttemptVerification:
         fake_ffmpeg.exit_codes = [1, 0]
         probes = spy_on_probe(monkeypatch, [Stream(0, "video", "vp8")])
 
-        result = convert_one(MKV_TO_MP4, task, TOOLS, overwrite=False)
+        result = convert_one(MP4, task, TOOLS, overwrite=False)
 
         assert result.attempt == "selective"
         assert len(probes) == 1
         assert result.notes == ("video stream 0 (vp8) re-encoded to h264",)
+
+
+class TestUnsupportedOutcome:
+    """The `unsupported` outcome (docs/specs/spec-target-driven-cli.md): a
+    source that carries no stream of any type the target profile has a rule
+    for at all, distinct from a stream a rule drops or fails to re-encode.
+    """
+
+    def _video_only_task(self, tmp_path: Path) -> Task:
+        src = tmp_path / "clip.mkv"
+        src.write_bytes(b"data")
+        return Task(src, tmp_path / "out" / "clip.wav")
+
+    def test_a_video_only_source_under_a_wav_target_is_unsupported(self, tmp_path, fake_ffmpeg):
+        """The mixed-tree case the outcome exists for: WAV has no rule for a
+        video stream, so a video-only source can never climb its ladder."""
+        task = self._video_only_task(tmp_path)
+        task.dst.parent.mkdir(parents=True)
+        fake_ffmpeg.exit_codes = [1]
+        fake_ffmpeg.streams = [Stream(0, "video", "h264")]
+
+        result = convert_one(WAV, task, TOOLS, overwrite=False)
+
+        assert result.outcome is Outcome.UNSUPPORTED
+        assert result.notes == ("video stream 0 (h264) dropped: not supported by WAV",)
+
+    def test_unsupported_does_not_climb_the_rest_of_the_ladder(self, tmp_path, fake_ffmpeg):
+        """Only the cheap attempt and one probe are spent -- further ffmpeg
+        attempts would only reconfirm what the probe already established."""
+        task = self._video_only_task(tmp_path)
+        task.dst.parent.mkdir(parents=True)
+        fake_ffmpeg.exit_codes = [1, 0]  # a second call would succeed if it ran
+        fake_ffmpeg.streams = [Stream(0, "video", "h264")]
+
+        convert_one(WAV, task, TOOLS, overwrite=False)
+
+        assert len(fake_ffmpeg.calls) == 1
+
+    def test_unsupported_output_is_removed_like_a_failure(self, tmp_path, fake_ffmpeg):
+        task = self._video_only_task(tmp_path)
+        task.dst.parent.mkdir(parents=True)
+        fake_ffmpeg.exit_codes = [1]
+        fake_ffmpeg.streams = [Stream(0, "video", "h264")]
+
+        convert_one(WAV, task, TOOLS, overwrite=False)
+
+        assert not task.dst.exists()
+
+    def test_a_re_run_over_the_same_unsupported_source_reports_the_same_outcome(
+        self, tmp_path, fake_ffmpeg
+    ):
+        """The idempotent-re-run criterion (docs/vision.md): the outcome exists
+        precisely so a second run does not turn this into a permanent failure."""
+        task = self._video_only_task(tmp_path)
+        task.dst.parent.mkdir(parents=True)
+        fake_ffmpeg.exit_codes = [1]
+        fake_ffmpeg.streams = [Stream(0, "video", "h264")]
+
+        first = summarise([convert_one(WAV, task, TOOLS, overwrite=False)])
+        second = summarise([convert_one(WAV, task, TOOLS, overwrite=False)])
+
+        assert (first.unsupported, first.exit_code) == (1, 0)
+        assert (second.unsupported, second.exit_code) == (1, 0)
+
+    def test_a_stream_the_profile_has_a_rule_for_is_a_genuine_failure(self, tmp_path, fake_ffmpeg):
+        """The distinction that matters: a stream the profile declares a rule
+        for is never unsupported, even when every attempt still fails -- or a
+        corrupt file would be quietly relabelled (spec-target-driven-cli.md)."""
+        task = self._video_only_task(tmp_path)
+        task.dst.parent.mkdir(parents=True)
+        fake_ffmpeg.exit_codes = [1]
+        fake_ffmpeg.streams = [Stream(0, "audio", "opus")]
+
+        result = convert_one(WAV, task, TOOLS, overwrite=False)
+
+        assert result.outcome is Outcome.FAILED
+
+    def test_summarise_counts_unsupported_and_it_does_not_set_the_exit_code(self):
+        summary = summarise(
+            [
+                Result(Task(Path("video.mkv"), Path("video.wav")), Outcome.UNSUPPORTED),
+                Result(Task(Path("clip.mkv"), Path("clip.mp4")), Outcome.CONVERTED),
+            ]
+        )
+
+        assert (summary.converted, summary.unsupported, summary.failed) == (1, 1, 0)
+        assert summary.total == 2
+        assert summary.exit_code == 0
 
 
 class TestRunBatch:
@@ -328,7 +408,7 @@ class TestRunBatch:
         raced and the losers died with FileExistsError."""
         tasks = [make_task(tmp_path, f"clip{i}") for i in range(5)]
 
-        results = run_batch(MKV_TO_MP4, tasks, TOOLS, jobs=4, progress=False)
+        results = run_batch(MP4, tasks, TOOLS, jobs=4, progress=False)
 
         assert (tmp_path / "out").is_dir()
         assert all(r.outcome is Outcome.CONVERTED for r in results)
@@ -339,7 +419,7 @@ class TestRunBatch:
         src.write_bytes(b"data")
         task = Task(src, tmp_path / "out" / "a" / "b" / "clip.mp4")
 
-        results = run_batch(MKV_TO_MP4, [task], TOOLS, progress=False)
+        results = run_batch(MP4, [task], TOOLS, progress=False)
 
         assert results[0].outcome is Outcome.CONVERTED
         assert task.dst.parent.is_dir()
@@ -347,13 +427,13 @@ class TestRunBatch:
     def test_returns_one_result_per_task(self, tmp_path, fake_ffmpeg):
         tasks = [make_task(tmp_path, f"clip{i}") for i in range(7)]
 
-        results = run_batch(OPUS_TO_WAV, tasks, TOOLS, jobs=3, progress=False)
+        results = run_batch(WAV, tasks, TOOLS, jobs=3, progress=False)
 
         assert len(results) == len(tasks)
         assert {r.task.src for r in results} == {t.src for t in tasks}
 
     def test_empty_task_list_is_harmless(self, tmp_path, fake_ffmpeg):
-        assert run_batch(MKV_TO_MP4, [], TOOLS, progress=False) == []
+        assert run_batch(MP4, [], TOOLS, progress=False) == []
 
     def test_interrupt_drops_work_that_has_not_started(self, tmp_path, monkeypatch):
         """Ctrl+C used to be noticed only after every queued file had converted:
@@ -379,7 +459,7 @@ class TestRunBatch:
         monkeypatch.setattr(batch.ffmpegtool, "run", run)
 
         with pytest.raises(KeyboardInterrupt):
-            run_batch(MKV_TO_MP4, tasks, TOOLS, jobs=1, progress=False)
+            run_batch(MP4, tasks, TOOLS, jobs=1, progress=False)
 
         assert len(calls) == 3
 
@@ -395,11 +475,17 @@ class TestSummarise:
                 self._result(Outcome.CONVERTED),
                 self._result(Outcome.SKIPPED),
                 self._result(Outcome.FAILED),
+                self._result(Outcome.UNSUPPORTED),
             ]
         )
 
-        assert (summary.converted, summary.skipped, summary.failed) == (2, 1, 1)
-        assert summary.total == 4
+        assert (summary.converted, summary.skipped, summary.failed, summary.unsupported) == (
+            2,
+            1,
+            1,
+            1,
+        )
+        assert summary.total == 5
 
     def test_any_failure_makes_the_exit_code_non_zero(self):
         """The old scripts always printed 'Conversion completed.' and exited 0."""
@@ -411,11 +497,16 @@ class TestSummarise:
     def test_skipped_only_is_not_a_failure(self):
         assert summarise([self._result(Outcome.SKIPPED)]).exit_code == 0
 
+    def test_unsupported_only_is_not_a_failure(self):
+        """The whole point of the outcome: it must never set the exit code."""
+        assert summarise([self._result(Outcome.UNSUPPORTED)]).exit_code == 0
+
     def test_describe_mentions_every_bucket(self):
         text = summarise([self._result(Outcome.CONVERTED)]).describe()
 
         assert "1 converted" in text
         assert "0 failed" in text
+        assert "0 unsupported" in text
 
 
 class TestDefaultJobs:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -339,15 +339,18 @@ class TestUnsupportedOutcome:
         assert result.notes == ("video stream 0 (h264) dropped: not supported by WAV",)
 
     def test_unsupported_does_not_climb_the_rest_of_the_ladder(self, tmp_path, fake_ffmpeg):
-        """Only the cheap attempt and one probe are spent -- further ffmpeg
-        attempts would only reconfirm what the probe already established."""
-        task = self._video_only_task(tmp_path)
+        """Only the cheap attempt and one probe are spent. WAV declares no
+        last-resort rung at all, so a video-only source proves nothing here --
+        MP4 does declare one, and an attachment-only source would let it
+        *succeed* if the short-circuit did not stop the ladder first."""
+        task = make_task(tmp_path)
         task.dst.parent.mkdir(parents=True)
-        fake_ffmpeg.exit_codes = [1, 0]  # a second call would succeed if it ran
-        fake_ffmpeg.streams = [Stream(0, "video", "h264")]
+        fake_ffmpeg.exit_codes = [1, 0]  # the last-resort rung would succeed if it ran
+        fake_ffmpeg.streams = [Stream(0, "attachment", "ttf")]
 
-        convert_one(WAV, task, TOOLS, overwrite=False)
+        result = convert_one(MP4, task, TOOLS, overwrite=False)
 
+        assert result.outcome is Outcome.UNSUPPORTED
         assert len(fake_ffmpeg.calls) == 1
 
     def test_unsupported_output_is_removed_like_a_failure(self, tmp_path, fake_ffmpeg):
@@ -400,6 +403,23 @@ class TestUnsupportedOutcome:
         assert (summary.converted, summary.unsupported, summary.failed) == (1, 1, 0)
         assert summary.total == 2
         assert summary.exit_code == 0
+
+    def test_a_probe_that_finds_no_streams_at_all_stays_a_genuine_failure(
+        self, tmp_path, fake_ffmpeg
+    ):
+        """A probe that succeeds but reports zero streams is what a corrupt or
+        truncated source looks like -- not evidence the format holds nothing
+        usable -- so it must not be quietly relabelled `unsupported` with no
+        notes and no error text (docs/specs/spec-target-driven-cli.md)."""
+        task = self._video_only_task(tmp_path)
+        task.dst.parent.mkdir(parents=True)
+        fake_ffmpeg.exit_codes = [1]
+        fake_ffmpeg.streams = []
+
+        result = convert_one(WAV, task, TOOLS, overwrite=False)
+
+        assert result.outcome is Outcome.FAILED
+        assert "boom" in result.error
 
 
 class TestRunBatch:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ import pytest
 
 from converter import batch, cli
 from converter.cli import build_parser, main, prompt_for_argv
-from converter.ffmpegtool import CommandResult, Tools
+from converter.ffmpegtool import CommandResult, Stream, Tools
 
 FAKE_TOOLS = Tools(ffmpeg="ffmpeg", ffprobe="ffprobe")
 
@@ -17,8 +17,8 @@ def parse(argv: list[str]):
 
 class TestParser:
     def test_video_and_audio_subcommands_exist(self):
-        assert parse(["video", "in", "out"]).job.target_suffix == ".mp4"
-        assert parse(["audio", "in", "out"]).job.target_suffix == ".wav"
+        assert parse(["video", "in", "out"]).binding.profile.target_suffix == ".mp4"
+        assert parse(["audio", "in", "out"]).binding.profile.target_suffix == ".wav"
 
     def test_output_directory_is_optional(self):
         assert parse(["video", "in"]).output_dir is None
@@ -200,6 +200,11 @@ class TestExitCodeWiring:
     def test_a_failed_conversion_exits_one(self, tmp_path, monkeypatch, capsys):
         """The old scripts always printed 'Conversion completed.' and exited 0."""
         self._prepare(tmp_path, monkeypatch, 1)
+        # A stream MP4 has a rule for, so this stays a genuine failure rather
+        # than the unsupported outcome.
+        monkeypatch.setattr(
+            batch.ffmpegtool, "probe_streams", lambda *_a: [Stream(0, "video", "h264")]
+        )
 
         code = main(["video", str(tmp_path / "in"), str(tmp_path / "out"), "-q"])
 
@@ -208,6 +213,9 @@ class TestExitCodeWiring:
 
     def test_a_failed_conversion_leaves_no_output_behind(self, tmp_path, monkeypatch):
         self._prepare(tmp_path, monkeypatch, 1)
+        monkeypatch.setattr(
+            batch.ffmpegtool, "probe_streams", lambda *_a: [Stream(0, "video", "h264")]
+        )
 
         main(["video", str(tmp_path / "in"), str(tmp_path / "out"), "-q"])
 


### PR DESCRIPTION
## Summary

Implements issue #14 (spec: `docs/specs/spec-target-driven-cli.md`).

- `converter/jobs.py`: `Job`, `JOBS` and `JOB_BINDINGS` are gone. The engine now
  exposes plain functions the caller passes a `Profile` to directly:
  `first_attempt(profile)`, `retries(profile, streams)`,
  `needs_verification(profile)`, `verify_success(profile, streams)` (the
  `make_verifier`-built closure's replacement), and the new
  `describe_unsupported(profile, streams)` -- the "no rule matches any present
  stream" discriminator, derived from the probe and never from ffmpeg's stderr.
  It returns `None` when the source carries a stream type the profile has a
  rule for, else a tuple of per-stream drop notes.
- `converter/batch.py`: `run_batch`/`convert_one` now take a `Profile` instead
  of a `Job`. A new `Outcome.UNSUPPORTED` is reported right after the
  failure-side probe when `jobs.describe_unsupported` returns non-`None` --
  short-circuiting before `jobs.retries` runs, since a source with no matching
  stream type can never climb the rest of the ladder either. `Summary` gained
  an `unsupported` counter that is included in `describe()` but does **not**
  affect `exit_code` -- only `failed` does. The progress-bar description is
  now taken from `profile.label`.
- `converter/cli.py`: minimal touch to keep Verify green now that `Job`/`JOBS`
  are gone. The `video`/`audio` sub-commands still work exactly as before,
  wired through a small private `_Binding`/`_BINDINGS` table that carries the
  same suffix/profile pairing `JOB_BINDINGS` used to. This is explicitly
  phase-2 scaffolding that issue #15 replaces when `--to` lands.
- Test migration: `tests/test_batch.py` is off `Job`/`MKV_TO_MP4`/`OPUS_TO_WAV`
  entirely and gained a `TestUnsupportedOutcome` class covering the acceptance
  scenario (a video-only source under a WAV target is `unsupported`, exit 0,
  and reports the same on a re-run) plus the failed/unsupported distinction.
  `tests/test_argv.py` and `tests/test_cli.py` also depended on the deleted
  names and are migrated too, since Verify cannot pass otherwise; `test_cli.py`
  additionally needed its shared failure fixture given a stream WAV/MP4 has a
  rule for, so it keeps testing a genuine failure rather than accidentally
  exercising the new unsupported path.
- Decisions recorded in the spec's Decision log: the three new entry-point
  names, the short-circuit-before-retries rule, moving the CLI binding table
  into `cli.py`, and the `describe()` format change.

## Verification

- `.venv/Scripts/python.exe scripts/verify.py` green: ruff check, ruff format
  --check, pytest (217 passed).

Closes #14