### PR TITLE
docs(spec): the Decision log overstates the probe-free happy path

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,15 +50,20 @@ The internal import graph is acyclic today and must stay that way:
    `paths.find_sources` collects the inputs, `paths.find_collisions` refuses up
    front if two inputs would write to the same output, then `batch.run_batch`
    runs the profile's cheapest attempt per file through the engine in `jobs.py`.
-   On success nothing else happens — no ffprobe round-trip is ever spent —
-   *provided* that attempt's mapping is exhaustive. A profile that declares its
-   cheap attempt **partial by construction** (`partial_mapping`: MP4's blind
-   `?`-selectors reach no attachment, WAV's single index reaches no second audio
-   stream) spends one probe on success too, and every source stream that mapping
-   could not carry becomes a note. The verification reads the profile's
-   *structural* verdicts only — whether it declares a rule for the stream's type,
-   and how many streams of that type it holds — never a codec-level one: the
-   attempt exited 0, so what it did with a codec worked.
+   Every profile shipped or currently specced declares its cheap attempt
+   **partial by construction** (`partial_mapping=True`: MP4's blind
+   `?`-selectors reach no attachment, WAV's single index reaches no second
+   audio stream, and phases 3-5 follow the same shape), so a success spends one
+   `ffprobe` round-trip to verify what that mapping could not carry, and every
+   source stream it missed becomes a note. The verification reads the
+   profile's *structural* verdicts only — whether it declares a rule for the
+   stream's type, and how many streams of that type it holds — never a
+   codec-level one: the attempt exited 0, so what it did with a codec worked.
+   A profile whose cheap attempt is *exhaustive* would skip this probe
+   entirely, but no shipped or currently specced profile is one — the
+   probe-on-success branch is presently the only path a successful conversion
+   takes; see the 2026-08-26 (issue #41) entries in
+   `docs/specs/spec-profile-registry.md`'s Decision log.
 2. **Degradation.** The attempt exits non-zero, so *now* `ffmpegtool.probe_streams`
    describes the file. The engine matches each stream against the profile's copy
    mask: streams the mask accepts pass through unchanged — as a literal `copy`, or

--- a/docs/specs/spec-profile-registry.md
+++ b/docs/specs/spec-profile-registry.md
@@ -427,3 +427,29 @@ why both audio fixtures use that suffix.
   plain success. Failing an otherwise good conversion because its bookkeeping
   could not be completed would be worse than the silence being fixed; saying
   nothing would re-open it.
+- 2026-08-26 (issue #41): confirmed directly against `converter/profiles.py` that
+  neither shipped profile is exhaustive — `MP4`'s cheap attempt maps blindly by
+  type (`-map 0:v? -map 0:a? -map 0:s?`) and `WAV`'s names one index
+  (`-map 0:a:0`); both declare `partial_mapping=True`. So the probe-free branch
+  the issue #18 entries above carved out has **no live instance** today: every
+  successful conversion spends one `ffprobe`. That cost is the right trade — it
+  buys the loss accounting `docs/vision.md` names as the USP, and issue #18's
+  gate already accepted it — but it was nowhere written down that the
+  probe-free branch itself is presently unreachable, which left `docs/architecture.md`
+  and this entry's own prose reading as though the round-trip-free case were
+  still the common one.
+- 2026-08-26 (issue #41): no exhaustive profile is expected in a later phase
+  either; the branch is kept as a guard, not as a cost this project plans to pay
+  down. The three phases already specced after this one —
+  `spec-audio-formats.md` (phase 3), `spec-video-formats.md` (phase 4),
+  `spec-image-formats.md` (phase 5) — each state in their own Constraints that
+  every cheap attempt they declare selects by type or by index, so every
+  profile in that phase is partial too and must declare `partial_mapping=True`.
+  A `?`-selector (or a single named index) is what lets a cheap attempt succeed
+  on a source that happens to lack a given stream type instead of failing the
+  whole attempt; an exhaustive mapping would have to enumerate every stream by
+  explicit index, the opposite of that robustness. So the probe-on-success
+  branch is not a transitional cost waiting on a future phase to retire it —
+  every declarative profile the roadmap currently describes needs it, and it
+  serves the purpose issue #18 built it for: a guard against a silent drop, run
+  on every conversion because every conversion is, structurally, at risk of one.

--- a/docs/specs/spec-profile-registry.md
+++ b/docs/specs/spec-profile-registry.md
@@ -435,12 +435,12 @@ why both audio fixtures use that suffix.
   successful conversion spends one `ffprobe`. That cost is the right trade — it
   buys the loss accounting `docs/vision.md` names as the USP, and issue #18's
   gate already accepted it — but it was nowhere written down that the
-  probe-free branch itself is presently unreachable, which left `docs/architecture.md`
-  and this entry's own prose reading as though the round-trip-free case were
-  still the common one.
-- 2026-08-26 (issue #41): no exhaustive profile is expected in a later phase
-  either; the branch is kept as a guard, not as a cost this project plans to pay
-  down. The three phases already specced after this one —
+  probe-free branch itself is presently unreachable, which left
+  `docs/architecture.md` and this entry's own prose reading as though the
+  round-trip-free case were still the common one.
+- 2026-08-26 (issue #41): the branch is kept as a guard, not as a cost this
+  project plans to pay down — checked against every phase `docs/roadmap.md`
+  currently names. The three coverage phases already specced —
   `spec-audio-formats.md` (phase 3), `spec-video-formats.md` (phase 4),
   `spec-image-formats.md` (phase 5) — each state in their own Constraints that
   every cheap attempt they declare selects by type or by index, so every
@@ -448,8 +448,17 @@ why both audio fixtures use that suffix.
   A `?`-selector (or a single named index) is what lets a cheap attempt succeed
   on a source that happens to lack a given stream type instead of failing the
   whole attempt; an exhaustive mapping would have to enumerate every stream by
-  explicit index, the opposite of that robustness. So the probe-on-success
-  branch is not a transitional cost waiting on a future phase to retire it —
-  every declarative profile the roadmap currently describes needs it, and it
-  serves the purpose issue #18 built it for: a guard against a silent drop, run
-  on every conversion because every conversion is, structurally, at risk of one.
+  explicit index, the opposite of that robustness. Phases 6 and 7 are not yet
+  specced, so this is read from `docs/roadmap.md`'s phase descriptions rather
+  than a Constraints section: phase 6 (`stream-disposition`) adds a
+  `disposition` field so `mp3`/`m4a`/`flac` stop dropping cover art, which
+  narrows a standing note but does not change the cheap attempt's mapping shape
+  from type-selector to exhaustive; phase 7 (`lossy-source-notes`) adds a
+  curated lossy-codec set for an advisory note and does not touch mapping shape
+  at all. Neither turns a profile exhaustive on the description available today.
+  So across every phase the roadmap currently names, the probe-on-success
+  branch is not a transitional cost waiting to be retired — it serves the
+  purpose issue #18 built it for: a guard against a silent drop, run on every
+  conversion because every conversion is, structurally, at risk of one. A phase
+  not yet on the roadmap could still introduce an exhaustive profile; nothing
+  here forecloses that.


### PR DESCRIPTION
## Summary
- Neither shipped profile (`MP4`, `WAV`) is exhaustive, and every already-specced phase 3-5 profile (`spec-audio-formats.md`, `spec-video-formats.md`, `spec-image-formats.md`) declares `partial_mapping=True` too — so the probe-free branch issue #18 carved out has no live instance today, and every successful conversion spends one `ffprobe`.
- Records this in the `docs/specs/spec-profile-registry.md` Decision log (two new 2026-08-26 issue #41 entries) and rewrites `docs/architecture.md` Key flows §1 so it no longer implies the probe-free path is the common case.
- States plainly that no exhaustive profile is expected in a later phase: the branch is kept as a guard against a silent drop, not a transitional cost.

Documentation-only change — no source file touched.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)