### PR TITLE
feat(profiles): mp3 and flac targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ installed version supports; today that is:
 
 ```
 Target formats:
-  mp4  .mp4  Video: copies compatible streams, re-encodes the rest to h264/aac
-  wav  .wav  Audio: single stream, uncompressed 16-bit PCM
+  flac  .flac  Audio: single stream, lossless FLAC
+  mp3   .mp3   Audio: single stream, MP3 (libmp3lame if re-encoded)
+  mp4   .mp4   Video: copies compatible streams, re-encodes the rest to h264/aac
+  wav   .wav   Audio: single stream, uncompressed 16-bit PCM
 ```
 
 More target formats can be added — see [Contributing](#contributing).
@@ -141,8 +143,13 @@ note    Show.S01E02.mkv: subtitle stream 2 (hdmv_pgs_subtitle) dropped: bitmap s
   put Vorbis or VP9 into an MP4 container, so step 1 succeeds and nothing is
   re-encoded — but many players and TVs will not touch those streams. If a
   converted file refuses to play, that is the likely reason.
-* **WAV holds one audio stream.** For a source with several audio streams,
-  the first one is converted and the rest are dropped.
+* **WAV, MP3 and FLAC each hold one audio stream.** For a source with several
+  audio streams, the first one is converted and the rest are dropped. For MP3
+  and FLAC that limit is the container's own muxer, not a choice this tool
+  makes.
+* **MP3 and FLAC never carry video.** Any non-audio stream — including
+  embedded cover art — is left out, and every conversion into either format
+  says so, whether or not that file actually had one to lose.
 * **Windows path length.** Mirroring a deep source tree onto a sub-directory can
   push paths past Windows' 260-character limit; the error message says so when it
   happens. Either pick a shorter output root or

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ installed version supports; today that is:
 ```
 Target formats:
   flac  .flac  Audio: single stream, lossless FLAC
-  mp3   .mp3   Audio: single stream, MP3 (libmp3lame if re-encoded)
-  mp4   .mp4   Video: copies compatible streams, re-encodes the rest to h264/aac
-  wav   .wav   Audio: single stream, uncompressed 16-bit PCM
+  mp3   .mp3  Audio: single stream, MP3 (libmp3lame if re-encoded)
+  mp4   .mp4  Video: copies compatible streams, re-encodes the rest to h264/aac
+  wav   .wav  Audio: single stream, uncompressed 16-bit PCM
 ```
 
 More target formats can be added — see [Contributing](#contributing).
@@ -148,8 +148,9 @@ note    Show.S01E02.mkv: subtitle stream 2 (hdmv_pgs_subtitle) dropped: bitmap s
   and FLAC that limit is the container's own muxer, not a choice this tool
   makes.
 * **MP3 and FLAC never carry video.** Any non-audio stream — including
-  embedded cover art — is left out, and every conversion into either format
-  says so, whether or not that file actually had one to lose.
+  embedded cover art — is left out. A straight copy says so even when the
+  source had nothing to lose; when the audio itself has to be re-encoded, the
+  dropped stream is still named, just without the extra line.
 * **Windows path length.** Mirroring a deep source tree onto a sub-directory can
   push paths past Windows' 260-character limit; the error message says so when it
   happens. Either pick a shorter output root or

--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -190,9 +190,98 @@ WAV = Profile(
     },
 )
 
+MP3 = Profile(
+    label="MP3",
+    name="mp3",
+    description="Audio: single stream, MP3 (libmp3lame if re-encoded)",
+    target_suffix=".mp3",
+    container_options=(),
+    # Blind by type, not by index: the mp3 muxer -- not this mapping --
+    # enforces "at most one audio stream" (measured against ffmpeg 9.0,
+    # docs/specs/spec-audio-formats.md), so a second stream fails the cheap
+    # attempt outright rather than needing an index-based selector to keep it
+    # out; that is what lets stream_limit=1 coexist with a blind "-map 0:a?"
+    # below, the muxer-enforced exemption docs/design/degradation-ladder.md
+    # names, rather than WAV's index-named one.
+    cheap_attempt=Attempt(
+        label="remux",
+        options=flags("-map 0:a? -c:a copy"),
+        # partial_mapping's success-side verification (docs/design/degradation-
+        # ladder.md) already names a dropped stream precisely when the ladder
+        # actually drops one; this line is the standing note the audio-formats
+        # spec's gate chose to keep alongside it -- always true, so it costs
+        # nothing to state even for the many files that had nothing to lose.
+        notes=("non-audio streams, including cover art, are not carried into MP3",),
+    ),
+    explicit_streams=False,
+    # "-map 0:a?" selects no video, subtitle or attachment stream, so any of
+    # those a source carries is left behind without ffmpeg ever complaining.
+    partial_mapping=True,
+    rules={
+        "audio": StreamRule(
+            copy_mask=frozenset({"mp3"}),
+            # stream_limit=1 means at most one output audio stream ever exists,
+            # so the position placeholder StreamRule's docstring describes is
+            # left out -- there is only ever "{n} == 0" to substitute.
+            accept_options=flags("-c:a copy"),
+            fallback_options=flags("-c:a libmp3lame -q:a 2"),
+            fallback_name="mp3",
+            stream_limit=1,
+        ),
+    },
+    last_resort=Attempt(
+        label="re-encode",
+        options=flags("-map 0:a:0 -c:a libmp3lame -q:a 2"),
+        # Rescues the one case the selective rung cannot: a mask hit whose
+        # -c:a copy the mp3 muxer refuses regardless. Explicit-index, so unlike
+        # the selective rung it cannot name a per-stream drop itself -- this is
+        # the only place that information about it exists.
+        notes=(
+            "non-audio streams, and any audio stream beyond the first, are not carried into MP3",
+        ),
+    ),
+)
+
+FLAC = Profile(
+    label="FLAC",
+    name="flac",
+    description="Audio: single stream, lossless FLAC",
+    target_suffix=".flac",
+    container_options=(),
+    # Same blind-by-type shape and the same reason as MP3's above: the flac
+    # muxer enforces "at most one audio stream" itself.
+    cheap_attempt=Attempt(
+        label="remux",
+        options=flags("-map 0:a? -c:a copy"),
+        notes=("non-audio streams, including cover art, are not carried into FLAC",),
+    ),
+    explicit_streams=False,
+    partial_mapping=True,
+    rules={
+        "audio": StreamRule(
+            copy_mask=frozenset({"flac"}),
+            accept_options=flags("-c:a copy"),
+            fallback_options=flags("-c:a flac"),
+            # No fallback_name: encoding into a container's own lossless codec
+            # gives up nothing, the same rule WAV's PCM fallback carries.
+            stream_limit=1,
+        ),
+    },
+    last_resort=Attempt(
+        label="re-encode",
+        options=flags("-map 0:a:0 -c:a flac"),
+        # Unlike MP3's, this note names no codec loss -- flac is lossless --
+        # only the streams -map 0:a:0 cannot reach, the same information MP3's
+        # last-resort note carries for the same structural reason.
+        notes=(
+            "non-audio streams, and any audio stream beyond the first, are not carried into FLAC",
+        ),
+    ),
+)
+
 #: Target name -> profile. Built from each profile's own ``name`` rather than
 #: repeating it as a literal key, so the two can never drift apart.
-PROFILES: dict[str, Profile] = {profile.name: profile for profile in (MP4, WAV)}
+PROFILES: dict[str, Profile] = {profile.name: profile for profile in (MP4, WAV, MP3, FLAC)}
 
 #: The curated set of suffixes discovery walks (`docs/design/source-selection.md`):
 #: a file is a candidate only if its suffix is in this set, never discovered from

--- a/docs/specs/spec-audio-formats.md
+++ b/docs/specs/spec-audio-formats.md
@@ -469,3 +469,22 @@ New-Item -ItemType Directory -Force art
   `TestSourceSuffixes` was updated in the same PR to pin the new exact set --
   its prior exact-equality assertion would otherwise fail the moment the set
   grew, regardless of who touches it next.
+- 2026-08-26 (#21): `mp3` and `flac` landed exactly as the fixed table and the
+  muxer facts above pin them -- blind `-map 0:a? -c:a copy`, `stream_limit=1`
+  backed by the muxer rather than the mapping, `flac`'s `fallback_name=None`,
+  and each declaring the standing non-audio note issue #21's own acceptance
+  carried forward from the gate's first decision. Measured against ffmpeg 9.0:
+  a stream copy of an already-mp3 file is packet-identical; `--to flac` from a
+  PCM `.wav` reaches the selective rung, not the last resort, and its re-encode
+  note is silent as designed; `--to mp3` on an mp3-plus-`attached_pic` source
+  now names the dropped picture stream on the *success* path, because issue
+  #18's `partial_mapping` verification (declared `True` on both profiles)
+  already covers what the superseded part of the cover-art decision above
+  worried was still an open hole -- the standing note and that precise
+  per-stream note print together for such a file, exactly the doubling-up the
+  superseded note flagged and issue #21's acceptance chose to keep anyway.
+  `tests/test_profiles.py`'s `MP3_SHAPED` stand-in was retired in the same PR:
+  the real `MP3` and `FLAC` profiles now prove the muxer-enforced
+  `stream_limit` exemption directly, so `SHIPPED` and `INVARIANT_CASES` carry
+  them instead of a shape-alike fixture describing a profile that no longer
+  needs standing in for.

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -200,6 +200,16 @@ class TestMp3Job:
 
         assert selective.notes == ("video stream 1 (h264) dropped: not supported by MP3",)
 
+    def test_last_resort_notes_are_pinned(self):
+        """The explicit-index last resort cannot name a per-stream drop itself
+        (unlike the selective rung), so what it gives up has to be its own
+        declared note -- the only place that information exists."""
+        reencode = jobs.retries(MP3, [])[-1]
+
+        assert reencode.notes == (
+            "non-audio streams, and any audio stream beyond the first, are not carried into MP3",
+        )
+
     def test_target_suffix(self):
         assert MP3.target_suffix == ".mp3"
 
@@ -256,6 +266,16 @@ class TestFlacJob:
         selective = jobs.retries(FLAC, streams)[0]
 
         assert selective.notes == ("video stream 1 (h264) dropped: not supported by FLAC",)
+
+    def test_last_resort_notes_are_pinned(self):
+        """Unlike its `StreamRule.fallback_name=None`, the last resort still
+        needs its own note: it is an explicit-index attempt, so it cannot name
+        a per-stream drop the way the selective rung does."""
+        reencode = jobs.retries(FLAC, [])[-1]
+
+        assert reencode.notes == (
+            "non-audio streams, and any audio stream beyond the first, are not carried into FLAC",
+        )
 
     def test_target_suffix(self):
         assert FLAC.target_suffix == ".flac"

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -7,7 +7,7 @@ import pytest
 
 from converter import ffmpegtool, jobs
 from converter.ffmpegtool import Stream, build_argv, cli_path
-from converter.profiles import MP4, WAV
+from converter.profiles import FLAC, MP3, MP4, WAV
 
 
 def options_of(argv: list[str], src: str, dst: str) -> list[str]:
@@ -140,6 +140,125 @@ class TestWavJob:
 
         assert len(attempts[0].notes) == 1
         assert not any("stream 0" in note for note in attempts[0].notes)
+
+
+class TestMp3Job:
+    """Issue #21, `docs/specs/spec-audio-formats.md`: mp3's cheap attempt maps
+    audio *blindly*, unlike WAV's index-explicit one, so unlike WAV a fully
+    compatible single-stream source still gets a selective rung -- the same
+    shape MP4 has (`TestMp4Retries.test_selective_copies_compatible_streams`)."""
+
+    def test_first_attempt_carries_the_standing_note(self):
+        attempt = jobs.first_attempt(MP3)
+
+        assert attempt.options == ("-map", "0:a?", "-c:a", "copy")
+        assert attempt.notes == (
+            "non-audio streams, including cover art, are not carried into MP3",
+        )
+
+    def test_single_mp3_stream_reaches_a_selective_copy(self):
+        streams = [Stream(0, "audio", "mp3")]
+
+        attempts = jobs.retries(MP3, streams)
+
+        assert [a.label for a in attempts] == ["selective", "re-encode"]
+        assert attempts[0].options == ("-map", "0:0", "-c:a", "copy")
+        assert attempts[0].notes == ()
+
+    def test_non_mp3_audio_reencodes_with_a_note(self):
+        streams = [Stream(0, "audio", "aac")]
+
+        selective = jobs.retries(MP3, streams)[0]
+
+        assert selective.options == ("-map", "0:0", "-c:a", "libmp3lame", "-q:a", "2")
+        assert selective.notes == ("audio stream 0 (aac) re-encoded to mp3",)
+
+    def test_second_audio_stream_is_dropped_by_the_muxer_enforced_limit(self):
+        """The mp3 muxer -- not the blind mapping -- is what makes a second
+        stream fail, so the drop is named on the failure-side selective rung,
+        the same shape WAV's own second-audio-stream drop has."""
+        streams = [Stream(0, "audio", "mp3"), Stream(1, "audio", "mp3")]
+
+        selective = jobs.retries(MP3, streams)[0]
+
+        assert selective.options == ("-map", "0:0", "-c:a", "copy")
+        assert selective.notes == ("audio stream 1 (mp3) dropped: MP3 holds 1 audio stream",)
+
+    def test_video_only_source_skips_straight_to_the_last_resort(self):
+        attempts = jobs.retries(MP3, [Stream(0, "video", "h264")])
+
+        assert [a.label for a in attempts] == ["re-encode"]
+
+    def test_video_stream_alongside_audio_is_dropped_with_a_note(self):
+        """No audio profile declares a video rule (spec-audio-formats.md), so
+        a video stream -- cover art included -- is always structurally
+        unsupported, named the same way MP4 names an attachment it has no
+        rule for."""
+        streams = [Stream(0, "audio", "mp3"), Stream(1, "video", "h264")]
+
+        selective = jobs.retries(MP3, streams)[0]
+
+        assert selective.notes == ("video stream 1 (h264) dropped: not supported by MP3",)
+
+    def test_target_suffix(self):
+        assert MP3.target_suffix == ".mp3"
+
+
+class TestFlacJob:
+    """Issue #21, `docs/specs/spec-audio-formats.md`: same blind-mapping shape
+    as `MP3`, but flac's fallback carries no `fallback_name`, so a re-encode
+    into flac itself is never reported as a loss."""
+
+    def test_first_attempt_carries_the_standing_note(self):
+        attempt = jobs.first_attempt(FLAC)
+
+        assert attempt.options == ("-map", "0:a?", "-c:a", "copy")
+        assert attempt.notes == (
+            "non-audio streams, including cover art, are not carried into FLAC",
+        )
+
+    def test_single_flac_stream_reaches_a_selective_copy(self):
+        streams = [Stream(0, "audio", "flac")]
+
+        attempts = jobs.retries(FLAC, streams)
+
+        assert [a.label for a in attempts] == ["selective", "re-encode"]
+        assert attempts[0].options == ("-map", "0:0", "-c:a", "copy")
+        assert attempts[0].notes == ()
+
+    def test_non_flac_audio_reencodes_with_no_note(self):
+        """Verification (spec-audio-formats.md): converting into flac emits no
+        note for the encode itself -- decoding into a lossless container's own
+        codec is not a loss, the same rule WAV's PCM fallback carries."""
+        streams = [Stream(0, "audio", "pcm_s16le")]
+
+        selective = jobs.retries(FLAC, streams)[0]
+
+        assert selective.options == ("-map", "0:0", "-c:a", "flac")
+        assert selective.notes == ()
+
+    def test_second_audio_stream_is_dropped_by_the_muxer_enforced_limit(self):
+        streams = [Stream(0, "audio", "flac"), Stream(1, "audio", "flac")]
+
+        selective = jobs.retries(FLAC, streams)[0]
+
+        assert selective.options == ("-map", "0:0", "-c:a", "copy")
+        assert selective.notes == ("audio stream 1 (flac) dropped: FLAC holds 1 audio stream",)
+
+    def test_video_only_source_skips_straight_to_the_last_resort(self):
+        attempts = jobs.retries(FLAC, [Stream(0, "video", "h264")])
+
+        assert [a.label for a in attempts] == ["re-encode"]
+
+    def test_video_stream_alongside_audio_is_dropped_with_a_note(self):
+        streams = [Stream(0, "audio", "flac"), Stream(1, "video", "h264")]
+
+        selective = jobs.retries(FLAC, streams)[0]
+
+        assert selective.notes == ("video stream 1 (h264) dropped: not supported by FLAC",)
+
+    def test_target_suffix(self):
+        assert FLAC.target_suffix == ".flac"
 
 
 class TestMp4Remux:
@@ -418,6 +537,132 @@ class TestProfileArgvPinning:
             "-c:a",
             "pcm_s16le",
             "out.wav",
+        ]
+
+    def test_mp3_cheap_attempt(self):
+        argv = build_argv("ffmpeg", "in.wav", jobs.first_attempt(MP3).options, "out.mp3")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.wav",
+            "-map",
+            "0:a?",
+            "-c:a",
+            "copy",
+            "out.mp3",
+        ]
+
+    def test_flac_cheap_attempt(self):
+        argv = build_argv("ffmpeg", "in.wav", jobs.first_attempt(FLAC).options, "out.flac")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.wav",
+            "-map",
+            "0:a?",
+            "-c:a",
+            "copy",
+            "out.flac",
+        ]
+
+    def test_mp3_copyable_source(self):
+        selective = jobs.retries(MP3, [Stream(0, "audio", "mp3")])[0]
+
+        argv = build_argv("ffmpeg", "in.wav", selective.options, "out.mp3")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.wav",
+            "-map",
+            "0:0",
+            "-c:a",
+            "copy",
+            "out.mp3",
+        ]
+
+    def test_mp3_non_copyable_source(self):
+        selective = jobs.retries(MP3, [Stream(0, "audio", "aac")])[0]
+
+        argv = build_argv("ffmpeg", "in.m4a", selective.options, "out.mp3")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.m4a",
+            "-map",
+            "0:0",
+            "-c:a",
+            "libmp3lame",
+            "-q:a",
+            "2",
+            "out.mp3",
+        ]
+
+    def test_flac_copyable_source(self):
+        selective = jobs.retries(FLAC, [Stream(0, "audio", "flac")])[0]
+
+        argv = build_argv("ffmpeg", "in.mkv", selective.options, "out.flac")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:0",
+            "-c:a",
+            "copy",
+            "out.flac",
+        ]
+
+    def test_flac_non_copyable_source(self):
+        """`--to flac` from a PCM source (Verification, spec-audio-formats.md):
+        reaches the selective rung, not `mp3`/`flac`'s last-resort."""
+        selective = jobs.retries(FLAC, [Stream(0, "audio", "pcm_s16le")])[0]
+
+        argv = build_argv("ffmpeg", "in.wav", selective.options, "out.flac")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.wav",
+            "-map",
+            "0:0",
+            "-c:a",
+            "flac",
+            "out.flac",
         ]
 
 

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,4 +1,4 @@
-"""Tests for the leaf module and the two profiles it declares."""
+"""Tests for the leaf module and the profiles it declares."""
 
 import ast
 import dataclasses
@@ -9,6 +9,8 @@ import pytest
 
 from converter import profiles
 from converter.profiles import (
+    FLAC,
+    MP3,
     MP4,
     PROFILES,
     SOURCE_SUFFIXES,
@@ -27,7 +29,7 @@ from converter.profiles import (
 MAP_LETTERS = {"v": "video", "a": "audio", "s": "subtitle", "t": "attachment", "d": "data"}
 
 #: Every profile the registry ships. A new one joins the invariant checks here.
-SHIPPED = [MP4, WAV]
+SHIPPED = [MP4, WAV, MP3, FLAC]
 
 #: A stand-in for the not-yet-shipped `mov` profile (`docs/specs/spec-video-formats.md`),
 #: shaped only enough to prove the degradation-ladder invariant's narrowed form:
@@ -57,35 +59,6 @@ MOV_SHAPED = Profile(
     },
 )
 
-#: A stand-in for a not-yet-shipped phase-3 profile shaped like `mp3`/`flac`
-#: (`docs/specs/spec-audio-formats.md`): its cheap attempt maps audio *blindly*
-#: (`-map 0:a?`), yet the rule still carries `stream_limit=1`, because the mp3
-#: and flac muxers themselves reject a second audio stream outright (measured
-#: against ffmpeg 9.0 during that spec's planning) -- a source that would trip
-#: the limit never reaches the success side at all; it fails the cheap attempt
-#: and lands on the failure side, where the declared limit drives the
-#: selective rung's own note instead. Proves the muxer-enforced `stream_limit`
-#: exemption (issue #40) the way `MOV_SHAPED` proves the force-failure one.
-MP3_SHAPED = Profile(
-    label="MP3 (shaped)",
-    name="mp3-shaped",
-    description="Stand-in for the invariant test, not a shipped profile",
-    target_suffix=".mp3",
-    container_options=(),
-    cheap_attempt=Attempt(label="remux", options=flags("-map 0:a? -c:a copy")),
-    explicit_streams=False,
-    partial_mapping=True,
-    rules={
-        "audio": StreamRule(
-            copy_mask=frozenset({"mp3"}),
-            accept_options=flags("-c:a copy"),
-            fallback_options=flags("-c:a libmp3lame -q:a 2"),
-            fallback_name="mp3",
-            stream_limit=1,
-        ),
-    },
-)
-
 #: Stream types each profile maps only to *force* the cheap attempt to fail when
 #: the source carries one -- never to carry it on the success side. The narrowed
 #: invariant (`docs/design/degradation-ladder.md`) exempts these from needing a
@@ -93,20 +66,29 @@ MP3_SHAPED = Profile(
 FORCED_FAILURE_TYPES: dict[str, frozenset[str]] = {
     MP4.name: frozenset(),
     WAV.name: frozenset(),
+    MP3.name: frozenset(),
+    FLAC.name: frozenset(),
     MOV_SHAPED.name: frozenset({"attachment"}),
-    MP3_SHAPED.name: frozenset(),
 }
 
 #: Stream types whose `stream_limit` is enforced by the container's own muxer
 #: rather than by the cheap attempt's own selectors -- the mirror of
 #: `FORCED_FAILURE_TYPES` for `stream_limit` instead of rule existence. A type
 #: listed here is mapped *blindly* and still carries a limit, because a source
-#: that would exceed it makes the cheap attempt itself fail (issue #40).
+#: that would exceed it makes the cheap attempt itself fail. `mp3` and `flac`
+#: are the profiles issue #40's narrowing was written for -- both map audio
+#: blindly (`-map 0:a?`) yet declare `stream_limit=1`, because their own
+#: muxers reject a second audio stream outright (measured against ffmpeg 9.0,
+#: `docs/specs/spec-audio-formats.md`): a source that would trip the limit
+#: never reaches the success side at all; it fails the cheap attempt and lands
+#: on the failure side, where the declared limit drives the selective rung's
+#: own note instead.
 MUXER_ENFORCED_LIMIT_TYPES: dict[str, frozenset[str]] = {
     MP4.name: frozenset(),
     WAV.name: frozenset(),
+    MP3.name: frozenset({"audio"}),
+    FLAC.name: frozenset({"audio"}),
     MOV_SHAPED.name: frozenset(),
-    MP3_SHAPED.name: frozenset({"audio"}),
 }
 
 
@@ -164,10 +146,13 @@ def named_index_counts(profile: Profile) -> dict[str, int]:
     return counts
 
 
-#: `SHIPPED` plus the two stand-ins, so the invariant is checked against
-#: profiles that actually exercise both exemptions -- otherwise the narrowed
-#: reading and a stricter one would agree on every case tested.
-INVARIANT_CASES = [*SHIPPED, MOV_SHAPED, MP3_SHAPED]
+#: `SHIPPED` plus the one remaining stand-in, so the invariant is checked
+#: against profiles that actually exercise both exemptions -- otherwise the
+#: narrowed reading and a stricter one would agree on every case tested. The
+#: muxer-enforced `stream_limit` exemption no longer needs a stand-in of its
+#: own: `MP3` and `FLAC` now prove it directly (`docs/specs/spec-audio-formats.md`),
+#: which is what retired the `MP3_SHAPED` fixture this list used to carry.
+INVARIANT_CASES = [*SHIPPED, MOV_SHAPED]
 
 
 @pytest.mark.parametrize("profile", INVARIANT_CASES, ids=lambda profile: profile.label)
@@ -392,9 +377,108 @@ class TestWavProfile:
         assert WAV.rules["audio"].stream_limit == 1
 
 
+class TestMp3Profile:
+    """Pins the shape Acceptance fixes for `mp3` (issue #21,
+    `docs/specs/spec-audio-formats.md`)."""
+
+    def test_label_and_suffix(self):
+        assert MP3.label == "MP3"
+        assert MP3.target_suffix == ".mp3"
+
+    def test_name_and_description(self):
+        assert MP3.name == "mp3"
+        assert MP3.description
+
+    def test_no_container_options(self):
+        assert MP3.container_options == ()
+
+    def test_cheap_attempt_maps_audio_blindly(self):
+        assert MP3.explicit_streams is False
+        assert MP3.cheap_attempt.options == ("-map", "0:a?", "-c:a", "copy")
+
+    def test_cheap_attempt_carries_the_standing_non_audio_note(self):
+        assert MP3.cheap_attempt.notes == (
+            "non-audio streams, including cover art, are not carried into MP3",
+        )
+
+    def test_cheap_attempt_is_declared_partial(self):
+        assert MP3.partial_mapping is True
+
+    def test_declares_only_an_audio_rule(self):
+        assert set(MP3.rules) == {"audio"}
+
+    def test_audio_rule_mask_and_fallback(self):
+        rule = MP3.rules["audio"]
+
+        assert rule.copy_mask == frozenset({"mp3"})
+        assert rule.accept_options == ("-c:a", "copy")
+        assert rule.fallback_options == ("-c:a", "libmp3lame", "-q:a", "2")
+        assert rule.fallback_name == "mp3"
+
+    def test_audio_rule_stream_limit_is_one(self):
+        """The mp3 muxer, not this mapping, enforces it -- the muxer-enforced
+        `stream_limit` exemption `docs/design/degradation-ladder.md` names."""
+        assert MP3.rules["audio"].stream_limit == 1
+
+    def test_declares_the_pinned_last_resort(self):
+        assert MP3.last_resort is not None
+        assert MP3.last_resort.options == ("-map", "0:a:0", "-c:a", "libmp3lame", "-q:a", "2")
+
+
+class TestFlacProfile:
+    """Pins the shape Acceptance fixes for `flac` (issue #21,
+    `docs/specs/spec-audio-formats.md`)."""
+
+    def test_label_and_suffix(self):
+        assert FLAC.label == "FLAC"
+        assert FLAC.target_suffix == ".flac"
+
+    def test_name_and_description(self):
+        assert FLAC.name == "flac"
+        assert FLAC.description
+
+    def test_no_container_options(self):
+        assert FLAC.container_options == ()
+
+    def test_cheap_attempt_maps_audio_blindly(self):
+        assert FLAC.explicit_streams is False
+        assert FLAC.cheap_attempt.options == ("-map", "0:a?", "-c:a", "copy")
+
+    def test_cheap_attempt_carries_the_standing_non_audio_note(self):
+        assert FLAC.cheap_attempt.notes == (
+            "non-audio streams, including cover art, are not carried into FLAC",
+        )
+
+    def test_cheap_attempt_is_declared_partial(self):
+        assert FLAC.partial_mapping is True
+
+    def test_declares_only_an_audio_rule(self):
+        assert set(FLAC.rules) == {"audio"}
+
+    def test_audio_rule_mask_and_fallback(self):
+        rule = FLAC.rules["audio"]
+
+        assert rule.copy_mask == frozenset({"flac"})
+        assert rule.accept_options == ("-c:a", "copy")
+        assert rule.fallback_options == ("-c:a", "flac")
+
+    def test_audio_rule_fallback_carries_no_re_encode_note(self):
+        """Encoding into a container's own lossless codec gives up nothing,
+        the same rule WAV's PCM fallback carries."""
+        assert FLAC.rules["audio"].fallback_name is None
+
+    def test_audio_rule_stream_limit_is_one(self):
+        """The flac muxer, not this mapping, enforces it, same as mp3's."""
+        assert FLAC.rules["audio"].stream_limit == 1
+
+    def test_declares_the_pinned_last_resort(self):
+        assert FLAC.last_resort is not None
+        assert FLAC.last_resort.options == ("-map", "0:a:0", "-c:a", "flac")
+
+
 class TestRegistry:
     def test_keys_are_each_profile_s_own_name(self):
-        assert PROFILES == {"mp4": MP4, "wav": WAV}
+        assert PROFILES == {"mp4": MP4, "wav": WAV, "mp3": MP3, "flac": FLAC}
 
 
 class TestResolveTarget:
@@ -405,8 +489,12 @@ class TestResolveTarget:
     def test_resolves_wav_too(self):
         assert resolve_target("wav") is WAV
 
+    def test_resolves_mp3_and_flac_too(self):
+        assert resolve_target("mp3") is MP3
+        assert resolve_target("flac") is FLAC
+
     def test_unknown_target_raises_value_error_listing_available_targets(self):
-        with pytest.raises(ValueError, match=r"mkv.*available targets: mp4, wav"):
+        with pytest.raises(ValueError, match=r"mkv.*available targets: flac, mp3, mp4, wav"):
             resolve_target("mkv")
 
 


### PR DESCRIPTION
## Summary

Adds the `mp3` and `flac` target profiles to `converter/profiles.py`, per
`docs/specs/spec-audio-formats.md`'s Prior decisions and fixed profile table --
the two whose muxers enforce exactly one audio stream, so `stream_limit=1` is
a real muxer constraint rather than a product judgement.

- `mp3`: mask `{mp3}`, `libmp3lame -q:a 2` fallback named `mp3`,
  `stream_limit=1`, blind cheap attempt `-map 0:a? -c:a copy`,
  `explicit_streams=False`, last resort `-map 0:a:0 -c:a libmp3lame -q:a 2`.
- `flac`: mask `{flac}`, `flac` fallback with `fallback_name=None` (a
  lossless re-encode carries no note), same shape otherwise, last resort
  `-map 0:a:0 -c:a flac`.
- Both carry the standing note that non-audio streams, cover art included,
  are not carried into the target -- kept per this issue's acceptance even
  though it now sometimes doubles up with issue #18's `partial_mapping`
  verification for a file that actually lost a stream.
- Neither profile declares a `video` rule, so a real video stream is a
  structural drop either way.
- Retires `tests/test_profiles.py`'s `MP3_SHAPED` stand-in: the real `MP3`
  and `FLAC` profiles now prove the muxer-enforced `stream_limit` exemption
  (`docs/design/degradation-ladder.md`) directly.

Diff touches only `converter/profiles.py`, `README.md`, `docs/specs/spec-audio-formats.md`
(decision log, following #47's precedent) and `tests/`.

## Test plan

- [x] `scripts/verify.py` green (ruff check, ruff format --check, pytest --
  347 passed).
- [x] Argv pinned for a copyable and a non-copyable input, for both `mp3`
  and `flac` (cheap attempt and selective rung).
- [x] A note test per degradation branch: re-encode naming both codecs,
  second-audio-stream drop (muxer-enforced limit), video drop, and the
  no-note flac encode.
- [x] Smoke-tested against real ffmpeg 9.0 (9.0-full_build):
  - `--to mp3` over a small fixture tree (already-mp3, aac `.m4a`, PCM
    `.wav`, and `clip.mp4`) converts all four, names every re-encode and the
    dropped video stream, exits 0.
  - The mp3 stream copy is packet-identical (`ffprobe -f md5` match) between
    source and output.
  - A second run over the converted tree: `0 converted, 4 skipped`, exit 0.
  - `--to flac` over the same tree plus a native `.flac` source converts all
    five; the PCM source's re-encode is silent as designed, only the
    video-drop note prints for `clip.mp4`.
  - An mp3-plus-`attached_pic` source (`art.mp3`) under `--to mp3`: the
    output holds only the mp3 audio stream; both the standing note and the
    `partial_mapping` verification's precise "video stream 1 (png) dropped:
    not supported by MP3" note print, confirming issue #18's fix already
    closes the cover-art hole for these two profiles without any change here.

Closes #21