### PR TITLE
feat(cli)!: --to replaces the video and audio sub-commands

### DIFF
--- a/converter/cli.py
+++ b/converter/cli.py
@@ -413,7 +413,11 @@ def _selection(choice: str, targets: Sequence[str]) -> str | None:
     """
     if choice == str(len(targets) + 1) or choice.strip().lower() == MIRROR_COMMAND:
         return MIRROR_COMMAND
-    if choice.isdigit():
+    # isdecimal, not isdigit: the latter is true for characters int() rejects,
+    # such as a superscript digit, and the prompt runs outside main()'s exception
+    # handling -- such an answer would escape as a traceback rather than being
+    # reported as an unknown selection.
+    if choice.isdecimal():
         index = int(choice)
         return targets[index - 1] if 1 <= index <= len(targets) else None
     try:

--- a/converter/cli.py
+++ b/converter/cli.py
@@ -1,75 +1,79 @@
 """Command-line interface.
 
-One parser with sub-commands replaces the four stand-alone scripts.  The
-interactive prompts of the old ``prepare*`` scripts are kept, but they now only
-assemble an argument list and hand it to the very same parser -- so there is a
-single code path to reason about and to test.
+The tool is driven by a *target format* rather than by a sub-command per format
+pair: ``converter --to <format> INPUT [OUTPUT]``.  There are two parsers -- the
+convert parser and the mirror parser -- because the two shapes genuinely cannot
+coexist in one: argparse's sub-parser action is itself a positional, so a
+top-level positional ``INPUT`` swallows the command name.  :func:`dispatch`
+therefore routes the raw argument list *before* anything is parsed, which is
+also what makes ``--list-formats`` reachable next to a required ``--to``
+(``docs/specs/spec-target-driven-cli.md``).
+
+The interactive prompt of the old ``prepare*`` scripts is kept, but it only
+assembles an argument list and hands it to :func:`dispatch` -- so the
+interactive path and the scripted path are literally the same code.
+
+This module deliberately names no target format anywhere: every one of them
+comes out of ``converter.profiles``, which is what lets a new format be data
+rather than a diff here (``docs/constitution.md``).  A test walks this file with
+``ast`` and fails if a string literal ever says otherwise.
 """
 
 import argparse
 import sys
 from collections.abc import Sequence
-from dataclasses import dataclass
 from pathlib import Path
 
 from converter import __version__, ffmpegtool, paths
-from converter.batch import Task, default_jobs, run_batch, summarise
-from converter.profiles import MP4, WAV, Profile
+from converter.batch import Outcome, Result, Task, default_jobs, run_batch, summarise
+from converter.profiles import PROFILES, SOURCE_SUFFIXES, Profile, resolve_target
 
 
 class UsageError(Exception):
     """Bad combination of otherwise valid arguments."""
 
 
-@dataclass(frozen=True)
-class _Binding:
-    """A sub-command's CLI-visible name plus which source suffixes feed which
-    target profile. Phase-2 scaffolding (``docs/specs/spec-target-driven-cli.md``):
-    replaced once ``--to`` takes over from the ``video``/``audio`` sub-commands.
+#: The one sub-command that survives the move to ``--to``: it converts nothing,
+#: so it has no target format and cannot be expressed as one.
+MIRROR_COMMAND = "mirror"
+
+#: Recognised only to produce a useful error -- these no longer run anything.
+LEGACY_COMMANDS: tuple[str, ...] = ("video", "audio")
+
+#: Routed before parsing, so it works without INPUT or --to (see :func:`dispatch`).
+LIST_FORMATS_FLAG = "--list-formats"
+
+
+def _add_convert_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add the conversion arguments.
+
+    Unchanged in name and meaning from the sub-commands they replace, so an
+    existing invocation only loses its verb.
     """
-
-    description: str
-    suffixes: tuple[str, ...]
-    profile: Profile
-
-
-#: Sub-command name -> binding. See :class:`_Binding`.
-_BINDINGS: dict[str, _Binding] = {
-    "video": _Binding(
-        description="Convert .mkv files to .mp4 (stream copy where possible)",
-        suffixes=(".mkv",),
-        profile=MP4,
-    ),
-    "audio": _Binding(
-        description="Convert .opus files to uncompressed .wav",
-        suffixes=(".opus",),
-        profile=WAV,
-    ),
-}
-
-
-def _add_convert_arguments(sub: argparse.ArgumentParser, binding: _Binding) -> None:
-    sub.add_argument("input_dir", type=Path, help="directory containing the input files")
-    sub.add_argument(
+    parser.add_argument(
+        "input_dir", metavar="INPUT", type=Path, help="directory containing the input files"
+    )
+    parser.add_argument(
         "output_dir",
+        metavar="OUTPUT",
         nargs="?",
         type=Path,
         default=None,
         help="directory to write the results to; omit when using --mirror-to",
     )
-    sub.add_argument(
+    parser.add_argument(
         "--mirror-to",
         metavar="ROOT",
         default=None,
         help=(
-            "derive the output directory by re-rooting INPUT_DIR onto ROOT, "
+            "derive the output directory by re-rooting INPUT onto ROOT, "
             r"e.g. 'E:' or 'E:\Backup'"
         ),
     )
-    sub.add_argument(
+    parser.add_argument(
         "-r", "--recursive", action="store_true", help="also convert files in sub-directories"
     )
-    sub.add_argument(
+    parser.add_argument(
         "-j",
         "--jobs",
         type=int,
@@ -77,54 +81,105 @@ def _add_convert_arguments(sub: argparse.ArgumentParser, binding: _Binding) -> N
         metavar="N",
         help=f"conversions to run in parallel (default: {default_jobs()})",
     )
-    sub.add_argument(
+    parser.add_argument(
         "--overwrite",
         action="store_true",
         help="replace existing output files instead of skipping them",
     )
-    sub.add_argument("--dry-run", action="store_true", help="list what would be converted and stop")
-    sub.add_argument("-q", "--quiet", action="store_true", help="hide the progress bar")
-    sub.add_argument("--ffmpeg", default=None, help="path to the ffmpeg executable")
-    sub.add_argument("--ffprobe", default=None, help="path to the ffprobe executable")
-    sub.set_defaults(binding=binding, handler=convert_command)
+    parser.add_argument(
+        "--dry-run", action="store_true", help="list what would be converted and stop"
+    )
+    parser.add_argument("-q", "--quiet", action="store_true", help="hide the progress bar")
+    parser.add_argument("--ffmpeg", default=None, help="path to the ffmpeg executable")
+    parser.add_argument("--ffprobe", default=None, help="path to the ffprobe executable")
 
 
 def build_parser() -> argparse.ArgumentParser:
+    """Build the convert parser -- the one that runs a conversion.
+
+    It carries ``--version`` and an epilog naming the mirror sub-command and the
+    list flag, because with ``mirror`` off a sub-parser list neither would
+    otherwise be discoverable from ``converter --help``.
+    """
     parser = argparse.ArgumentParser(
         prog="converter",
         description="Batch media conversion driven by the ffmpeg command-line program.",
+        epilog=(
+            f"Run 'converter {LIST_FORMATS_FLAG}' for the target formats available, "
+            f"and 'converter {MIRROR_COMMAND} --help' for the directory-mirroring "
+            "sub-command."
+        ),
     )
     parser.add_argument("--version", action="version", version=f"converter {__version__}")
-    subparsers = parser.add_subparsers(dest="command", metavar="COMMAND")
+    parser.add_argument(
+        "--to",
+        required=True,
+        metavar="FORMAT",
+        help=f"target format to convert everything to; see {LIST_FORMATS_FLAG}",
+    )
+    # Declared so 'converter --help' lists it, but dispatch() intercepts it
+    # first: a required --to and a required INPUT would otherwise reject it.
+    parser.add_argument(
+        LIST_FORMATS_FLAG, action="store_true", help="list the target formats and exit"
+    )
+    _add_convert_arguments(parser)
+    return parser
 
-    for name, binding in _BINDINGS.items():
-        sub = subparsers.add_parser(name, help=binding.description, description=binding.description)
-        _add_convert_arguments(sub, binding)
 
-    mirror = subparsers.add_parser(
-        "mirror",
-        help="Re-create a directory tree on another drive",
+def build_mirror_parser() -> argparse.ArgumentParser:
+    """Build the mirror parser: re-create a directory tree on another drive."""
+    parser = argparse.ArgumentParser(
+        prog=f"converter {MIRROR_COMMAND}",
         description=(
             "Print (and optionally create) the directory tree that INPUT_ROOT would "
             "map to underneath OUTPUT_ROOT."
         ),
     )
-    mirror.add_argument("input_root", type=Path)
-    mirror.add_argument("output_root", help=r"target drive or directory, e.g. 'E:' or 'E:\Backup'")
-    mirror.add_argument(
+    parser.add_argument("input_root", type=Path)
+    parser.add_argument("output_root", help=r"target drive or directory, e.g. 'E:' or 'E:\Backup'")
+    parser.add_argument(
         "--create", action="store_true", help="actually create the directories, not just list them"
     )
-    mirror.add_argument(
+    parser.add_argument(
         "--no-recursive", dest="recursive", action="store_false", help="only the top level"
     )
-    mirror.set_defaults(handler=mirror_command)
-
     return parser
+
+
+def _legacy_message(command: str) -> str:
+    """Explain the removal generically.
+
+    Which target replaces which sub-command is documented in the README and in
+    the breaking release's migration note -- naming one here would be the single
+    string that defeats this module's own format-name check, and every phase
+    that adds a format depends on that check.
+    """
+    return (
+        f"the {command!r} sub-command is gone; converter is driven by a target format now:\n"
+        "  converter --to <format> IN OUT\n"
+        f"Run 'converter {LIST_FORMATS_FLAG}' for the formats available."
+    )
+
+
+def list_formats_command() -> int:
+    """Print one line per registry target, sorted by name.
+
+    Resolves no tools and touches no filesystem: someone who guessed a format
+    name wrong needs the list without owning a valid input directory, and
+    without ffmpeg being installed yet.
+    """
+    names = sorted(PROFILES)
+    width = max(len(name) for name in names)
+    print("Target formats:")
+    for name in names:
+        profile = PROFILES[name]
+        print(f"  {name:<{width}}  {profile.target_suffix}  {profile.description}")
+    return 0
 
 
 def _resolve_output_root(args: argparse.Namespace) -> Path:
     if args.output_dir is not None and args.mirror_to is not None:
-        raise UsageError("give either OUTPUT_DIR or --mirror-to, not both")
+        raise UsageError("give either OUTPUT or --mirror-to, not both")
     if args.mirror_to is not None:
         try:
             return paths.mirror_to_drive(args.input_dir.resolve(), args.mirror_to)
@@ -132,33 +187,76 @@ def _resolve_output_root(args: argparse.Namespace) -> Path:
             raise UsageError(str(exc)) from exc
     if args.output_dir is not None:
         return args.output_dir
-    raise UsageError("OUTPUT_DIR is required unless --mirror-to is given")
+    raise UsageError("OUTPUT is required unless --mirror-to is given")
 
 
-def convert_command(args: argparse.Namespace) -> int:
-    binding: _Binding = args.binding
-    if args.jobs is not None and args.jobs < 1:
-        raise UsageError(f"--jobs must be 1 or more, got {args.jobs}")
-    output_root = _resolve_output_root(args)
-
+def _resolve_profile(target: str) -> Profile:
+    """Turn ``--to``'s value into a profile, or a usage error naming the alternatives."""
     try:
-        sources = paths.find_sources(args.input_dir, binding.suffixes, recursive=args.recursive)
+        return resolve_target(target)
+    except ValueError as exc:
+        # A wrong format name is a typo, not a conversion failure.
+        raise UsageError(str(exc)) from exc
+
+
+def _selected_pairs(
+    args: argparse.Namespace, profile: Profile, output_root: Path
+) -> list[tuple[Path, Path]]:
+    """Pair every candidate under INPUT with the output path it would produce.
+
+    The output root is handed to discovery unconditionally: it is skipped only
+    when it really is a strict descendant of the input root, which is the one
+    shape where the walk could otherwise rediscover its own output
+    (``docs/design/source-selection.md``).
+    """
+    try:
+        sources = paths.find_sources(
+            args.input_dir, SOURCE_SUFFIXES, recursive=args.recursive, exclude=output_root
+        )
     except NotADirectoryError as exc:
         # A bad path is a usage error, not a conversion failure.
         raise UsageError(str(exc)) from exc
-    if not sources:
-        hint = "" if args.recursive else " (pass --recursive to include sub-directories)"
-        print(
-            f"No {' / '.join(binding.suffixes)} files found in {args.input_dir}{hint}.",
-            file=sys.stderr,
-        )
-        return 0
-
-    tasks = [
-        Task(src, paths.output_for(src, args.input_dir, output_root, binding.profile.target_suffix))
+    return [
+        (src, paths.output_for(src, args.input_dir, output_root, profile.target_suffix))
         for src in sources
     ]
 
+
+def _partition_self_writes(
+    pairs: Sequence[tuple[Path, Path]],
+) -> tuple[list[Result], list[Task]]:
+    """Split candidates into self-writing sources and real tasks.
+
+    A source whose output path resolves to its own input path leaves the run as
+    a counted skip rather than a silent drop, so converting a tree in place
+    stays idempotent and still reports what it did not do.
+    """
+    skipped: list[Result] = []
+    tasks: list[Task] = []
+    for src, dst in pairs:
+        if paths.is_self_write(src, dst):
+            skipped.append(
+                Result(
+                    Task(src, dst),
+                    Outcome.SKIPPED,
+                    notes=("the output path is this file itself; nothing to convert",),
+                )
+            )
+        else:
+            tasks.append(Task(src, dst))
+    return skipped, tasks
+
+
+def _refuse_destructive(
+    pairs: Sequence[tuple[Path, Path]], tasks: Sequence[Task], *, overwrite: bool
+) -> int | None:
+    """Refuse the whole run up front, or return ``None`` to let it proceed.
+
+    The two passes deliberately look at different sets: collisions at what will
+    actually be written, hazards at every selected source including the
+    self-writers -- the motivating hazard *is* a self-writer being overwritten
+    by a sibling (``docs/design/source-selection.md``).
+    """
     collisions = paths.find_collisions((task.src, task.dst) for task in tasks)
     if collisions:
         print("error: several inputs would be written to the same output:", file=sys.stderr)
@@ -168,30 +266,99 @@ def convert_command(args: argparse.Namespace) -> int:
                 print(f"    <- {src}", file=sys.stderr)
         return 2
 
-    if args.dry_run:
-        for task in tasks:
-            print(f"{task.src} -> {task.dst}")
-        print(f"{len(tasks)} file(s) would be converted.")
-        return 0
+    hazards = paths.find_overwrite_hazards(pairs) if overwrite else []
+    if hazards:
+        print("error: --overwrite would destroy inputs this run also reads:", file=sys.stderr)
+        for victim, writer in hazards:
+            print(f"  {victim}", file=sys.stderr)
+            print(f"    <- would be overwritten by {writer}", file=sys.stderr)
+        return 2
+    return None
 
+
+def _nothing_found_hint(args: argparse.Namespace) -> str:
+    """The stderr note for a run with no candidates.
+
+    It names no suffix: the curated set is dozens of entries, so interpolating
+    it would be unreadable -- and the summary on stdout is what carries the
+    result, which is why this is a hint rather than an error.
+    """
+    hint = "" if args.recursive else " (pass --recursive to include sub-directories)"
+    return f"note: no convertible files found in {args.input_dir}{hint}."
+
+
+def _announce_skips(skipped: Sequence[Result]) -> None:
+    """Name every skip decided before the batch started.
+
+    The batch reports its own skips through the progress bar; these never reach
+    it, and a file the user pointed at and did not get must not be passed over
+    in silence (``docs/constitution.md``).  Not gated on ``--quiet``, which
+    hides the progress bar rather than the reasons -- the batch's own notes are
+    not gated either, and a file reported by one path and not the other would
+    read as an inconsistency in the tool.
+    """
+    for result in skipped:
+        for note in result.notes:
+            print(f"note    {result.task.src.name}: {note}")
+
+
+def _run_tasks(profile: Profile, tasks: Sequence[Task], args: argparse.Namespace) -> list[Result]:
+    """Locate the tools and convert.
+
+    Short-circuited when there is nothing to convert, so a run that consists
+    only of skips still works on a machine with no ffmpeg installed.
+    """
+    if not tasks:
+        return []
     tools = ffmpegtool.resolve_tools(args.ffmpeg, args.ffprobe)
     if not args.quiet:
         print(f"Using {ffmpegtool.version(tools)}")
-
-    results = run_batch(
-        binding.profile,
+    return run_batch(
+        profile,
         tasks,
         tools,
         jobs=args.jobs,
         overwrite=args.overwrite,
         progress=not args.quiet,
     )
-    summary = summarise(results)
+
+
+def convert_command(args: argparse.Namespace) -> int:
+    """Select, refuse or convert -- the whole of ``docs/design/source-selection.md``.
+
+    Selection finishes before ffmpeg is ever located, which is what lets
+    ``--dry-run`` and a refusal work on a machine that has no ffmpeg.
+    """
+    if args.jobs is not None and args.jobs < 1:
+        raise UsageError(f"--jobs must be 1 or more, got {args.jobs}")
+    profile = _resolve_profile(args.to)
+    output_root = _resolve_output_root(args)
+
+    pairs = _selected_pairs(args, profile, output_root)
+    if not pairs:
+        print(summarise(()).describe())
+        print(_nothing_found_hint(args), file=sys.stderr)
+        return 0
+
+    skipped, tasks = _partition_self_writes(pairs)
+    refusal = _refuse_destructive(pairs, tasks, overwrite=args.overwrite)
+    if refusal is not None:
+        return refusal
+
+    _announce_skips(skipped)
+    if args.dry_run:
+        for task in tasks:
+            print(f"{task.src} -> {task.dst}")
+        print(f"{len(tasks)} file(s) would be converted.")
+        return 0
+
+    summary = summarise([*skipped, *_run_tasks(profile, tasks, args)])
     print(summary.describe())
     return summary.exit_code
 
 
 def mirror_command(args: argparse.Namespace) -> int:
+    """Print, and optionally create, the mirrored directory tree."""
     try:
         directories = paths.list_directories(args.input_root, recursive=args.recursive)
     except NotADirectoryError as exc:
@@ -209,6 +376,23 @@ def mirror_command(args: argparse.Namespace) -> int:
     return 0
 
 
+def dispatch(raw: Sequence[str]) -> int:
+    """Route *raw* to the command that owns it, before any parsing happens.
+
+    The order is the one ``docs/specs/spec-target-driven-cli.md`` fixes: a
+    leading mirror token, then a leading legacy token, then the list flag
+    anywhere, then the convert parser.  Both the prompt's output and a typed
+    argument list come through here, which is what keeps them one code path.
+    """
+    if raw and raw[0] == MIRROR_COMMAND:
+        return mirror_command(build_mirror_parser().parse_args(raw[1:]))
+    if raw and raw[0] in LEGACY_COMMANDS:
+        raise UsageError(_legacy_message(raw[0]))
+    if LIST_FORMATS_FLAG in raw:
+        return list_formats_command()
+    return convert_command(build_parser().parse_args(raw))
+
+
 def _ask(question: str, default: str = "") -> str:
     suffix = f" [{default}]" if default else ""
     answer = input(f"{question}{suffix}: ").strip().strip('"')
@@ -220,40 +404,48 @@ def _ask_yes_no(question: str, *, default: bool = False) -> bool:
     return answer.startswith("y")
 
 
-def prompt_for_argv() -> list[str] | None:
-    """Ask for the options interactively and return them as an argument list.
+def _selection(choice: str, targets: Sequence[str]) -> str | None:
+    """Map a menu answer onto a target name or the mirror token.
 
-    Returning an argv list rather than acting directly keeps the interactive
-    path and the scripted path on exactly the same code.
+    A number indexes the menu; anything else is offered to the registry, so a
+    format name typed straight out is the escape hatch once counting entries
+    gets silly.  ``None`` means the answer matched nothing.
     """
-    print(f"converter {__version__} - interactive mode")
-    print("  1) .mkv -> .mp4")
-    print("  2) .opus -> .wav")
-    print("  3) mirror a directory tree onto another drive")
-    choice = _ask("Select", "1")
-
-    commands = {"1": "video", "2": "audio", "3": "mirror"}
-    command = commands.get(choice)
-    if command is None:
-        print(f"Unknown selection: {choice!r}", file=sys.stderr)
+    if choice == str(len(targets) + 1) or choice.strip().lower() == MIRROR_COMMAND:
+        return MIRROR_COMMAND
+    if choice.isdigit():
+        index = int(choice)
+        return targets[index - 1] if 1 <= index <= len(targets) else None
+    try:
+        return resolve_target(choice).name
+    except ValueError:
         return None
 
-    input_root = _ask("Input directory")
-    if not input_root:
-        print("An input directory is required.", file=sys.stderr)
+
+def _prompt_menu() -> list[str]:
+    """Print the numbered menu and return the target names it offered, in order."""
+    targets = sorted(PROFILES)
+    for number, name in enumerate(targets, start=1):
+        print(f"  {number}) {name} - {PROFILES[name].description}")
+    print(f"  {len(targets) + 1}) {MIRROR_COMMAND} - re-create a directory tree on another drive")
+    return targets
+
+
+def _prompt_mirror_argv(input_root: str) -> list[str] | None:
+    """Ask for the rest of a mirror invocation."""
+    output_root = _ask("Output drive or directory")
+    if not output_root:
+        print("An output drive or directory is required.", file=sys.stderr)
         return None
+    argv = [MIRROR_COMMAND, input_root, output_root]
+    if _ask_yes_no("Create the directories now?"):
+        argv.append("--create")
+    return argv
 
-    if command == "mirror":
-        output_root = _ask("Output drive or directory")
-        if not output_root:
-            print("An output drive or directory is required.", file=sys.stderr)
-            return None
-        argv = [command, input_root, output_root]
-        if _ask_yes_no("Create the directories now?"):
-            argv.append("--create")
-        return argv
 
-    argv = [command, input_root]
+def _prompt_convert_argv(target: str, input_root: str) -> list[str] | None:
+    """Ask for the rest of a conversion invocation."""
+    argv = ["--to", target, input_root]
     output_dir = _ask("Output directory (empty to mirror onto another drive instead)")
     if output_dir:
         argv.append(output_dir)
@@ -271,26 +463,52 @@ def prompt_for_argv() -> list[str] | None:
     return argv
 
 
+def prompt_for_argv() -> list[str] | None:
+    """Ask for the options interactively and return them as an argument list.
+
+    Returning an argv list rather than acting directly keeps the interactive
+    path and the scripted path on exactly the same code -- and the menu is built
+    from the registry, so it grows with it instead of being maintained here.
+    """
+    print(f"converter {__version__} - interactive mode")
+    targets = _prompt_menu()
+    choice = _ask("Select", "1")
+
+    selection = _selection(choice, targets)
+    if selection is None:
+        print(f"Unknown selection: {choice!r}", file=sys.stderr)
+        return None
+
+    input_root = _ask("Input directory")
+    if not input_root:
+        print("An input directory is required.", file=sys.stderr)
+        return None
+
+    if selection == MIRROR_COMMAND:
+        return _prompt_mirror_argv(input_root)
+    return _prompt_convert_argv(selection, input_root)
+
+
 def main(argv: Sequence[str] | None = None) -> int:
-    parser = build_parser()
+    """Run one invocation and return its exit code.
+
+    The prompt fills ``raw`` *before* routing, so a prompted mirror argument
+    list reaches the mirror parser exactly like a typed one does.
+    """
     raw = list(sys.argv[1:] if argv is None else argv)
 
     if not raw:
         try:
-            raw = prompt_for_argv()
+            prompted = prompt_for_argv()
         except (EOFError, KeyboardInterrupt):
             print("\nAborted.", file=sys.stderr)
             return 130
-        if raw is None:
+        if prompted is None:
             return 2
-
-    args = parser.parse_args(raw)
-    if not hasattr(args, "handler"):
-        parser.print_help()
-        return 2
+        raw = prompted
 
     try:
-        return args.handler(args)
+        return dispatch(raw)
     except UsageError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
@@ -305,4 +523,4 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 130
 
 
-__all__ = ["build_parser", "main"]
+__all__ = ["build_mirror_parser", "build_parser", "dispatch", "main"]

--- a/docs/constitution.md
+++ b/docs/constitution.md
@@ -75,6 +75,5 @@
 
 | Deviation | Where | Plan |
 | --------- | ----- | ---- |
-| `convert_command` is 54 lines, over the 50-line limit | `converter/cli.py` | Phase 2 rewrites it target-format-driven; split it there |
 | Ruff `D` (pydocstyle) rules are not enabled, so the docstring convention rests on review | `pyproject.toml` | Enable pydocstyle once the noise is acceptable |
 | The README names `develop` as the pull-request target | `README.md` | The base branch is `main`; correct it with the next docs change |

--- a/docs/specs/spec-target-driven-cli.md
+++ b/docs/specs/spec-target-driven-cli.md
@@ -402,3 +402,44 @@ reusing the fixtures the phase-1 gate synthesises:
   spec's own mixed-tree write-up warns against. Fixed: an empty stream list now
   returns `None` too, so the source falls through to the ordinary ladder and
   ends up `failed` with its stderr kept, same as before this issue.
+- 2026-08-26 (#15): The routing step is a named public function, `cli.dispatch`,
+  rather than an inline block in `main()`. `main()` owns only the bare-invocation
+  prompt and the exception-to-exit-code mapping; everything with an argument list
+  in hand goes through `dispatch`. That is what lets the prompt round-trip test
+  assert on the *router* instead of on one parser, which is the property this
+  spec's Risks table names — a prompted `mirror` argv the convert parser cannot
+  parse is exactly what it protects.
+- 2026-08-26 (#15): `--list-formats` is *also* declared on the convert parser,
+  even though `dispatch` intercepts it before parsing and its parsed value is
+  never read. Without the declaration `converter --help` would not list a flag
+  the epilog tells the reader to run, which is the discoverability regression the
+  epilog decision exists to prevent. The comment at the declaration says so, so
+  the apparently dead argument is not "cleaned up" later.
+- 2026-08-26 (#15): The self-write skips are built in `cli.py` as ordinary
+  `batch.Result` values and folded into the *same* `summarise()` call as the
+  batch's own results. Selection happens before the batch exists, so the
+  alternative would have been handing `run_batch` a list of pre-decided
+  outcomes — plumbing in `batch.py` for a decision `batch.py` does not make. The
+  counted-skip promise of `docs/design/source-selection.md` is therefore met
+  without a second summary type.
+- 2026-08-26 (#15): A run whose selection produces only skips never resolves the
+  tools: `_run_tasks` short-circuits on an empty task list. Otherwise an in-place
+  re-run over a finished tree — the exact invocation `docs/vision.md`'s
+  idempotence criterion names — would fail with "ffmpeg was not found" on a
+  machine where it is not installed, despite having no conversion to run.
+- 2026-08-26 (#15): The pre-batch skip notes are **not** gated on `--quiet`.
+  Found by the hand smoke test: `-q` hid the self-write note while the batch's
+  own skip notes (written through the progress bar, which `-q` only disables)
+  still printed, so one skipped file was named and another was not in the same
+  run. `--quiet` hides the progress bar, not the reasons.
+- 2026-08-26 (#15): The `ast` format-name check lives in `tests/test_cli.py`
+  rather than in `tests/test_argv.py`, and it walks *every* `ast.Constant`
+  string reachable from the module — which covers the literal parts of
+  f-strings, where a format name would most plausibly be interpolated. Two
+  companion tests keep it from going vacuous: a canary asserting the walker
+  finds a planted format name, and one asserting a docstring is excluded.
+- 2026-08-26 (#15): The positional metavars became `INPUT` / `OUTPUT` (the
+  spec's own spelling) while the argparse dests stay `input_dir` /
+  `output_dir`, so `_resolve_output_root` and every caller are unchanged. The
+  two usage messages it raises were reworded to match the metavar the user
+  actually sees.

--- a/docs/specs/spec-target-driven-cli.md
+++ b/docs/specs/spec-target-driven-cli.md
@@ -443,3 +443,19 @@ reusing the fixtures the phase-1 gate synthesises:
   `output_dir`, so `_resolve_output_root` and every caller are unchanged. The
   two usage messages it raises were reworded to match the metavar the user
   actually sees.
+- 2026-08-26 (#15, review round 1): The epilog test was vacuous. It asserted the
+  mirror token and the list flag appeared in `format_help()`, which is true with
+  no epilog at all — `--mirror-to` contains the mirror token, and
+  `--list-formats` is an option on that very parser. It now asserts on
+  `parser.epilog` plus the rendered `mirror --help` phrase, so the one thing
+  keeping the mirror *sub-command* discoverable is actually pinned.
+- 2026-08-26 (#15, review round 1): The prompt used `str.isdigit()`, which is
+  true for characters `int()` rejects (a superscript digit). `prompt_for_argv`
+  runs *outside* `main()`'s exception handling, so such an answer escaped as a
+  traceback rather than as "Unknown selection". Changed to `str.isdecimal()`,
+  with a test.
+- 2026-08-26 (#15, review round 1): The only collision test monkeypatched
+  `find_collisions`, justified by a case-sensitivity argument that stopped
+  holding when one target began drawing in several source suffixes: `a.mkv` plus
+  `a.opus` under one target is a genuine collision on every platform. A real one
+  was added next to the stubbed message-formatting test.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,10 +100,17 @@ class TestConvertParser:
         assert args.quiet is True
 
     def test_the_epilog_leads_to_mirror_and_the_format_list(self):
-        help_text = build_parser().format_help()
+        """Asserted on the epilog itself, not on the rendered help: `--mirror-to`
+        contains the mirror token and `--list-formats` is an option on this very
+        parser, so a `format_help()` substring check would pass with no epilog at
+        all -- and the epilog is the only thing keeping the mirror *sub-command*
+        discoverable now that it is off a sub-parser list."""
+        epilog = build_parser().epilog
 
-        assert cli.MIRROR_COMMAND in help_text
-        assert cli.LIST_FORMATS_FLAG in help_text
+        assert cli.MIRROR_COMMAND in epilog
+        assert cli.LIST_FORMATS_FLAG in epilog
+        # Rendered too, so an epilog that argparse never prints cannot pass.
+        assert f"{cli.MIRROR_COMMAND} --help" in " ".join(build_parser().format_help().split())
 
 
 class TestMirrorParser:
@@ -332,6 +339,20 @@ class TestConvertCommand:
 
         assert code == 0
 
+    def test_two_real_sources_colliding_on_one_output_stop_the_run(self, tmp_path, capsys):
+        """One target now draws in many source suffixes, so a genuine collision
+        no longer needs a case-folding trick to produce: two files differing only
+        in suffix map to the same output on every platform."""
+        make_source(tmp_path / "in", "a.mkv")
+        make_source(tmp_path / "in", "a.opus")
+
+        code = main(convert_argv(str(tmp_path / "in"), str(tmp_path / "out"), "--dry-run"))
+        err = capsys.readouterr().err
+
+        assert code == 2
+        assert "a.mkv" in err
+        assert "a.opus" in err
+
     def test_a_collision_stops_the_run(self, tmp_path, capsys, monkeypatch):
         """Whether two real files can collide depends on the filesystem's case
         sensitivity, so the CLI's reaction to a collision is driven directly
@@ -557,6 +578,8 @@ class TestExitCodeWiring:
 
     def test_the_audio_target_runs_through_the_same_wiring(self, tmp_path, monkeypatch, capsys):
         make_source(tmp_path / "in", "tone.opus")
+        # _prepare adds a second source of its own, and one target now draws in
+        # every source suffix -- hence two conversions, not one.
         self._prepare(tmp_path, monkeypatch, 0)
 
         code = main(["--to", AUDIO_TARGET, str(tmp_path / "in"), str(tmp_path / "out"), "-q"])
@@ -660,6 +683,14 @@ class TestInteractivePrompt:
 
     def test_unknown_selection_is_rejected(self, monkeypatch, capsys):
         self._answers(monkeypatch, ["nonsense"])
+
+        assert prompt_for_argv() is None
+        assert "Unknown selection" in capsys.readouterr().err
+
+    def test_a_digit_like_character_int_rejects_is_not_a_crash(self, monkeypatch, capsys):
+        """A superscript digit is `isdigit()` but not `int()`-able, and the prompt
+        runs outside main()'s exception handling."""
+        self._answers(monkeypatch, ["\N{SUPERSCRIPT TWO}"])
 
         assert prompt_for_argv() is None
         assert "Unknown selection" in capsys.readouterr().err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,30 +1,91 @@
-"""Tests for argument handling and the interactive prompt."""
+"""Tests for routing, argument handling, source selection and the prompt.
 
+Everything here drives the CLI through :func:`converter.cli.main` or
+:func:`converter.cli.dispatch` rather than through one parser, because routing
+happens before parsing and is therefore only observable from the outside.
+
+The profiles used are read out of the registry rather than named as literals, so
+these tests keep working as later phases add targets -- the same property the
+``ast`` check at the bottom of this file enforces on the CLI itself.
+"""
+
+import ast
+import os
 from pathlib import Path
 
 import pytest
 
 from converter import batch, cli
-from converter.cli import build_parser, main, prompt_for_argv
+from converter.cli import build_mirror_parser, build_parser, dispatch, main, prompt_for_argv
 from converter.ffmpegtool import CommandResult, Stream, Tools
+from converter.profiles import MP4, PROFILES, WAV
 
 FAKE_TOOLS = Tools(ffmpeg="ffmpeg", ffprobe="ffprobe")
+
+#: The two targets this phase ships, taken from the registry rather than spelled
+#: out: VIDEO_TARGET reads .mkv and writes MP4, AUDIO_TARGET writes WAV.
+VIDEO_TARGET = MP4.name
+AUDIO_TARGET = WAV.name
+VIDEO_SUFFIX = MP4.target_suffix
+AUDIO_SUFFIX = WAV.target_suffix
 
 
 def parse(argv: list[str]):
     return build_parser().parse_args(argv)
 
 
-class TestParser:
-    def test_video_and_audio_subcommands_exist(self):
-        assert parse(["video", "in", "out"]).binding.profile.target_suffix == ".mp4"
-        assert parse(["audio", "in", "out"]).binding.profile.target_suffix == ".wav"
+def convert_argv(*args: str) -> list[str]:
+    """A convert invocation for the video target, with INPUT/OUTPUT filled in."""
+    return ["--to", VIDEO_TARGET, *args]
+
+
+def make_source(root: Path, name: str) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    source = root / name
+    source.write_bytes(b"data")
+    return source
+
+
+def self_mirroring_root(path: Path) -> str:
+    """The ``--mirror-to`` root that maps *path* back onto itself.
+
+    ``mirror_to_drive`` re-roots the whole drive-relative path underneath the
+    given root, so the root that reproduces the input is the drive itself --
+    the filesystem root on POSIX.  This is the only spelling that makes the
+    resolved-vs-as-given difference observable without a second real drive.
+    """
+    return os.path.splitdrive(str(path))[0] or os.sep
+
+
+@pytest.fixture
+def stub_ffmpeg(monkeypatch):
+    """Replace the whole subprocess boundary with a stub that always succeeds."""
+
+    def run(argv, **_kwargs):
+        Path(argv[-1]).write_bytes(b"converted")
+        return CommandResult(tuple(argv), 0, "", "")
+
+    monkeypatch.setattr(cli.ffmpegtool, "resolve_tools", lambda *_a: FAKE_TOOLS)
+    monkeypatch.setattr(cli.ffmpegtool, "version", lambda _tools: "ffmpeg test build")
+    monkeypatch.setattr(batch.ffmpegtool, "run", run)
+    monkeypatch.setattr(batch.ffmpegtool, "probe_streams", lambda *_a: [])
+    return run
+
+
+class TestConvertParser:
+    def test_target_is_required(self):
+        with pytest.raises(SystemExit):
+            parse(["in", "out"])
+
+    def test_input_is_required(self):
+        with pytest.raises(SystemExit):
+            parse(["--to", VIDEO_TARGET])
 
     def test_output_directory_is_optional(self):
-        assert parse(["video", "in"]).output_dir is None
+        assert parse(convert_argv("in")).output_dir is None
 
     def test_flags_default_to_the_safe_choice(self):
-        args = parse(["video", "in", "out"])
+        args = parse(convert_argv("in", "out"))
 
         assert args.recursive is False
         assert args.overwrite is False
@@ -32,39 +93,147 @@ class TestParser:
         assert args.jobs is None
 
     def test_short_flags(self):
-        args = parse(["video", "in", "out", "-r", "-j", "8", "-q"])
+        args = parse(convert_argv("in", "out", "-r", "-j", "8", "-q"))
 
         assert args.recursive is True
         assert args.jobs == 8
         assert args.quiet is True
 
-    def test_mirror_subcommand(self):
-        args = parse(["mirror", "C:/in", "E:"])
+    def test_the_epilog_leads_to_mirror_and_the_format_list(self):
+        help_text = build_parser().format_help()
+
+        assert cli.MIRROR_COMMAND in help_text
+        assert cli.LIST_FORMATS_FLAG in help_text
+
+
+class TestMirrorParser:
+    def test_it_parses_its_own_arguments(self):
+        args = build_mirror_parser().parse_args(["C:/in", "E:"])
 
         assert args.output_root == "E:"
         assert args.recursive is True
         assert args.create is False
 
-    def test_unknown_subcommand_is_rejected(self):
-        with pytest.raises(SystemExit):
-            parse(["nonsense", "in", "out"])
+    def test_no_recursive(self):
+        args = build_mirror_parser().parse_args(["C:/in", "E:", "--no-recursive"])
+
+        assert args.recursive is False
+
+
+class TestRouting:
+    def test_mirror_goes_to_the_mirror_parser(self, tmp_path, capsys):
+        (tmp_path / "a").mkdir()
+
+        code = dispatch([cli.MIRROR_COMMAND, str(tmp_path / "a"), str(tmp_path / "mirror")])
+
+        assert code == 0
+        assert "->" in capsys.readouterr().out
+
+    @pytest.mark.parametrize("command", cli.LEGACY_COMMANDS)
+    def test_a_legacy_subcommand_exits_two_and_says_what_to_run(self, capsys, command):
+        code = main([command, "in", "out"])
+        err = capsys.readouterr().err
+
+        assert code == 2
+        assert "--to <format>" in err
+        assert cli.LIST_FORMATS_FLAG in err
+
+    @pytest.mark.parametrize("command", cli.LEGACY_COMMANDS)
+    def test_the_legacy_message_names_no_format(self, capsys, command):
+        """Naming one here would be the string that defeats the ast check below."""
+        main([command, "in", "out"])
+        err = capsys.readouterr().err.lower()
+
+        for profile in PROFILES.values():
+            assert profile.name not in err
+            assert profile.target_suffix not in err
+
+    def test_the_list_flag_is_reachable_without_input_or_target(self, capsys):
+        code = main([cli.LIST_FORMATS_FLAG])
+
+        assert code == 0
+        assert capsys.readouterr().out
+
+    def test_the_list_flag_is_recognised_anywhere_in_the_argument_list(self, capsys):
+        code = main(["--to", VIDEO_TARGET, "in", cli.LIST_FORMATS_FLAG])
+
+        assert code == 0
+        assert capsys.readouterr().out
+
+    def test_version_still_exits_zero_although_target_is_required(self, capsys):
+        with pytest.raises(SystemExit) as exit_info:
+            main(["--version"])
+
+        assert exit_info.value.code == 0
+        assert "converter" in capsys.readouterr().out
+
+
+class TestListFormats:
+    def test_one_line_per_registry_entry(self, capsys):
+        code = main([cli.LIST_FORMATS_FLAG])
+        out = capsys.readouterr().out
+
+        assert code == 0
+        for profile in PROFILES.values():
+            line = next(li for li in out.splitlines() if li.strip().startswith(profile.name))
+            assert profile.target_suffix in line
+            assert profile.description in line
+
+    def test_sorted_by_name(self, capsys):
+        main([cli.LIST_FORMATS_FLAG])
+        out = capsys.readouterr().out
+
+        positions = [out.index(f" {name} ") for name in sorted(PROFILES)]
+        assert positions == sorted(positions)
+
+    def test_it_resolves_no_tools_and_touches_no_filesystem(self, monkeypatch, capsys):
+        def explode(*_args, **_kwargs):
+            raise AssertionError("--list-formats must not reach the filesystem or ffmpeg")
+
+        monkeypatch.setattr(cli.ffmpegtool, "resolve_tools", explode)
+        monkeypatch.setattr(cli.paths, "find_sources", explode)
+
+        assert main([cli.LIST_FORMATS_FLAG]) == 0
+        assert capsys.readouterr().out
+
+
+class TestTargetResolution:
+    @pytest.mark.parametrize("spelling", [VIDEO_TARGET, VIDEO_TARGET.upper(), VIDEO_SUFFIX])
+    def test_name_suffix_and_case_all_select_the_same_profile(
+        self, tmp_path, capsys, stub_ffmpeg, spelling
+    ):
+        make_source(tmp_path / "in", f"clip{AUDIO_SUFFIX}")
+
+        code = main(["--to", spelling, str(tmp_path / "in"), str(tmp_path / "out"), "-q"])
+
+        assert code == 0
+        assert (tmp_path / "out" / f"clip{VIDEO_SUFFIX}").exists()
+        assert "1 converted" in capsys.readouterr().out
+
+    def test_an_unknown_target_is_a_usage_error_listing_the_available_ones(self, tmp_path, capsys):
+        code = main(["--to", "nonsense", str(tmp_path), str(tmp_path / "out")])
+        err = capsys.readouterr().err
+
+        assert code == 2
+        for name in PROFILES:
+            assert name in err
 
 
 class TestOutputRootResolution:
     def test_output_dir_and_mirror_to_are_mutually_exclusive(self, tmp_path):
-        args = parse(["video", str(tmp_path), "out", "--mirror-to", "E:"])
+        args = parse(convert_argv(str(tmp_path), "out", "--mirror-to", "E:"))
 
         with pytest.raises(cli.UsageError, match="not both"):
             cli._resolve_output_root(args)
 
     def test_one_of_them_is_required(self, tmp_path):
-        args = parse(["video", str(tmp_path)])
+        args = parse(convert_argv(str(tmp_path)))
 
         with pytest.raises(cli.UsageError, match="required"):
             cli._resolve_output_root(args)
 
     def test_explicit_output_dir_is_used_as_is(self, tmp_path):
-        args = parse(["video", str(tmp_path), "some/out"])
+        args = parse(convert_argv(str(tmp_path), "some/out"))
 
         assert cli._resolve_output_root(args) == Path("some/out")
 
@@ -72,7 +241,7 @@ class TestOutputRootResolution:
 class TestConvertCommand:
     def test_missing_input_directory_is_a_usage_error(self, tmp_path, capsys):
         """A bad path is a usage error (2), not "a file failed to convert" (1)."""
-        code = main(["video", str(tmp_path / "nope"), str(tmp_path / "out")])
+        code = main(convert_argv(str(tmp_path / "nope"), str(tmp_path / "out")))
 
         assert code == 2
         assert "does not exist" in capsys.readouterr().err
@@ -80,7 +249,7 @@ class TestConvertCommand:
     def test_empty_mirror_target_is_a_usage_error(self, tmp_path, capsys):
         (tmp_path / "in").mkdir()
 
-        code = main(["video", str(tmp_path / "in"), "--mirror-to", ""])
+        code = main(convert_argv(str(tmp_path / "in"), "--mirror-to", ""))
 
         assert code == 2
         assert "must not be empty" in capsys.readouterr().err
@@ -89,53 +258,78 @@ class TestConvertCommand:
     def test_non_positive_jobs_is_a_usage_error(self, tmp_path, capsys, flag):
         """0 used to fall through to the default and negatives were clamped to 1,
         both without a word to the user."""
-        code = main(["video", str(tmp_path / "in"), str(tmp_path / "out"), flag])
+        code = main(convert_argv(str(tmp_path / "in"), str(tmp_path / "out"), flag))
 
         assert code == 2
         assert "--jobs must be 1 or more" in capsys.readouterr().err
 
-    def test_no_matching_files_says_so_loudly(self, tmp_path, capsys):
-        """Silently exiting 0 with nothing done was the original sin."""
+    def test_no_candidates_prints_the_summary_and_a_hint_and_exits_zero(self, tmp_path, capsys):
+        """The summary is what the idempotent-re-run criterion is read from, and
+        an empty directory is not an error -- so the hint goes to stderr and the
+        count to stdout."""
         (tmp_path / "in").mkdir()
         (tmp_path / "in" / "notes.txt").write_text("hi")
 
-        code = main(["video", str(tmp_path / "in"), str(tmp_path / "out")])
+        code = main(convert_argv(str(tmp_path / "in"), str(tmp_path / "out")))
+        captured = capsys.readouterr()
 
         assert code == 0
-        assert "No .mkv files found" in capsys.readouterr().err
+        assert "0 converted" in captured.out
+        assert "0 failed" in captured.out
+        assert "no convertible files found" in captured.err
+
+    def test_the_hint_names_no_suffix(self, tmp_path, capsys):
+        """The curated source set is far too long to interpolate readably."""
+        (tmp_path / "in").mkdir()
+
+        main(convert_argv(str(tmp_path / "in"), str(tmp_path / "out")))
+        err = capsys.readouterr().err.lower()
+
+        for profile in PROFILES.values():
+            assert profile.target_suffix not in err
 
     def test_hint_about_recursive_when_not_recursive(self, tmp_path, capsys):
         (tmp_path / "in" / "nested").mkdir(parents=True)
 
-        main(["video", str(tmp_path / "in"), str(tmp_path / "out")])
+        main(convert_argv(str(tmp_path / "in"), str(tmp_path / "out")))
 
         assert "--recursive" in capsys.readouterr().err
 
-    def test_dry_run_lists_pairs_without_touching_ffmpeg(self, tmp_path, capsys):
-        source = tmp_path / "in" / "clip.mkv"
-        source.parent.mkdir(parents=True)
-        source.write_bytes(b"")
+    def test_a_non_media_file_is_never_a_candidate(self, tmp_path, capsys):
+        make_source(tmp_path / "in", "clip.mkv")
+        (tmp_path / "in" / "readme.nfo").write_text("hi")
 
-        code = main(["video", str(tmp_path / "in"), str(tmp_path / "out"), "--dry-run"])
+        main(convert_argv(str(tmp_path / "in"), str(tmp_path / "out"), "--dry-run"))
+        out = capsys.readouterr().out
+
+        assert "readme" not in out
+        assert "1 file(s) would be converted" in out
+
+    def test_dry_run_lists_pairs_without_touching_ffmpeg(self, tmp_path, capsys, monkeypatch):
+        def explode(*_args, **_kwargs):
+            raise AssertionError("--dry-run must work without ffmpeg installed")
+
+        monkeypatch.setattr(cli.ffmpegtool, "resolve_tools", explode)
+        make_source(tmp_path / "in", "clip.mkv")
+
+        code = main(convert_argv(str(tmp_path / "in"), str(tmp_path / "out"), "--dry-run"))
         out = capsys.readouterr().out
 
         assert code == 0
         assert "clip.mkv" in out
-        assert "clip.mp4" in out
+        assert f"clip{VIDEO_SUFFIX}" in out
         assert not (tmp_path / "out").exists()
 
-    def test_collisions_are_refused_before_any_conversion(self, tmp_path):
-        """Two inputs mapping to one output means one of them would be lost."""
+    def test_distinct_sub_directories_are_not_a_collision(self, tmp_path):
+        """Two inputs mapping to one output means one of them would be lost --
+        but the mirrored tree is exactly what keeps these two apart."""
         for folder in ("a", "b"):
-            path = tmp_path / "in" / folder / "ep1.mkv"
-            path.parent.mkdir(parents=True)
-            path.write_bytes(b"")
+            make_source(tmp_path / "in" / folder, "ep1.mkv")
 
         code = main(
-            ["video", str(tmp_path / "in"), str(tmp_path / "out"), "--recursive", "--dry-run"]
+            convert_argv(str(tmp_path / "in"), str(tmp_path / "out"), "--recursive", "--dry-run")
         )
 
-        # Distinct sub-directories are preserved, so this must NOT be a collision.
         assert code == 0
 
     def test_a_collision_stops_the_run(self, tmp_path, capsys, monkeypatch):
@@ -143,26 +337,22 @@ class TestConvertCommand:
         sensitivity, so the CLI's reaction to a collision is driven directly
         instead of through a case-folding trick that only works on one platform.
         """
-        source = tmp_path / "in" / "clip.mkv"
-        source.parent.mkdir(parents=True)
-        source.write_bytes(b"")
-        clash = tmp_path / "out" / "clip.mp4"
+        source = make_source(tmp_path / "in", "clip.mkv")
+        clash = tmp_path / "out" / f"clip{VIDEO_SUFFIX}"
         monkeypatch.setattr(cli.paths, "find_collisions", lambda _pairs: {clash: [source, source]})
 
-        code = main(["video", str(tmp_path / "in"), str(tmp_path / "out"), "--dry-run"])
+        code = main(convert_argv(str(tmp_path / "in"), str(tmp_path / "out"), "--dry-run"))
         err = capsys.readouterr().err
 
         assert code == 2
         assert "same output" in err
-        assert "clip.mp4" in err
+        assert f"clip{VIDEO_SUFFIX}" in err
 
     def test_missing_ffmpeg_is_reported_once_and_clearly(self, tmp_path, capsys, monkeypatch):
-        source = tmp_path / "in" / "clip.mkv"
-        source.parent.mkdir(parents=True)
-        source.write_bytes(b"")
+        make_source(tmp_path / "in", "clip.mkv")
         monkeypatch.setattr(cli.ffmpegtool, "which", lambda _name: None)
 
-        code = main(["video", str(tmp_path / "in"), str(tmp_path / "out")])
+        code = main(convert_argv(str(tmp_path / "in"), str(tmp_path / "out")))
         err = capsys.readouterr().err
 
         assert code == 2
@@ -170,14 +360,146 @@ class TestConvertCommand:
         assert "winget install" in err
 
 
+class TestSourceSelection:
+    """The rules of docs/design/source-selection.md, driven through main()."""
+
+    def test_a_source_with_the_target_suffix_converts_to_a_different_root(
+        self, tmp_path, capsys, stub_ffmpeg
+    ):
+        """A source that already carries the target suffix is a legitimate remux
+        into a separate output root, not a self-write."""
+        make_source(tmp_path / "in", f"a{VIDEO_SUFFIX}")
+
+        code = main(convert_argv(str(tmp_path / "in"), str(tmp_path / "out"), "-q"))
+
+        assert code == 0
+        assert "1 converted" in capsys.readouterr().out
+        assert (tmp_path / "out" / f"a{VIDEO_SUFFIX}").exists()
+
+    def test_a_self_writing_source_is_a_counted_skip(self, tmp_path, capsys, stub_ffmpeg):
+        """Converting a tree in place must stay idempotent and still report."""
+        source = make_source(tmp_path / "in", f"a{VIDEO_SUFFIX}")
+        before = source.read_bytes()
+
+        code = main(convert_argv(str(tmp_path / "in"), str(tmp_path / "in"), "-q"))
+
+        assert code == 0
+        assert "0 converted, 1 skipped" in capsys.readouterr().out
+        assert source.read_bytes() == before
+
+    @pytest.mark.parametrize("extra", [[], ["-q"]])
+    def test_a_self_write_is_named_rather_than_passed_over(
+        self, tmp_path, capsys, stub_ffmpeg, extra
+    ):
+        """--quiet hides the progress bar, not the reasons: the batch prints its
+        own skip notes either way, so these must not disappear either."""
+        make_source(tmp_path / "in", f"a{VIDEO_SUFFIX}")
+
+        main(convert_argv(str(tmp_path / "in"), str(tmp_path / "in"), *extra))
+        out = capsys.readouterr().out
+
+        assert f"a{VIDEO_SUFFIX}" in out
+        assert "this file itself" in out
+
+    def test_the_self_write_guard_fires_under_mirror_to(self, tmp_path, capsys, stub_ffmpeg):
+        """--mirror-to derives the output root from a *resolved* input path while
+        discovery returns paths built from the root as typed, so a guard that
+        compared them as given would miss this."""
+        inside = tmp_path / "in"
+        make_source(inside, f"a{VIDEO_SUFFIX}")
+
+        code = main(convert_argv(str(inside), "--mirror-to", self_mirroring_root(inside), "-q"))
+
+        assert code == 0
+        assert "1 skipped" in capsys.readouterr().out
+
+    def test_an_existing_output_is_skipped(self, tmp_path, capsys, stub_ffmpeg):
+        make_source(tmp_path / "in", "clip.mkv")
+        existing = tmp_path / "out" / f"clip{VIDEO_SUFFIX}"
+        existing.parent.mkdir(parents=True)
+        existing.write_bytes(b"already done")
+
+        code = main(convert_argv(str(tmp_path / "in"), str(tmp_path / "out"), "-q"))
+
+        assert code == 0
+        assert "1 skipped" in capsys.readouterr().out
+        assert existing.read_bytes() == b"already done"
+
+    def test_overwrite_refuses_when_a_sibling_would_destroy_a_selected_source(
+        self, tmp_path, capsys, stub_ffmpeg
+    ):
+        """Reporting `a.mp4` as skipped and then overwriting it would destroy a
+        file the run said it kept."""
+        make_source(tmp_path / "in", "a.mkv")
+        victim = make_source(tmp_path / "in", f"a{VIDEO_SUFFIX}")
+
+        code = main(convert_argv(str(tmp_path / "in"), str(tmp_path / "in"), "--overwrite", "-q"))
+        err = capsys.readouterr().err
+
+        assert code == 2
+        assert "a.mkv" in err
+        assert f"a{VIDEO_SUFFIX}" in err
+        assert victim.read_bytes() == b"data"
+
+    def test_without_overwrite_the_same_directory_is_merely_idempotent(
+        self, tmp_path, capsys, stub_ffmpeg
+    ):
+        """Nothing is at risk, so an in-place re-run must not exit 2."""
+        make_source(tmp_path / "in", "a.mkv")
+        make_source(tmp_path / "in", f"a{VIDEO_SUFFIX}")
+
+        code = main(convert_argv(str(tmp_path / "in"), str(tmp_path / "in"), "-q"))
+
+        assert code == 0
+        assert "0 converted, 2 skipped" in capsys.readouterr().out
+
+    def test_the_overwrite_refusal_also_fires_under_mirror_to(self, tmp_path, capsys, stub_ffmpeg):
+        """The paths differ as given and agree only once resolved, which the
+        one-directory test cannot tell apart."""
+        inside = tmp_path / "in"
+        make_source(inside, "a.mkv")
+        make_source(inside, f"a{VIDEO_SUFFIX}")
+        root = self_mirroring_root(inside)
+
+        code = main(convert_argv(str(inside), "--mirror-to", root, "--overwrite", "-q"))
+
+        assert code == 2
+        assert "would be overwritten" in capsys.readouterr().err
+
+    def test_a_nested_output_root_converges(self, tmp_path, capsys, stub_ffmpeg):
+        """Without the output-tree exclusion this grows one `converted` level per
+        run, forever, while reporting `1 converted` every time."""
+        inside = tmp_path / "in"
+        make_source(inside, "clip.mkv")
+        argv = convert_argv(str(inside), str(inside / "converted"), "--recursive", "-q")
+
+        assert main(argv) == 0
+        capsys.readouterr()
+        assert main(argv) == 0
+
+        out = capsys.readouterr().out
+        assert "0 converted" in out
+        assert not (inside / "converted" / "converted").exists()
+
+    def test_an_ancestor_output_root_still_converts(self, tmp_path, capsys, stub_ffmpeg):
+        """A rule written as "lies under the output root" without the strict-
+        descendant clause would exclude every candidate here."""
+        make_source(tmp_path / "in" / "sub", "clip.mkv")
+        argv = convert_argv(str(tmp_path / "in" / "sub"), str(tmp_path / "in"), "-q")
+
+        assert main(argv) == 0
+        assert "1 converted" in capsys.readouterr().out
+
+        assert main(argv) == 0
+        assert "0 converted" in capsys.readouterr().out
+
+
 class TestExitCodeWiring:
     """Drives a whole run through main() with a stubbed ffmpeg, so the exit-code
     contract in the README is checked end to end rather than per unit."""
 
     def _prepare(self, tmp_path, monkeypatch, returncode: int) -> None:
-        source = tmp_path / "in" / "clip.mkv"
-        source.parent.mkdir(parents=True, exist_ok=True)
-        source.write_bytes(b"data")
+        make_source(tmp_path / "in", "clip.mkv")
 
         def run(argv, **_kwargs):
             Path(argv[-1]).write_bytes(b"converted")
@@ -191,22 +513,22 @@ class TestExitCodeWiring:
     def test_a_clean_run_exits_zero(self, tmp_path, monkeypatch, capsys):
         self._prepare(tmp_path, monkeypatch, 0)
 
-        code = main(["video", str(tmp_path / "in"), str(tmp_path / "out"), "-q"])
+        code = main(convert_argv(str(tmp_path / "in"), str(tmp_path / "out"), "-q"))
 
         assert code == 0
         assert "1 converted" in capsys.readouterr().out
-        assert (tmp_path / "out" / "clip.mp4").exists()
+        assert (tmp_path / "out" / f"clip{VIDEO_SUFFIX}").exists()
 
     def test_a_failed_conversion_exits_one(self, tmp_path, monkeypatch, capsys):
         """The old scripts always printed 'Conversion completed.' and exited 0."""
         self._prepare(tmp_path, monkeypatch, 1)
-        # A stream MP4 has a rule for, so this stays a genuine failure rather
-        # than the unsupported outcome.
+        # A stream the target has a rule for, so this stays a genuine failure
+        # rather than the unsupported outcome.
         monkeypatch.setattr(
             batch.ffmpegtool, "probe_streams", lambda *_a: [Stream(0, "video", "h264")]
         )
 
-        code = main(["video", str(tmp_path / "in"), str(tmp_path / "out"), "-q"])
+        code = main(convert_argv(str(tmp_path / "in"), str(tmp_path / "out"), "-q"))
 
         assert code == 1
         assert "1 failed" in capsys.readouterr().out
@@ -217,33 +539,31 @@ class TestExitCodeWiring:
             batch.ffmpegtool, "probe_streams", lambda *_a: [Stream(0, "video", "h264")]
         )
 
-        main(["video", str(tmp_path / "in"), str(tmp_path / "out"), "-q"])
+        main(convert_argv(str(tmp_path / "in"), str(tmp_path / "out"), "-q"))
 
-        assert not (tmp_path / "out" / "clip.mp4").exists()
+        assert not (tmp_path / "out" / f"clip{VIDEO_SUFFIX}").exists()
 
-    def test_skipping_everything_still_exits_zero(self, tmp_path, monkeypatch, capsys):
-        self._prepare(tmp_path, monkeypatch, 0)
-        existing = tmp_path / "out" / "clip.mp4"
-        existing.parent.mkdir(parents=True)
-        existing.write_bytes(b"already done")
+    def test_an_unsupported_source_does_not_set_the_exit_code(self, tmp_path, monkeypatch, capsys):
+        """A mixed tree converts what it can and reports the rest by name."""
+        self._prepare(tmp_path, monkeypatch, 1)
+        monkeypatch.setattr(
+            batch.ffmpegtool, "probe_streams", lambda *_a: [Stream(0, "video", "h264")]
+        )
 
-        code = main(["video", str(tmp_path / "in"), str(tmp_path / "out"), "-q"])
-
-        assert code == 0
-        assert "1 skipped" in capsys.readouterr().out
-        assert existing.read_bytes() == b"already done"
-
-    def test_audio_conversion_runs_through_the_same_wiring(self, tmp_path, monkeypatch, capsys):
-        source = tmp_path / "in" / "tone.opus"
-        source.parent.mkdir(parents=True)
-        source.write_bytes(b"data")
-        self._prepare(tmp_path, monkeypatch, 0)
-
-        code = main(["audio", str(tmp_path / "in"), str(tmp_path / "out"), "-q"])
+        code = main(["--to", AUDIO_TARGET, str(tmp_path / "in"), str(tmp_path / "out"), "-q"])
 
         assert code == 0
-        assert "1 converted" in capsys.readouterr().out
-        assert (tmp_path / "out" / "tone.wav").exists()
+        assert "1 unsupported" in capsys.readouterr().out
+
+    def test_the_audio_target_runs_through_the_same_wiring(self, tmp_path, monkeypatch, capsys):
+        make_source(tmp_path / "in", "tone.opus")
+        self._prepare(tmp_path, monkeypatch, 0)
+
+        code = main(["--to", AUDIO_TARGET, str(tmp_path / "in"), str(tmp_path / "out"), "-q"])
+
+        assert code == 0
+        assert "2 converted" in capsys.readouterr().out
+        assert (tmp_path / "out" / f"tone{AUDIO_SUFFIX}").exists()
 
 
 class TestMirrorCommand:
@@ -251,7 +571,7 @@ class TestMirrorCommand:
         (tmp_path / "a" / "b").mkdir(parents=True)
         target = tmp_path / "mirror"
 
-        code = main(["mirror", str(tmp_path / "a"), str(target)])
+        code = main([cli.MIRROR_COMMAND, str(tmp_path / "a"), str(target)])
         out = capsys.readouterr().out
 
         assert code == 0
@@ -262,7 +582,7 @@ class TestMirrorCommand:
         (tmp_path / "a" / "b").mkdir(parents=True)
         target = tmp_path / "mirror"
 
-        code = main(["mirror", str(tmp_path / "a"), str(target), "--create"])
+        code = main([cli.MIRROR_COMMAND, str(tmp_path / "a"), str(target), "--create"])
 
         assert code == 0
         assert target.is_dir()
@@ -270,9 +590,15 @@ class TestMirrorCommand:
     def test_includes_the_root_directory_itself(self, tmp_path, capsys):
         (tmp_path / "a").mkdir()
 
-        main(["mirror", str(tmp_path / "a"), str(tmp_path / "mirror")])
+        main([cli.MIRROR_COMMAND, str(tmp_path / "a"), str(tmp_path / "mirror")])
 
         assert str(tmp_path / "a") in capsys.readouterr().out
+
+    def test_a_missing_input_root_is_a_usage_error(self, tmp_path, capsys):
+        code = main([cli.MIRROR_COMMAND, str(tmp_path / "nope"), str(tmp_path / "mirror")])
+
+        assert code == 2
+        assert "does not exist" in capsys.readouterr().err
 
 
 class TestInteractivePrompt:
@@ -280,33 +606,66 @@ class TestInteractivePrompt:
         queue = list(answers)
         monkeypatch.setattr("builtins.input", lambda _prompt="": queue.pop(0))
 
-    def test_video_with_explicit_output_directory(self, monkeypatch):
-        self._answers(monkeypatch, ["1", "C:/in", "C:/out", "y", "n"])
+    def test_the_menu_offers_the_registry_in_sorted_order_with_mirror_last(
+        self, monkeypatch, capsys
+    ):
+        self._answers(monkeypatch, ["1", "C:/in", "C:/out", "n", "n"])
 
-        assert prompt_for_argv() == ["video", "C:/in", "C:/out", "--recursive"]
+        prompt_for_argv()
+        lines = [li.strip() for li in capsys.readouterr().out.splitlines() if ")" in li]
 
-    def test_audio_falling_back_to_a_mirror_drive(self, monkeypatch):
-        self._answers(monkeypatch, ["2", "C:/in", "", "E:", "n", "y"])
+        assert [li.split(") ", 1)[1].split(" - ")[0] for li in lines] == [
+            *sorted(PROFILES),
+            cli.MIRROR_COMMAND,
+        ]
 
-        assert prompt_for_argv() == ["audio", "C:/in", "--mirror-to", "E:", "--overwrite"]
+    def test_the_first_target_is_the_default(self, monkeypatch):
+        self._answers(monkeypatch, ["", "C:/in", "C:/out", "n", "n"])
 
-    def test_mirror_choice(self, monkeypatch):
-        self._answers(monkeypatch, ["3", "C:/in", "E:", "y"])
+        assert prompt_for_argv()[:2] == ["--to", sorted(PROFILES)[0]]
 
-        assert prompt_for_argv() == ["mirror", "C:/in", "E:", "--create"]
+    def test_a_number_selects_a_target_with_an_explicit_output_directory(self, monkeypatch):
+        index = sorted(PROFILES).index(VIDEO_TARGET) + 1
+        self._answers(monkeypatch, [str(index), "C:/in", "C:/out", "y", "n"])
+
+        assert prompt_for_argv() == ["--to", VIDEO_TARGET, "C:/in", "C:/out", "--recursive"]
+
+    def test_a_typed_format_name_is_accepted_instead_of_a_number(self, monkeypatch):
+        self._answers(monkeypatch, [AUDIO_SUFFIX, "C:/in", "C:/out", "n", "n"])
+
+        assert prompt_for_argv() == ["--to", AUDIO_TARGET, "C:/in", "C:/out"]
+
+    def test_falling_back_to_a_mirror_drive(self, monkeypatch):
+        index = sorted(PROFILES).index(AUDIO_TARGET) + 1
+        self._answers(monkeypatch, [str(index), "C:/in", "", "E:", "n", "y"])
+
+        assert prompt_for_argv() == [
+            "--to",
+            AUDIO_TARGET,
+            "C:/in",
+            "--mirror-to",
+            "E:",
+            "--overwrite",
+        ]
+
+    def test_mirror_is_the_last_entry(self, monkeypatch):
+        self._answers(monkeypatch, [str(len(PROFILES) + 1), "C:/in", "E:", "y"])
+
+        assert prompt_for_argv() == [cli.MIRROR_COMMAND, "C:/in", "E:", "--create"]
 
     def test_quoted_paths_are_accepted(self, monkeypatch):
         self._answers(monkeypatch, ["1", '"C:/in"', '"C:/out"', "n", "n"])
 
-        assert prompt_for_argv() == ["video", "C:/in", "C:/out"]
-
-    def test_default_selection_is_video(self, monkeypatch):
-        self._answers(monkeypatch, ["", "C:/in", "C:/out", "n", "n"])
-
-        assert prompt_for_argv()[0] == "video"
+        assert prompt_for_argv()[2:] == ["C:/in", "C:/out"]
 
     def test_unknown_selection_is_rejected(self, monkeypatch, capsys):
-        self._answers(monkeypatch, ["9"])
+        self._answers(monkeypatch, ["nonsense"])
+
+        assert prompt_for_argv() is None
+        assert "Unknown selection" in capsys.readouterr().err
+
+    def test_an_out_of_range_number_is_rejected(self, monkeypatch, capsys):
+        self._answers(monkeypatch, [str(len(PROFILES) + 2)])
 
         assert prompt_for_argv() is None
         assert "Unknown selection" in capsys.readouterr().err
@@ -316,28 +675,44 @@ class TestInteractivePrompt:
 
         assert prompt_for_argv() is None
 
-    def test_prompt_output_feeds_the_real_parser(self, monkeypatch):
-        """The interactive path must not be able to build an unparsable command."""
-        self._answers(monkeypatch, ["1", "C:/in", "C:/out", "y", "y"])
+    def test_a_prompted_conversion_round_trips_through_the_router(
+        self, monkeypatch, tmp_path, capsys, stub_ffmpeg
+    ):
+        """The interactive path must not be able to build an unroutable command."""
+        make_source(tmp_path / "in", "clip.mkv")
+        index = sorted(PROFILES).index(VIDEO_TARGET) + 1
+        self._answers(
+            monkeypatch, [str(index), str(tmp_path / "in"), str(tmp_path / "out"), "y", "y"]
+        )
 
-        argv = prompt_for_argv()
-        args = build_parser().parse_args(argv)
+        assert dispatch(prompt_for_argv()) == 0
+        assert "1 converted" in capsys.readouterr().out
 
-        assert args.recursive is True
-        assert args.overwrite is True
+    def test_a_prompted_mirror_round_trips_through_the_router(self, monkeypatch, tmp_path, capsys):
+        """A prompted mirror argv the convert parser cannot parse is exactly what
+        routing through dispatch() protects."""
+        (tmp_path / "a").mkdir()
+        self._answers(
+            monkeypatch,
+            [str(len(PROFILES) + 1), str(tmp_path / "a"), str(tmp_path / "mirror"), "n"],
+        )
+
+        assert dispatch(prompt_for_argv()) == 0
+        assert "->" in capsys.readouterr().out
 
 
 class TestMainDispatch:
     def test_no_arguments_starts_the_interactive_prompt(self, monkeypatch, tmp_path, capsys):
         (tmp_path / "in").mkdir()
-        answers = ["1", str(tmp_path / "in"), str(tmp_path / "out"), "n", "n"]
-        queue = list(answers)
+        queue = ["1", str(tmp_path / "in"), str(tmp_path / "out"), "n", "n"]
         monkeypatch.setattr("builtins.input", lambda _prompt="": queue.pop(0))
 
         code = main([])
+        captured = capsys.readouterr()
 
         assert code == 0
-        assert "No .mkv files found" in capsys.readouterr().err
+        assert "0 converted" in captured.out
+        assert "no convertible files found" in captured.err
 
     def test_aborting_the_prompt_is_not_a_crash(self, monkeypatch):
         def refuse(_prompt=""):
@@ -347,9 +722,77 @@ class TestMainDispatch:
 
         assert main([]) == 130
 
-    def test_version_flag(self, capsys):
-        with pytest.raises(SystemExit) as exit_info:
-            main(["--version"])
 
-        assert exit_info.value.code == 0
-        assert "converter" in capsys.readouterr().out
+#: The tokens no string literal in the CLI may contain, taken from the registry
+#: so a format added later is covered without touching this test.
+FORMAT_TOKENS: frozenset[str] = frozenset(
+    {profile.name for profile in PROFILES.values()}
+    | {profile.target_suffix for profile in PROFILES.values()}
+)
+
+
+def _docstring_nodes(tree: ast.Module) -> set[int]:
+    """The identities of the string constants that are docstrings, not data."""
+    holders = (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+    found = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, holders) or not node.body:
+            continue
+        first = node.body[0]
+        if (
+            isinstance(first, ast.Expr)
+            and isinstance(first.value, ast.Constant)
+            and isinstance(first.value.value, str)
+        ):
+            found.add(id(first.value))
+    return found
+
+
+def _code_strings(source: str) -> list[str]:
+    """Every string literal in *source* except the docstrings.
+
+    f-strings are covered too: their literal parts are ordinary ``Constant``
+    nodes inside the ``JoinedStr``, which ``ast.walk`` reaches.
+    """
+    tree = ast.parse(source)
+    docstrings = _docstring_nodes(tree)
+    return [
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and id(node) not in docstrings
+    ]
+
+
+class TestFormatNamesStayOutOfTheCli:
+    """The machine check behind "a target format is data, not code".
+
+    A plain grep cannot do this: ``paths.py`` illustrates its rules with a
+    suffix in prose, and a case-sensitive grep would miss an upper-cased one --
+    the check has to look at code, not at text.
+    """
+
+    @pytest.mark.parametrize("module", [cli, batch], ids=lambda m: m.__name__)
+    def test_no_string_literal_names_a_registry_format(self, module):
+        source = Path(module.__file__).read_text(encoding="utf-8")
+
+        offenders = [
+            (text, token)
+            for text in _code_strings(source)
+            for token in FORMAT_TOKENS
+            if token in text.lower()
+        ]
+
+        assert offenders == []
+
+    def test_the_check_would_catch_a_format_name(self):
+        """A canary, so a broken walker cannot make the check above vacuous."""
+        planted = f'x = "convert everything to {next(iter(FORMAT_TOKENS))}"'
+
+        assert any(
+            token in text.lower() for text in _code_strings(planted) for token in FORMAT_TOKENS
+        )
+
+    def test_a_docstring_is_not_a_string_literal_for_this_check(self):
+        assert _code_strings('"""A module docstring."""\nx = "data"\n') == ["data"]


### PR DESCRIPTION
Closes #15. Spec: `docs/specs/spec-target-driven-cli.md`.

The milestone's breaking change: the two format-pair sub-commands are gone and
the tool is driven by a target format.

## Migration

| Before | After |
| --- | --- |
| `converter video IN OUT` | `converter --to mp4 IN OUT` |
| `converter audio IN OUT` | `converter --to wav IN OUT` |

`converter mirror ...` and `converter --version` are unchanged. Both legacy
tokens are still *recognised*, only to exit 2 with a generic message that shows
the `--to` shape and points at `--list-formats` — it names no format, because
naming one in `cli.py` would defeat this PR's own format-name check.

## What changed

- **Two parsers, routed before parsing.** `build_parser()` returns the convert
  parser (positional `INPUT`, optional `OUTPUT`, required `--to`);
  `build_mirror_parser()` returns the mirror parser. `dispatch(raw)` routes on
  the raw argv: leading `mirror` → mirror parser, leading `video`/`audio` →
  migration message and 2, `--list-formats` anywhere → the list and 0, otherwise
  the convert parser. The subparsers action is itself a positional, so with
  `INPUT` on the top-level parser the two shapes genuinely cannot coexist.
- **`main()` routes on `raw` after the prompt has filled it**, so a prompted
  `mirror` argv reaches the mirror parser exactly like a typed one. The
  `hasattr(args, "handler")` fallback is gone — both parsers always reach a
  command now.
- **`--list-formats`** prints name, suffix and description per registry entry,
  sorted by name, resolving no tools and touching no filesystem.
- **The prompt is built from the registry**: targets in that same sorted order,
  `mirror` last, the first target as the default, and a typed format name
  (`wav`, `WAV`, `.wav`) accepted instead of a number.
- **Source selection now follows `docs/design/source-selection.md` end to end**:
  a nested output tree is excluded from discovery, a self-writing source is a
  counted skip, `--overwrite` refuses a run that would destroy a file it also
  reads, and a run with no candidates prints the ordinary summary plus a hint on
  stderr, exit 0 — no interpolated suffix list.
- **`cli.py`'s placeholder `_Binding`/`_BINDINGS` table is deleted**, and
  `convert_command` is 32 lines, so its tech-debt row leaves
  `docs/constitution.md`.
- **A new `ast`-based test** asserts no non-docstring string literal in `cli.py`
  or `batch.py` contains a registry format name or suffix — the machine check
  behind "a target format is data, not code", which phases 3-5 depend on. Two
  companion tests keep it from going vacuous.

`tests/test_cli.py` is rewritten against the new shape (281 tests total, up from
259) and reads its targets out of the registry, so it survives later phases.

## Verification

Verify green (ruff check, ruff format --check, 281 pytest). Wheel builds. Hand
smoke-tested against the real ffmpeg with absolute `--ffmpeg`/`--ffprobe` paths:
a mixed tree converts to `mp4` (4 converted) and re-runs `0 converted, 4
skipped`, exit 0; the same tree to `wav` reports `3 converted, 1 unsupported`,
exit 0, twice; the in-place `--overwrite` hazard is refused naming both files;
a nested output root converges; `--dry-run` works with ffmpeg off PATH;
`--list-formats`, the legacy messages and the bare-invocation prompt (both a
typed format name and the `mirror` entry) behave as described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pdnJyntsFJyawGBSGj4cV
