### PR TITLE
feat(profiles): widen SOURCE_SUFFIXES for image containers

### DIFF
--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -209,8 +209,10 @@ PROFILES: dict[str, Profile] = {profile.name: profile for profile in (MP4, WAV)}
 #: they land -- `.opus` and `.wav` are covered already. Phase 4 (issue #26,
 #: `spec-video-formats.md`) widens it once more with the video containers no
 #: earlier phase added, ahead of the `mkv`/`webm`/`mov` profiles that milestone
-#: still adds. Later phases extend this set further as they add profiles (#33 for
-#: image ones); none of them re-adds a suffix this set already holds.
+#: still adds. Phase 5 (issue #33, `spec-image-formats.md`) widens it once more
+#: with the image containers the seven image profiles that milestone still adds
+#: will need, ahead of those profiles landing. None of them re-adds a suffix this
+#: set already holds.
 SOURCE_SUFFIXES: frozenset[str] = frozenset(
     {
         # phase 2: old sub-commands plus the two shipped profiles' own suffixes
@@ -248,6 +250,19 @@ SOURCE_SUFFIXES: frozenset[str] = frozenset(
         ".vob",
         ".ogv",
         ".3gp",
+        # phase 5: image containers ahead of the seven image profiles
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".webp",
+        ".avif",
+        ".gif",
+        ".tif",
+        ".tiff",
+        ".bmp",
+        ".ppm",
+        ".pgm",
+        ".tga",
     }
 )
 

--- a/docs/specs/spec-image-formats.md
+++ b/docs/specs/spec-image-formats.md
@@ -353,3 +353,9 @@ New-Item -ItemType Directory -Force in
   `gif` and `avif` force their encoder, so every standing note sits on a rung that
   always wins — `gif` pays nothing for it, `avif` pays a generation loss and seven
   seconds per already-AVIF file, accepted rather than leaving its losses silent.
+- 2026-08-26: Issue #33 widened `SOURCE_SUFFIXES` with the twelve image
+  containers this phase's `In scope` names — `.png`, `.jpg`, `.jpeg`, `.webp`,
+  `.avif`, `.gif`, `.tif`, `.tiff`, `.bmp`, `.ppm`, `.pgm`, `.tga` — ahead of the
+  seven image profiles this milestone still adds, following the phase-3/phase-4
+  precedent of widening the suffix set before its profiles land. None of the
+  twelve was already present.

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -411,7 +411,7 @@ class TestResolveTarget:
 
 
 class TestSourceSuffixes:
-    def test_holds_the_phase_2_through_phase_4_suffixes(self):
+    def test_holds_the_phase_2_through_phase_5_suffixes(self):
         """`.mkv`/`.opus` are what the old sub-commands read; `.mp4`/`.wav` are
         what let a source already carrying the target suffix take part in
         selection (the self-write and existing-output cases,
@@ -420,7 +420,9 @@ class TestSourceSuffixes:
         containers a "rip the audio" run needs, and the remaining audio target
         suffixes ahead of the profiles that will claim them. Issue #26
         (`spec-video-formats.md`) widens it once more with the video containers
-        no earlier phase added."""
+        no earlier phase added. Issue #33 (`spec-image-formats.md`) widens it
+        once more with the image containers ahead of the seven image profiles
+        that milestone still adds."""
         assert {
             ".mkv",
             ".mp4",
@@ -452,6 +454,18 @@ class TestSourceSuffixes:
             ".vob",
             ".ogv",
             ".3gp",
+            ".png",
+            ".jpg",
+            ".jpeg",
+            ".webp",
+            ".avif",
+            ".gif",
+            ".tif",
+            ".tiff",
+            ".bmp",
+            ".ppm",
+            ".pgm",
+            ".tga",
         } == SOURCE_SUFFIXES
 
     def test_every_shipped_profile_s_target_suffix_is_a_source_suffix(self):
@@ -473,6 +487,27 @@ class TestSourceSuffixes:
         covered by the phase-2/phase-3 suffixes above."""
         phase_4_suffixes = {".mpg", ".mpeg", ".ts", ".m2ts", ".mts", ".vob", ".ogv", ".3gp"}
         assert phase_4_suffixes <= SOURCE_SUFFIXES
+
+    def test_holds_the_phase_5_image_container_suffixes(self):
+        """Issue #33 (`spec-image-formats.md`): the image containers ahead of the
+        seven image profiles that milestone still adds -- `png`, `jpg`, `webp`,
+        `avif`, `gif`, `tiff`, `bmp`. None of these twelve suffixes was already
+        present in the set seeded by phases 2 through 4."""
+        phase_5_suffixes = {
+            ".png",
+            ".jpg",
+            ".jpeg",
+            ".webp",
+            ".avif",
+            ".gif",
+            ".tif",
+            ".tiff",
+            ".bmp",
+            ".ppm",
+            ".pgm",
+            ".tga",
+        }
+        assert phase_5_suffixes <= SOURCE_SUFFIXES
 
 
 class TestValueTypesAreFrozen:

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -489,10 +489,10 @@ class TestSourceSuffixes:
         assert phase_4_suffixes <= SOURCE_SUFFIXES
 
     def test_holds_the_phase_5_image_container_suffixes(self):
-        """Issue #33 (`spec-image-formats.md`): the image containers ahead of the
-        seven image profiles that milestone still adds -- `png`, `jpg`, `webp`,
-        `avif`, `gif`, `tiff`, `bmp`. None of these twelve suffixes was already
-        present in the set seeded by phases 2 through 4."""
+        """Issue #33 (`spec-image-formats.md`): the twelve image container
+        suffixes ahead of the seven image profiles (`png`, `jpg`, `webp`, `avif`,
+        `gif`, `tiff`, `bmp`) that milestone still adds. None of the twelve was
+        already present in the set seeded by phases 2 through 4."""
         phase_5_suffixes = {
             ".png",
             ".jpg",


### PR DESCRIPTION
## Summary

Extends the curated `SOURCE_SUFFIXES` set in `converter/profiles.py` with the
twelve image container suffixes `docs/specs/spec-image-formats.md` names, ahead
of the seven image profiles that milestone still adds (mirrors the phase-3
(#20) and phase-4 (#26) precedent of widening the suffix set before its
profiles land).

Added: `.png`, `.jpg`, `.jpeg`, `.webp`, `.avif`, `.gif`, `.tif`, `.tiff`,
`.bmp`, `.ppm`, `.pgm`, `.tga`. None of the twelve was already present in the
set.

Only `SOURCE_SUFFIXES` and its comment changed — no `PROFILES` entries touched,
per issue #33's file-ownership split with the concurrent #21 (mp3/flac) and
#27 (mkv) work.

## Test plan
- [x] `.venv/Scripts/python.exe scripts/verify.py` green (lint, format, 301
  tests passing)
- [x] `tests/test_profiles.py::TestSourceSuffixes` extended: the full-set
  equality assertion now includes the twelve new suffixes, plus a new
  `test_holds_the_phase_5_image_container_suffixes` subset test following the
  established phase-4 pattern
- [x] Decision-log entry added to `docs/specs/spec-image-formats.md`

Closes #33