### PR TITLE
feat(profiles): widen the source-suffix set for audio and video sources

### DIFF
--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -201,8 +201,44 @@ PROFILES: dict[str, Profile] = {profile.name: profile for profile in (MP4, WAV)}
 #: profile's own target suffix (``.mp4``, ``.wav``) -- the latter is what lets a
 #: source that already carries the target suffix take part in selection at all
 #: (the self-write and existing-output-skip cases `source-selection.md` and this
-#: phase's QA gate both need). Later phases extend this set as they add profiles.
-SOURCE_SUFFIXES: frozenset[str] = frozenset({".mkv", ".mp4", ".opus", ".wav"})
+#: phase's QA gate both need). Phase 3 (issue #20, `spec-audio-formats.md`) widens
+#: it three ways: the audio containers people actually have that were not yet
+#: readable as a source, the video containers a "rip the audio" run needs, and the
+#: remaining audio target suffixes (``.mp3``, ``.m4a``, ``.flac``, ``.ogg``) so the
+#: profiles this milestone still adds already have their own suffix covered when
+#: they land -- `.opus` and `.wav` are covered already. Later phases extend this
+#: set further as they add profiles (#26 for video containers, #33 for image ones);
+#: none of them re-adds a suffix this set already holds.
+SOURCE_SUFFIXES: frozenset[str] = frozenset(
+    {
+        # phase 2: old sub-commands plus the two shipped profiles' own suffixes
+        ".mkv",
+        ".mp4",
+        ".opus",
+        ".wav",
+        # phase 3: audio containers people actually have
+        ".aac",
+        ".m4b",
+        ".wma",
+        ".aiff",
+        ".aif",
+        ".ape",
+        ".wv",
+        ".caf",
+        # phase 3: video containers a "rip the audio" run needs
+        ".mov",
+        ".avi",
+        ".webm",
+        ".m4v",
+        ".wmv",
+        ".flv",
+        # phase 3: the remaining audio target suffixes, ahead of their profiles
+        ".mp3",
+        ".m4a",
+        ".flac",
+        ".ogg",
+    }
+)
 
 
 def resolve_target(target: str) -> Profile:

--- a/docs/specs/spec-audio-formats.md
+++ b/docs/specs/spec-audio-formats.md
@@ -452,3 +452,17 @@ New-Item -ItemType Directory -Force art
   carried. `wav` was deliberately left out: closing its hole would have changed a
   phase-1 note assertion this phase promised to leave alone, so the hole stays,
   named, for a later phase.
+- 2026-08-26 (#20): `SOURCE_SUFFIXES` widened with exactly the Scope list --
+  the eight audio containers and the seven video containers -- plus `.mp3`,
+  `.m4a`, `.flac` and `.ogg`, the four remaining audio target suffixes not yet
+  in the set (`.opus` and `.wav` already were). The last part is not itself in
+  the Scope prose but is a separate Acceptance item on the issue ("the six
+  audio target suffixes are all present in the set"): without it, the five
+  profile-adding issues later in this milestone would each have to widen
+  `SOURCE_SUFFIXES` again for their own target suffix, which is exactly the
+  kind of `converter/profiles.py` churn this phase's per-PR diff check is
+  trying to keep narrow. No new profile, no engine change: pure data, per
+  `converter/profiles.py`'s leaf-module contract. `tests/test_profiles.py`'s
+  `TestSourceSuffixes` was updated in the same PR to pin the new exact set --
+  its prior exact-equality assertion would otherwise fail the moment the set
+  grew, regardless of who touches it next.

--- a/docs/specs/spec-audio-formats.md
+++ b/docs/specs/spec-audio-formats.md
@@ -453,11 +453,12 @@ New-Item -ItemType Directory -Force art
   phase-1 note assertion this phase promised to leave alone, so the hole stays,
   named, for a later phase.
 - 2026-08-26 (#20): `SOURCE_SUFFIXES` widened with exactly the Scope list --
-  the eight audio containers and the seven video containers -- plus `.mp3`,
+  the eight audio containers and the seven video containers (`.mp4` already
+  was in the set, so six of the seven are a net addition) -- plus `.mp3`,
   `.m4a`, `.flac` and `.ogg`, the four remaining audio target suffixes not yet
   in the set (`.opus` and `.wav` already were). The last part is not itself in
   the Scope prose but is a separate Acceptance item on the issue ("the six
-  audio target suffixes are all present in the set"): without it, the five
+  audio target suffixes are all present in the set"): without it, the four
   profile-adding issues later in this milestone would each have to widen
   `SOURCE_SUFFIXES` again for their own target suffix, which is exactly the
   kind of `converter/profiles.py` churn this phase's per-PR diff check is

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -278,15 +278,49 @@ class TestResolveTarget:
 
 
 class TestSourceSuffixes:
-    def test_holds_the_old_job_suffixes_and_each_shipped_profile_s_own_suffix(self):
+    def test_holds_the_phase_2_and_phase_3_suffixes(self):
         """`.mkv`/`.opus` are what the old sub-commands read; `.mp4`/`.wav` are
         what let a source already carrying the target suffix take part in
         selection (the self-write and existing-output cases,
-        `docs/design/source-selection.md`)."""
-        assert {".mkv", ".mp4", ".opus", ".wav"} == SOURCE_SUFFIXES
+        `docs/design/source-selection.md`). Issue #20 (`spec-audio-formats.md`)
+        widens the set with the audio containers people actually have, the video
+        containers a "rip the audio" run needs, and the remaining audio target
+        suffixes ahead of the profiles that will claim them."""
+        assert {
+            ".mkv",
+            ".mp4",
+            ".opus",
+            ".wav",
+            ".aac",
+            ".m4b",
+            ".wma",
+            ".aiff",
+            ".aif",
+            ".ape",
+            ".wv",
+            ".caf",
+            ".mov",
+            ".avi",
+            ".webm",
+            ".m4v",
+            ".wmv",
+            ".flv",
+            ".mp3",
+            ".m4a",
+            ".flac",
+            ".ogg",
+        } == SOURCE_SUFFIXES
 
     def test_every_shipped_profile_s_target_suffix_is_a_source_suffix(self):
         assert all(profile.target_suffix in SOURCE_SUFFIXES for profile in SHIPPED)
+
+    def test_every_audio_target_suffix_is_a_source_suffix(self):
+        """The six audio targets this milestone covers -- `mp3`, `m4a`, `flac`,
+        `opus`, `ogg`, `wav` -- all have their own suffix readable as a source,
+        even for the five whose profile has not landed yet, so #20 does not block
+        on issue order within the milestone."""
+        audio_target_suffixes = {".mp3", ".m4a", ".flac", ".opus", ".ogg", ".wav"}
+        assert audio_target_suffixes <= SOURCE_SUFFIXES
 
 
 class TestValueTypesAreFrozen:


### PR DESCRIPTION
## Summary
- Widens `converter/profiles.py`'s `SOURCE_SUFFIXES` with the audio containers (`.aac`, `.m4b`, `.wma`, `.aiff`, `.aif`, `.ape`, `.wv`, `.caf`) and video containers (`.mov`, `.avi`, `.webm`, `.m4v`, `.wmv`, `.flv`; `.mp4` was already present) the Scope of `docs/specs/spec-audio-formats.md` lists, plus the four remaining audio target suffixes (`.mp3`, `.m4a`, `.flac`, `.ogg`) so every one of the six audio target suffixes is now present ahead of the profiles that will claim them.
- Pure data change per the leaf-module contract -- no diff outside `converter/profiles.py`, `docs/specs/spec-audio-formats.md` and `tests/`.
- Updates `tests/test_profiles.py`'s pre-existing exact-equality assertion on `SOURCE_SUFFIXES` to the new set (it would otherwise fail the moment the set grew), and adds a coverage test for the six audio target suffixes.
- Records the decision, including why the target-suffix bullet is not itself in the spec's Scope prose, in the spec's Decision log.

## Test plan
- [x] `.venv/Scripts/python.exe scripts/verify.py` -- ruff check, ruff format --check, pytest (231 passed) all green.
- [x] Diff touches only `converter/profiles.py`, `docs/specs/spec-audio-formats.md` and `tests/test_profiles.py`.

Closes #20