### PR TITLE
fix(spec): narrow the cheap-attempt invariant to admit a deliberately-failing map (mov)

### DIFF
--- a/docs/design/degradation-ladder.md
+++ b/docs/design/degradation-ladder.md
@@ -63,10 +63,19 @@ flowchart TD
   of the option list is sound only while the rules and the mapping agree, so a
   profile that sets `partial_mapping` must satisfy both halves of this. A new
   profile that cannot is the bug — not the verification.
-  1. **A rule for every stream type its cheap attempt maps.** Otherwise the
-     verification announces a drop that never happened. A profile that carries
-     attachments with `-map 0:t?` has to declare an `attachment` rule, or every
-     font it faithfully copied is reported as lost.
+  1. **A rule for every stream type the cheap attempt can successfully
+     carry.** Otherwise the verification announces a drop that never
+     happened — but a type the cheap attempt maps only to *force a failure*
+     never reaches the success side `V` checks, so it needs no rule to keep
+     that check honest. `mkv` and `mov` both map `-map 0:t?`, and the two
+     need opposite treatment: MKV's muxer holds an attachment, so `mkv`
+     carries fonts on the success side and owes an `attachment` rule, or
+     every font it faithfully copied is reported as lost. MOV's muxer
+     rejects any mapped attachment outright, so `mov` maps `0:t?`
+     deliberately to make an attachment-bearing source fail the cheap
+     attempt and land on the failure side instead — the type never survives
+     to `V`, so `mov` needs no `attachment` rule (`docs/specs/spec-video-formats.md`,
+     issue #39).
   2. **No `stream_limit` on a type its cheap attempt selects blindly.** A blind
      `-map 0:a?` maps *every* audio stream, so a limit the mapping does not
      enforce would have the verification report surplus streams the output does
@@ -76,7 +85,10 @@ flowchart TD
   The two shipped profiles satisfy both by construction — MP4's selectors match
   its three rules exactly and it declares no limit, WAV names one audio index and
   limits audio to 1 — and `tests/test_profiles.py` checks the pair per profile
-  rather than leaving it to review.
+  rather than leaving it to review. A mov-shaped profile in that same test corpus
+  proves the narrowed form of rule 1 specifically: it maps `attachment` with no
+  rule for it and still passes, because the type is exempted as force-failure
+  only, not because the check was skipped.
 - **Cheapest first.** Rung 1 is whatever the profile declares as its cheap attempt:
   a *blind* stream copy for a container that can hold the source codecs
   (`-map 0:v? -map 0:a? ...`), or a *stream-explicit* selection where it cannot

--- a/docs/specs/spec-video-formats.md
+++ b/docs/specs/spec-video-formats.md
@@ -70,10 +70,16 @@ orchestrators (`docs/workflow.md`).
   that mapping could not carry is named (`docs/constitution.md`, narrowed by
   issue #18). Every cheap attempt in the table below selects by type or by
   index, so every profile in this phase is partial and must declare it --
-  together with a rule for each stream type it maps, per the invariant in
-  `docs/design/degradation-ladder.md`. `mkv`'s `-map 0:t?` is the case to
-  watch: it carries attachments, so the profile owes an `attachment` rule or
-  the fonts it keeps get reported as dropped.
+  together with a rule for each stream type it can *successfully carry*, per
+  the load-bearing form of the invariant in `docs/design/degradation-ladder.md`
+  (issue #39). `mkv` and `mov` both map `-map 0:t?`, and the two resolve
+  oppositely: `mkv`'s muxer holds an attachment, so it carries fonts on the
+  success side and the profile owes an `attachment` rule, or the fonts it
+  keeps get reported as dropped. `mov`'s muxer rejects any mapped attachment
+  outright, so mapping it there only ever forces the cheap attempt to fail
+  into the ladder when the source has one -- the type never reaches the
+  success side, so `mov` needs no `attachment` rule to keep the verification
+  honest.
 - Never report success for a conversion that silently dropped something.
 - The test suite keeps passing with no ffmpeg installed.
 
@@ -256,3 +262,15 @@ New-Item -ItemType Directory -Force in
 - 2026-08-26: `mp4`'s standing-note hole is left open deliberately, following the
   phase-3 gate's `wav` precedent — the two holes are better closed together in
   one later phase than piecemeal.
+- 2026-08-26 (issue #39): The cheap-attempt invariant in
+  `docs/design/degradation-ladder.md` ("a rule for every stream type its cheap
+  attempt maps") was too broad: `mov` maps `attachment` via `-map 0:t?`
+  deliberately to force a failure into the ladder, never to carry one on the
+  success side, so a mov-shaped profile has no `attachment` rule and would
+  fail that reading. Resolved by narrowing the invariant to the types the
+  cheap attempt can *successfully carry* -- a type mapped only to force a
+  failure never reaches the success-side check -- rather than by adding a
+  drop-only `attachment` `StreamRule` to `mov`. Both docs now name `mov`
+  alongside `mkv` as the pair that distinguishes the two readings, and
+  `tests/test_profiles.py` proves the narrowed form with a mov-shaped profile
+  in its test corpus.

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -26,6 +26,44 @@ MAP_LETTERS = {"v": "video", "a": "audio", "s": "subtitle", "t": "attachment", "
 #: Every profile the registry ships. A new one joins the invariant checks here.
 SHIPPED = [MP4, WAV]
 
+#: A stand-in for the not-yet-shipped `mov` profile (`docs/specs/spec-video-formats.md`),
+#: shaped only enough to prove the degradation-ladder invariant's narrowed form:
+#: it maps `attachment` via `-map 0:t?` -- exactly `mov`'s pinned cheap attempt --
+#: but declares no `attachment` rule, because MOV's muxer rejects any mapped
+#: attachment outright. An attachment-bearing source fails the cheap attempt and
+#: is routed into the ladder instead of reaching the success-side check, so the
+#: type never needs a rule to keep that check honest (issue #39).
+MOV_SHAPED = Profile(
+    label="MOV (shaped)",
+    name="mov-shaped",
+    description="Stand-in for the invariant test, not a shipped profile",
+    target_suffix=".mov",
+    container_options=(),
+    cheap_attempt=Attempt(
+        label="remux",
+        options=flags("-map 0:v? -map 0:a? -map 0:s? -map 0:t? -c copy -c:s mov_text"),
+    ),
+    explicit_streams=False,
+    partial_mapping=True,
+    rules={
+        "video": StreamRule(copy_mask=frozenset({"h264"}), accept_options=flags("-c:v:{n} copy")),
+        "audio": StreamRule(copy_mask=frozenset({"aac"}), accept_options=flags("-c:a:{n} copy")),
+        "subtitle": StreamRule(
+            copy_mask=frozenset(), accept_options=(), drop_reason="not modelled here"
+        ),
+    },
+)
+
+#: Stream types each profile maps only to *force* the cheap attempt to fail when
+#: the source carries one -- never to carry it on the success side. The narrowed
+#: invariant (`docs/design/degradation-ladder.md`) exempts these from needing a
+#: rule: a type mapped to force a failure never reaches the success-side check.
+FORCED_FAILURE_TYPES: dict[str, frozenset[str]] = {
+    MP4.name: frozenset(),
+    WAV.name: frozenset(),
+    MOV_SHAPED.name: frozenset({"attachment"}),
+}
+
 
 def mapped_types(profile: Profile) -> dict[str, bool]:
     """Stream types the cheap attempt maps -> whether it maps them *blindly*.
@@ -47,7 +85,13 @@ def mapped_types(profile: Profile) -> dict[str, bool]:
     return mapped
 
 
-@pytest.mark.parametrize("profile", SHIPPED, ids=lambda profile: profile.label)
+#: `SHIPPED` plus the mov-shaped stand-in, so the invariant is checked against a
+#: profile that actually exercises the force-failure exemption -- otherwise the
+#: narrowed reading and the old, broader one would agree on every case tested.
+INVARIANT_CASES = [*SHIPPED, MOV_SHAPED]
+
+
+@pytest.mark.parametrize("profile", INVARIANT_CASES, ids=lambda profile: profile.label)
 class TestPartialMappingInvariant:
     """What `degradation-ladder.md` says a `partial_mapping` profile owes.
 
@@ -57,14 +101,39 @@ class TestPartialMappingInvariant:
     nobody has written yet.
     """
 
-    def test_every_stream_type_the_cheap_attempt_maps_has_a_rule(self, profile):
-        """Otherwise a stream the attempt faithfully copied is announced as lost."""
-        assert set(mapped_types(profile)) <= set(profile.rules)
+    def test_every_successfully_carryable_type_the_cheap_attempt_maps_has_a_rule(self, profile):
+        """Otherwise a stream the attempt faithfully copied is announced as lost.
+
+        Narrowed form (issue #39): a type mapped only to *force* the cheap
+        attempt to fail -- `mov`'s `attachment`, per `FORCED_FAILURE_TYPES` --
+        never reaches the success side this check protects, so it is exempt.
+        """
+        forced_failure = FORCED_FAILURE_TYPES[profile.name]
+
+        assert set(mapped_types(profile)) - forced_failure <= set(profile.rules)
+
+    def test_forced_failure_types_carry_no_rule(self, profile):
+        """The exemption is for a type genuinely absent from `rules`, not a
+        second way to satisfy the requirement -- otherwise `mov`-shaped would
+        stop proving the distinction the moment someone added a belt-and-braces
+        rule alongside it."""
+        forced_failure = FORCED_FAILURE_TYPES[profile.name]
+
+        assert forced_failure.isdisjoint(profile.rules)
 
     def test_no_blindly_mapped_type_carries_a_stream_limit(self, profile):
         """A blind selector maps every stream of its type, so a limit it does not
-        enforce would have the verification report drops the output disproves."""
-        blind = [kind for kind, is_blind in mapped_types(profile).items() if is_blind]
+        enforce would have the verification report drops the output disproves.
+
+        Only checked for a type that actually has a rule: a force-failure type
+        by definition has none, and a limit on a rule that does not exist is not
+        a thing that can be checked.
+        """
+        blind = [
+            kind
+            for kind, is_blind in mapped_types(profile).items()
+            if is_blind and kind in profile.rules
+        ]
 
         assert all(profile.rules[kind].stream_limit is None for kind in blind)
 


### PR DESCRIPTION
## Summary

- Restates the degradation-ladder cheap-attempt invariant in its load-bearing form: a rule is needed for every stream type the cheap attempt can *successfully carry*, not every type it maps. A type mapped only to force a failure (mov's `attachment`, via `-map 0:t?`) never reaches the success-side check, so it needs no rule.
- Names `mov` alongside `mkv` in both `docs/design/degradation-ladder.md` and `docs/specs/spec-video-formats.md`, resolving the constraint paragraph that referenced the old, broader invariant.
- Adds a mov-shaped stand-in `Profile` to `tests/test_profiles.py`'s invariant test corpus (not registered — `mov` itself ships in the video-formats phase) that maps `attachment` with no rule for it, proving the narrowed invariant admits the exemption rather than the check being skipped.
- Decision log entry in `docs/specs/spec-video-formats.md`.

Found by the review gate on PR #38 (issue #18): `mov`'s cheap attempt deliberately maps `attachment` to fail into the ladder, which the invariant as first written did not account for.

Closes #39

## Test plan

- [x] `.venv/Scripts/python.exe scripts/verify.py` — lint, format, tests all green (230 passed)
- [x] `git diff main...HEAD --name-only` touches only the three owned files: `docs/design/degradation-ladder.md`, `docs/specs/spec-video-formats.md`, `tests/test_profiles.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pdnJyntsFJyawGBSGj4cV