### PR TITLE
feat(profiles): widen the source-suffix set for video containers

### DIFF
--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -206,9 +206,11 @@ PROFILES: dict[str, Profile] = {profile.name: profile for profile in (MP4, WAV)}
 #: readable as a source, the video containers a "rip the audio" run needs, and the
 #: remaining audio target suffixes (``.mp3``, ``.m4a``, ``.flac``, ``.ogg``) so the
 #: profiles this milestone still adds already have their own suffix covered when
-#: they land -- `.opus` and `.wav` are covered already. Later phases extend this
-#: set further as they add profiles (#26 for video containers, #33 for image ones);
-#: none of them re-adds a suffix this set already holds.
+#: they land -- `.opus` and `.wav` are covered already. Phase 4 (issue #26,
+#: `spec-video-formats.md`) widens it once more with the video containers no
+#: earlier phase added, ahead of the `mkv`/`webm`/`mov` profiles that milestone
+#: still adds. Later phases extend this set further as they add profiles (#33 for
+#: image ones); none of them re-adds a suffix this set already holds.
 SOURCE_SUFFIXES: frozenset[str] = frozenset(
     {
         # phase 2: old sub-commands plus the two shipped profiles' own suffixes
@@ -237,6 +239,15 @@ SOURCE_SUFFIXES: frozenset[str] = frozenset(
         ".m4a",
         ".flac",
         ".ogg",
+        # phase 4: video containers no earlier phase added
+        ".mpg",
+        ".mpeg",
+        ".ts",
+        ".m2ts",
+        ".mts",
+        ".vob",
+        ".ogv",
+        ".3gp",
     }
 )
 

--- a/docs/specs/spec-video-formats.md
+++ b/docs/specs/spec-video-formats.md
@@ -317,3 +317,13 @@ New-Item -ItemType Directory -Force in
   No shipped profile was affected -- MP4 and WAV both already satisfy the
   equality -- so this closes a hole in the contract before phases 3-5 write
   target profiles against it, not a live bug.
+
+- 2026-08-26 (issue #26): Widened `SOURCE_SUFFIXES` with the video containers
+  this phase's Scope names -- `.mpg`, `.mpeg`, `.ts`, `.m2ts`, `.mts`, `.vob`,
+  `.ogv`, `.3gp` -- ahead of the `mkv`/`webm`/`mov` profiles this milestone
+  still adds, the same ahead-of-the-profile shape phase 3 used for the
+  remaining audio target suffixes. `.mkv` (phase 2) and `.mp4`/`.mov`/`.avi`/
+  `.webm`/`.m4v`/`.wmv`/`.flv` (phase 3) were already present and are not
+  repeated. No profile, engine, or CLI change -- data only, per this issue's
+  scope; the three new `Profile` entries remain a separate issue in this
+  milestone.

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -411,14 +411,16 @@ class TestResolveTarget:
 
 
 class TestSourceSuffixes:
-    def test_holds_the_phase_2_and_phase_3_suffixes(self):
+    def test_holds_the_phase_2_through_phase_4_suffixes(self):
         """`.mkv`/`.opus` are what the old sub-commands read; `.mp4`/`.wav` are
         what let a source already carrying the target suffix take part in
         selection (the self-write and existing-output cases,
         `docs/design/source-selection.md`). Issue #20 (`spec-audio-formats.md`)
         widens the set with the audio containers people actually have, the video
         containers a "rip the audio" run needs, and the remaining audio target
-        suffixes ahead of the profiles that will claim them."""
+        suffixes ahead of the profiles that will claim them. Issue #26
+        (`spec-video-formats.md`) widens it once more with the video containers
+        no earlier phase added."""
         assert {
             ".mkv",
             ".mp4",
@@ -442,6 +444,14 @@ class TestSourceSuffixes:
             ".m4a",
             ".flac",
             ".ogg",
+            ".mpg",
+            ".mpeg",
+            ".ts",
+            ".m2ts",
+            ".mts",
+            ".vob",
+            ".ogv",
+            ".3gp",
         } == SOURCE_SUFFIXES
 
     def test_every_shipped_profile_s_target_suffix_is_a_source_suffix(self):
@@ -454,6 +464,15 @@ class TestSourceSuffixes:
         on issue order within the milestone."""
         audio_target_suffixes = {".mp3", ".m4a", ".flac", ".opus", ".ogg", ".wav"}
         assert audio_target_suffixes <= SOURCE_SUFFIXES
+
+    def test_holds_the_phase_4_video_container_suffixes(self):
+        """Issue #26 (`spec-video-formats.md`): the video containers no earlier
+        phase added, ahead of the `mkv`/`webm`/`mov` profiles that milestone still
+        adds. `.mkv` (phase 2) and `.mp4`/`.mov`/`.avi`/`.webm`/`.m4v`/`.wmv`/
+        `.flv` (phase 3) are deliberately not repeated here -- they are already
+        covered by the phase-2/phase-3 suffixes above."""
+        phase_4_suffixes = {".mpg", ".mpeg", ".ts", ".m2ts", ".mts", ".vob", ".ogv", ".3gp"}
+        assert phase_4_suffixes <= SOURCE_SUFFIXES
 
 
 class TestValueTypesAreFrozen:


### PR DESCRIPTION
## Summary
- Widens `SOURCE_SUFFIXES` in `converter/profiles.py` with the video containers no earlier phase added: `.mpg`, `.mpeg`, `.ts`, `.m2ts`, `.mts`, `.vob`, `.ogv`, `.3gp`.
- Already present and deliberately not re-added: `.mkv` (phase 2); `.mp4`, `.mov`, `.avi`, `.webm`, `.m4v`, `.wmv`, `.flv` (phase 3).
- Data-only change, scoped to `SOURCE_SUFFIXES` per issue #26 -- the `mkv`/`webm`/`mov` `Profile` entries themselves are a separate issue in this milestone, and `PROFILES`/profile definitions are untouched (owned by issue #21, in flight in parallel).
- Decision-log entry added to `docs/specs/spec-video-formats.md`.

## Test plan
- [x] `.venv/Scripts/python.exe scripts/verify.py` -- lint, format, and 300 tests green.
- [x] `tests/test_profiles.py::TestSourceSuffixes` updated: the full-set assertion now includes the eight new suffixes, and a new `test_holds_the_phase_4_video_container_suffixes` pins them explicitly.

Closes #26