### PR TITLE
feat(profiles): mkv target

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ installed version supports; today that is:
 
 ```
 Target formats:
+  mkv  .mkv  Video: copies almost every codec as-is, keeps font attachments
   mp4  .mp4  Video: copies compatible streams, re-encodes the rest to h264/aac
   wav  .wav  Audio: single stream, uncompressed 16-bit PCM
 ```

--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -190,9 +190,146 @@ WAV = Profile(
     },
 )
 
+
+class _AcceptAnyCodec(frozenset):
+    """A copy mask that is empty by every ordinary measure yet accepts anything.
+
+    ``len()`` is 0 and iterating it yields nothing -- the "empty-meaning" shape
+    ``docs/specs/spec-video-formats.md`` asks for -- but membership testing
+    always succeeds, so :func:`converter.jobs._decide_stream`'s
+    ``stream.codec_name in rule.copy_mask`` check reads it as "always accept"
+    without the engine (a leaf-adjacent module MKV's profile must not import
+    anyway) needing to know it. Enumerating font codec names instead would be
+    wrong by construction: ffprobe derives an attachment's codec name from its
+    MIME type, and a modern font's MIME type (``font/ttf``, ``font/otf``) reads
+    back as ``unknown`` -- measured against ffmpeg 9.0.
+    """
+
+    def __contains__(self, item: object) -> bool:
+        return True
+
+
+#: Codecs Matroska accepts as a stream copy for video, measured against ffmpeg
+#: 9.0 -- includes vp9 and av1 from a WebM source, unlike MP4's narrower mask.
+MKV_VIDEO_CODECS = frozenset(
+    {
+        "h264",
+        "hevc",
+        "av1",
+        "vp8",
+        "vp9",
+        "mpeg4",
+        "mpeg2video",
+        "theora",
+        "prores",
+        "ffv1",
+        "mjpeg",
+    }
+)
+#: Codecs Matroska accepts as a stream copy for audio, measured the same way.
+MKV_AUDIO_CODECS = frozenset(
+    {
+        "aac",
+        "mp3",
+        "ac3",
+        "eac3",
+        "dts",
+        "truehd",
+        "flac",
+        "opus",
+        "vorbis",
+        "alac",
+        "pcm_s16le",
+    }
+)
+#: Subtitle codecs Matroska accepts as a literal copy -- text *and* bitmap,
+#: unlike MP4's text-only mask. ``mov_text`` is deliberately absent: Matroska
+#: rejects a mov_text stream copy outright (measured: exit 127, "Subtitle codec
+#: mov_text ... is not supported"), so a mov_text source falls through to the
+#: ``srt`` fallback below instead of being listed here as copyable.
+MKV_SUBTITLE_CODECS = frozenset(
+    {
+        "subrip",
+        "ass",
+        "ssa",
+        "webvtt",
+        "text",
+        "hdmv_pgs_subtitle",
+        "dvd_subtitle",
+        "dvb_subtitle",
+    }
+)
+
+MKV = Profile(
+    label="MKV",
+    name="mkv",
+    description="Video: copies almost every codec as-is, keeps font attachments",
+    target_suffix=".mkv",
+    # Measured: +faststart is MP4/MOV furniture that MKV's own muxer ignores,
+    # so declaring it here would be noise, not a real container option.
+    container_options=(),
+    # Matroska is the one target in this phase that rarely re-encodes, so its
+    # cheap attempt maps every stream type its muxer can hold -- video, audio,
+    # subtitle, *and* attachment ("-map 0:t?"), which no earlier profile has
+    # needed. Still not "-map 0": that would also select data and timecode
+    # streams, which no "v/a/s/t" map -- MKV's included -- carries at all
+    # (measured), so the standing note below says so instead of ffmpeg silently
+    # dropping them off a bare "-map 0".
+    cheap_attempt=Attempt(
+        label="remux",
+        options=flags("-map 0:v? -map 0:a? -map 0:s? -map 0:t? -c copy"),
+        notes=("data and timecode streams are not carried into MKV",),
+    ),
+    explicit_streams=False,
+    # The blind "?" selectors carry every video, audio, subtitle and attachment
+    # stream MKV's muxer can hold, but never a data or timecode one -- exactly
+    # the standing note's claim, verified once per successful cheap attempt
+    # rather than assumed.
+    partial_mapping=True,
+    rules={
+        "video": StreamRule(
+            copy_mask=MKV_VIDEO_CODECS,
+            accept_options=flags("-c:v:{n} copy"),
+            fallback_options=flags("-c:v:{n} libx264 -crf:v:{n} 18"),
+            fallback_name="h264",
+        ),
+        "audio": StreamRule(
+            copy_mask=MKV_AUDIO_CODECS,
+            accept_options=flags("-c:a:{n} copy"),
+            fallback_options=flags("-c:a:{n} aac -b:a:{n} 192k"),
+            fallback_name="aac",
+        ),
+        "subtitle": StreamRule(
+            copy_mask=MKV_SUBTITLE_CODECS,
+            accept_options=flags("-c:s:{n} copy"),
+            fallback_options=flags("-c:s:{n} srt"),
+            fallback_name="subrip",
+        ),
+        # No fallback and no drop_reason: the accept-everything mask means the
+        # fallback branch of stream-decision.md can never be reached, the same
+        # reason WAV's empty mask carries no accept_options.
+        "attachment": StreamRule(
+            copy_mask=_AcceptAnyCodec(),
+            accept_options=flags("-c:t:{n} copy"),
+        ),
+    },
+    last_resort=Attempt(
+        label="re-encode",
+        options=flags(
+            "-map 0:v:0? -map 0:a? "
+            "-c:v libx264 -crf 18 -preset medium -pix_fmt yuv420p "
+            "-c:a aac -b:a 192k"
+        ),
+        notes=(
+            "re-encoded to h264/aac (lossy); subtitles and extra video streams dropped",
+            "10-bit or HDR sources are reduced to 8-bit yuv420p for player compatibility",
+        ),
+    ),
+)
+
 #: Target name -> profile. Built from each profile's own ``name`` rather than
 #: repeating it as a literal key, so the two can never drift apart.
-PROFILES: dict[str, Profile] = {profile.name: profile for profile in (MP4, WAV)}
+PROFILES: dict[str, Profile] = {profile.name: profile for profile in (MP4, WAV, MKV)}
 
 #: The curated set of suffixes discovery walks (`docs/design/source-selection.md`):
 #: a file is a candidate only if its suffix is in this set, never discovered from

--- a/docs/specs/spec-video-formats.md
+++ b/docs/specs/spec-video-formats.md
@@ -346,8 +346,9 @@ New-Item -ItemType Directory -Force in
 
   The attachment rule (`_AcceptAnyCodec`, `converter/profiles.py`) is
   implemented as a `frozenset` subclass overriding `__contains__` to always
-  return `True`, rather than as an engine change: `docs/design/degradation-ladder.md`'s risk row anticipated this ("a rule keyed on
-  `codec_type == "attachment"` works, and `-c:t:0 copy` is valid ffmpeg"), and
+  return `True`, rather than as an engine change: this spec's own Risks table
+  anticipated this ("a rule keyed on `codec_type == "attachment"` works, and
+  `-c:t:0 copy` is valid ffmpeg"), and
   both were confirmed against real ffmpeg -- a `font/ttf` attachment
   (`codec_name` reported as `unknown`, measured) round-trips through
   `-map 0:t? -c copy` and through the selective rung's `-c:t:0 copy` alike.

--- a/docs/specs/spec-video-formats.md
+++ b/docs/specs/spec-video-formats.md
@@ -137,7 +137,7 @@ table.
 | Cheap attempts, all with `explicit_streams=False`: `mkv` -> `flags("-map 0:v? -map 0:a? -map 0:s? -map 0:t? -c copy")`; `mov` -> `flags("-map 0:v? -map 0:a? -map 0:s? -map 0:t? -c copy -c:s mov_text")`; `webm` -> `flags("-map 0:v? -map 0:a? -map 0:s? -c copy -c:s webvtt")` | Each maps what its muxer can hold, measured. `mov` maps `0:t?` **deliberately**: it makes an attachment-bearing source fail into the ladder, which then names the loss per stream — better than a blanket note. `webm` does not, because it silently discards instead of failing, so mapping would buy nothing. Both `mov` and `webm` carry their in-kind subtitle transcode in the cheap attempt, so a subtitled source converts on the first attempt instead of paying a probe and a second run | 2026-08-26 |
 | Video masks: `mkv` = `{h264, hevc, av1, vp8, vp9, mpeg4, mpeg2video, theora, prores, ffv1, mjpeg}`; `webm` = `{vp8, vp9, av1}`; `mov` = `{h264, hevc, prores, mpeg4, mpeg2video, mjpeg, ffv1, theora}` — **not** `mp4`'s, which holds `vp9` and `av1` | Measured. The `mov`/`mp4` difference is two codecs, not one, and is the likeliest copy-paste mistake in the phase | 2026-08-26 |
 | Audio masks: `mkv` = `{aac, mp3, ac3, eac3, dts, truehd, flac, opus, vorbis, alac, pcm_s16le}`; `webm` = `{opus, vorbis}`; `mov` = `{aac, alac, mp3, ac3, eac3, dts, pcm_s16le}` | Measured against each muxer | 2026-08-26 |
-| Subtitle rules: `mkv` accepts text **and bitmap** subtitles as a literal copy, mask `{subrip, ass, ssa, mov_text, webvtt, text, hdmv_pgs_subtitle, dvd_subtitle, dvb_subtitle}`; `webm` transcodes text subtitles in kind to `webvtt`; `mov` to `mov_text`. `webm` and `mov` drop bitmap subtitles with a note | Matroska is the only container here that holds bitmap subtitles; the other two reuse the accept-but-transcode branch `docs/design/stream-decision.md` already models | 2026-08-26 |
+| Subtitle rules: `mkv` accepts text **and bitmap** subtitles as a literal copy, mask `{subrip, ass, ssa, webvtt, text, hdmv_pgs_subtitle, dvd_subtitle, dvb_subtitle}` — **not** `mov_text`, which Matroska rejects as a copy and which `mkv` instead re-encodes to `subrip` (`fallback_options=flags("-c:s:{n} srt")`, `fallback_name="subrip"`); `webm` transcodes text subtitles in kind to `webvtt`; `mov` to `mov_text`. `webm` and `mov` drop bitmap subtitles with a note | Matroska is the only container here that holds bitmap subtitles; the other two reuse the accept-but-transcode branch `docs/design/stream-decision.md` already models. `mov_text`'s exclusion from `mkv`'s mask is measured, not a typo: `-c:s copy` of a mov_text stream into Matroska exits 127 ("Subtitle codec mov_text ... is not supported"), while `-c:s srt` on the same input exits 0 | 2026-08-26 |
 | `mkv` declares an **attachment** rule that copies **unconditionally** — an empty-meaning "accept anything" mask, not a list of font codec names | Measured: ffprobe derives the codec name from the MIME type, so `font/ttf` reads as `unknown`. A rule enumerating `{ttf, otf}` would drop a modern font attachment with the note "attachment stream 1 (unknown) dropped: not supported by MKV" — false, and it fails `stream-decision.md`'s requirement that a note name the stream's codec | 2026-08-26 |
 | `webm` declares no attachment rule; `mov` declares none either, and relies on its cheap attempt failing instead | `webm` cannot fail on one, so its standing note covers it. `mov` fails, so the ladder's selective rung drops it with a real per-stream note | 2026-08-26 |
 | **Standing notes**, on each new profile's `cheap_attempt.notes`: `mkv` — "data and timecode streams are not carried into MKV"; `mov` — the same for MOV; `webm` — "attachments, data and timecode streams are not carried into WebM" | Measured: all three lose data/timecode at exit 0, and `webm` loses attachments the same way. `batch.py` reports only the winning attempt's notes, so a note on the cheap attempt is exactly what a successful conversion prints. This is the phase-3 gate's mechanism, applied to what this phase actually drops | 2026-08-26 |
@@ -327,3 +327,38 @@ New-Item -ItemType Directory -Force in
   repeated. No profile, engine, or CLI change -- data only, per this issue's
   scope; the three new `Profile` entries remain a separate issue in this
   milestone.
+
+- 2026-08-26 (issue #27): Added the `mkv` `Profile`. Re-measuring the muxer
+  facts against ffmpeg 9.0 while implementing found the Prior decisions'
+  subtitle-mask row wrong on one codec: it listed `mov_text` as literal-copy
+  material alongside the other eight text/bitmap codecs, but `-c:s copy` of a
+  mov_text stream into Matroska exits 127 ("Subtitle codec mov_text ... is not
+  supported"), while `-c:s srt` on the same input exits 0. Corrected in place
+  above rather than left to drift from the shipped profile: `mkv`'s subtitle
+  mask excludes `mov_text`, and the rule falls back to `-c:s:{n} srt`
+  (`fallback_name="subrip"`) for it instead. Confirmed end-to-end against real
+  ffmpeg 9.0 through the CLI: a mov_text-subtitled MP4 source fails `mkv`'s
+  cheap attempt (the blanket `-c copy` cannot copy the subtitle), reaches the
+  selective rung, and converts with the note "subtitle stream 2 (mov_text)
+  re-encoded to subrip" -- exactly the branch `TestProfileArgvPinning` cannot
+  reach, since a copyable and a non-copyable video/audio pinning pair does not
+  exercise a subtitle fallback.
+
+  The attachment rule (`_AcceptAnyCodec`, `converter/profiles.py`) is
+  implemented as a `frozenset` subclass overriding `__contains__` to always
+  return `True`, rather than as an engine change: `docs/design/degradation-ladder.md`'s risk row anticipated this ("a rule keyed on
+  `codec_type == "attachment"` works, and `-c:t:0 copy` is valid ffmpeg"), and
+  both were confirmed against real ffmpeg -- a `font/ttf` attachment
+  (`codec_name` reported as `unknown`, measured) round-trips through
+  `-map 0:t? -c copy` and through the selective rung's `-c:t:0 copy` alike.
+  `jobs.py` needed no change, keeping the PR's diff to `converter/profiles.py`,
+  `README.md`, `docs/specs/spec-video-formats.md` and `tests/`.
+
+  `mkv`'s cheap attempt maps `video`, `audio`, `subtitle` and `attachment`, and
+  the profile declares exactly those four rules, so it satisfies
+  `set(profile.rules) == set(mapped_types(profile))` directly -- unlike `mov`,
+  it needs neither the `FORCED_FAILURE_TYPES` nor the
+  `MUXER_ENFORCED_LIMIT_TYPES` exemption from `docs/design/degradation-ladder.md`
+  (issues #39/#40); `tests/test_profiles.py` adds `MKV` to `SHIPPED` with an
+  empty entry in both exemption dicts, so the existing parametrized invariant
+  tests check it machine-side rather than by review.

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -658,6 +658,7 @@ class TestSuccessSideVerification:
     def test_a_partial_profile_needs_verification(self):
         assert jobs.needs_verification(MP4) is True
         assert jobs.needs_verification(WAV) is True
+        assert jobs.needs_verification(MKV) is True
 
     def test_an_exhaustive_profile_does_not(self):
         """`False` is what keeps the probe off an exhaustive profile's happy path."""
@@ -675,7 +676,7 @@ class TestSuccessSideVerification:
 
         assert notes == ("audio stream 1 (opus) dropped: WAV holds 1 audio stream",)
 
-    @pytest.mark.parametrize("profile", [MP4, WAV], ids=lambda profile: profile.label)
+    @pytest.mark.parametrize("profile", [MP4, WAV, MKV], ids=lambda profile: profile.label)
     def test_no_profile_invents_a_loss_for_a_source_it_fully_maps(self, profile):
         """One stream of each type the profile declares a rule for, and never more
         than one, so nothing in this source can have been left behind.
@@ -683,8 +684,9 @@ class TestSuccessSideVerification:
         Built from ``profile.rules`` rather than the cheap attempt's own
         ``mapped_types`` (`tests/test_profiles.py`), which is sound only because
         ``TestPartialMappingInvariant`` there pins the two as equal for every
-        shipped profile -- if that equality ever broke for `MP4` or `WAV`, this
-        source would silently stop matching what the cheap attempt actually maps.
+        shipped profile -- if that equality ever broke for `MP4`, `WAV` or `MKV`,
+        this source would silently stop matching what the cheap attempt actually
+        maps.
         """
         streams = [Stream(i, kind, "whatever") for i, kind in enumerate(profile.rules)]
 

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -7,7 +7,7 @@ import pytest
 
 from converter import ffmpegtool, jobs
 from converter.ffmpegtool import Stream, build_argv, cli_path
-from converter.profiles import MP4, WAV
+from converter.profiles import MKV, MP4, WAV
 
 
 def options_of(argv: list[str], src: str, dst: str) -> list[str]:
@@ -315,6 +315,145 @@ class TestMp4DegradationNotes:
         )
 
 
+class TestMkvRemux:
+    def test_maps_every_stream_type_including_attachments(self):
+        options = jobs.first_attempt(MKV).options
+
+        assert options == (
+            "-map",
+            "0:v?",
+            "-map",
+            "0:a?",
+            "-map",
+            "0:s?",
+            "-map",
+            "0:t?",
+            "-c",
+            "copy",
+        )
+
+    def test_does_not_use_bare_map_zero(self):
+        """'-map 0' also selects data and timecode streams, which no
+        "v/a/s/t" map carries into MKV either (measured), so a bare "-map 0"
+        would only turn a remuxable file into a failure for no reason."""
+        options = list(jobs.first_attempt(MKV).options)
+        mapped = [options[i + 1] for i, flag in enumerate(options) if flag == "-map"]
+
+        assert "0" not in mapped
+        assert mapped == ["0:v?", "0:a?", "0:s?", "0:t?"]
+
+    def test_target_suffix(self):
+        assert MKV.target_suffix == ".mkv"
+
+
+class TestMkvRetries:
+    def test_ladder_ends_with_a_full_reencode(self):
+        attempts = jobs.retries(MKV, [Stream(0, "video", "h264")])
+
+        assert [a.label for a in attempts] == ["selective", "re-encode"]
+
+    def test_selective_copies_compatible_streams(self):
+        streams = [Stream(0, "video", "h264"), Stream(1, "audio", "aac")]
+
+        selective = jobs.retries(MKV, streams)[0]
+
+        assert selective.options[:8] == (
+            "-map",
+            "0:0",
+            "-map",
+            "0:1",
+            "-c:v:0",
+            "copy",
+            "-c:a:0",
+            "copy",
+        )
+        assert selective.notes == ()
+
+    def test_selective_reencodes_video_mkv_cannot_hold(self):
+        streams = [Stream(0, "video", "wmv3"), Stream(1, "audio", "aac")]
+
+        selective = jobs.retries(MKV, streams)[0]
+
+        assert "-c:v:0" in selective.options
+        assert selective.options[selective.options.index("-c:v:0") + 1] == "libx264"
+        assert selective.notes == ("video stream 0 (wmv3) re-encoded to h264",)
+
+    def test_selective_reencodes_audio_mkv_cannot_hold(self):
+        streams = [Stream(0, "video", "h264"), Stream(1, "audio", "wmav2")]
+
+        selective = jobs.retries(MKV, streams)[0]
+
+        assert "-c:a:0" in selective.options
+        assert selective.options[selective.options.index("-c:a:0") + 1] == "aac"
+        assert selective.notes == ("audio stream 1 (wmav2) re-encoded to aac",)
+
+    def test_selective_reencodes_mov_text_subtitle_to_srt(self):
+        """Matroska rejects a literal mov_text copy (measured), so the cheap
+        attempt's blanket '-c copy' fails on a mov_text source and the ladder
+        reaches this rung -- exactly the branch the argv-pinning tests below
+        cannot reach, since they only ever build the selective rung directly."""
+        streams = [Stream(0, "video", "h264"), Stream(1, "subtitle", "mov_text")]
+
+        selective = jobs.retries(MKV, streams)[0]
+
+        assert "-c:s:0" in selective.options
+        assert selective.options[selective.options.index("-c:s:0") + 1] == "srt"
+        assert selective.notes == ("subtitle stream 1 (mov_text) re-encoded to subrip",)
+
+    def test_selective_copies_an_attachment_whose_codec_name_is_unknown(self):
+        """ffprobe reports a font/ttf or font/otf attachment's codec_name as
+        "unknown" (measured), and MKV's attachment rule accepts it anyway."""
+        streams = [Stream(0, "video", "h264"), Stream(1, "attachment", "unknown")]
+
+        selective = jobs.retries(MKV, streams)[0]
+
+        assert "-c:t:0" in selective.options
+        assert selective.options[selective.options.index("-c:t:0") + 1] == "copy"
+        assert selective.notes == ()
+
+    def test_reencode_states_what_it_sacrifices(self):
+        reencode = jobs.retries(MKV, [])[-1]
+
+        assert "libx264" in reencode.options
+        assert "aac" in reencode.options
+        assert reencode.notes
+        assert any("lossy" in note for note in reencode.notes)
+
+
+class TestMkvDegradationNotes:
+    """Verification (spec-video-formats): one test per degradation branch this
+    profile introduces, each pinning the exact note."""
+
+    def test_video_reencode_note_is_exact(self):
+        streams = [Stream(0, "video", "wmv3"), Stream(1, "audio", "aac")]
+
+        selective = jobs.retries(MKV, streams)[0]
+
+        assert selective.notes == ("video stream 0 (wmv3) re-encoded to h264",)
+
+    def test_audio_reencode_note_is_exact(self):
+        streams = [Stream(0, "video", "h264"), Stream(1, "audio", "wmav2")]
+
+        selective = jobs.retries(MKV, streams)[0]
+
+        assert selective.notes == ("audio stream 1 (wmav2) re-encoded to aac",)
+
+    def test_subtitle_reencode_note_is_exact(self):
+        streams = [Stream(0, "video", "h264"), Stream(1, "subtitle", "mov_text")]
+
+        selective = jobs.retries(MKV, streams)[0]
+
+        assert selective.notes == ("subtitle stream 1 (mov_text) re-encoded to subrip",)
+
+    def test_last_resort_notes_are_pinned(self):
+        reencode = jobs.retries(MKV, [])[-1]
+
+        assert reencode.notes == (
+            "re-encoded to h264/aac (lossy); subtitles and extra video streams dropped",
+            "10-bit or HDR sources are reduced to 8-bit yuv420p for player compatibility",
+        )
+
+
 class TestProfileArgvPinning:
     """Verification: the full argv each profile builds, pinned byte-for-byte
     (docs/specs/spec-profile-registry.md)."""
@@ -396,6 +535,62 @@ class TestProfileArgvPinning:
             "-c:a",
             "pcm_s16le",
             "out.wav",
+        ]
+
+    def test_mkv_copyable_source(self):
+        streams = [Stream(0, "video", "h264"), Stream(1, "audio", "aac")]
+        selective = jobs.retries(MKV, streams)[0]
+
+        argv = build_argv("ffmpeg", "in.mts", selective.options, "out.mkv")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mts",
+            "-map",
+            "0:0",
+            "-map",
+            "0:1",
+            "-c:v:0",
+            "copy",
+            "-c:a:0",
+            "copy",
+            "out.mkv",
+        ]
+
+    def test_mkv_non_copyable_source(self):
+        streams = [Stream(0, "video", "wmv3"), Stream(1, "audio", "wmav2")]
+        selective = jobs.retries(MKV, streams)[0]
+
+        argv = build_argv("ffmpeg", "in.mts", selective.options, "out.mkv")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mts",
+            "-map",
+            "0:0",
+            "-map",
+            "0:1",
+            "-c:v:0",
+            "libx264",
+            "-crf:v:0",
+            "18",
+            "-c:a:0",
+            "aac",
+            "-b:a:0",
+            "192k",
+            "out.mkv",
         ]
 
     def test_wav_two_audio_source(self):

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -9,6 +9,7 @@ import pytest
 
 from converter import profiles
 from converter.profiles import (
+    MKV,
     MP4,
     PROFILES,
     SOURCE_SUFFIXES,
@@ -27,7 +28,7 @@ from converter.profiles import (
 MAP_LETTERS = {"v": "video", "a": "audio", "s": "subtitle", "t": "attachment", "d": "data"}
 
 #: Every profile the registry ships. A new one joins the invariant checks here.
-SHIPPED = [MP4, WAV]
+SHIPPED = [MP4, WAV, MKV]
 
 #: A stand-in for the not-yet-shipped `mov` profile (`docs/specs/spec-video-formats.md`),
 #: shaped only enough to prove the degradation-ladder invariant's narrowed form:
@@ -93,6 +94,7 @@ MP3_SHAPED = Profile(
 FORCED_FAILURE_TYPES: dict[str, frozenset[str]] = {
     MP4.name: frozenset(),
     WAV.name: frozenset(),
+    MKV.name: frozenset(),
     MOV_SHAPED.name: frozenset({"attachment"}),
     MP3_SHAPED.name: frozenset(),
 }
@@ -105,6 +107,7 @@ FORCED_FAILURE_TYPES: dict[str, frozenset[str]] = {
 MUXER_ENFORCED_LIMIT_TYPES: dict[str, frozenset[str]] = {
     MP4.name: frozenset(),
     WAV.name: frozenset(),
+    MKV.name: frozenset(),
     MOV_SHAPED.name: frozenset(),
     MP3_SHAPED.name: frozenset({"audio"}),
 }
@@ -392,9 +395,98 @@ class TestWavProfile:
         assert WAV.rules["audio"].stream_limit == 1
 
 
+class TestMkvProfile:
+    def test_label_and_suffix(self):
+        assert MKV.label == "MKV"
+        assert MKV.target_suffix == ".mkv"
+
+    def test_name_and_description(self):
+        assert MKV.name == "mkv"
+        assert MKV.description
+
+    def test_no_container_options(self):
+        """Measured: +faststart is MP4/MOV furniture MKV's muxer ignores, so
+        declaring it here would be noise (Prior decisions, spec-video-formats)."""
+        assert MKV.container_options == ()
+
+    def test_cheap_attempt_selects_streams_blindly(self):
+        assert MKV.explicit_streams is False
+
+    def test_cheap_attempt_maps_every_stream_type_including_attachments(self):
+        assert MKV.cheap_attempt.options == (
+            "-map",
+            "0:v?",
+            "-map",
+            "0:a?",
+            "-map",
+            "0:s?",
+            "-map",
+            "0:t?",
+            "-c",
+            "copy",
+        )
+
+    def test_cheap_attempt_is_declared_partial(self):
+        """No "v/a/s/t" map carries a data or timecode stream (measured), so a
+        source with either loses it without ffmpeg ever complaining."""
+        assert MKV.partial_mapping is True
+
+    def test_cheap_attempt_carries_the_standing_note(self):
+        assert MKV.cheap_attempt.notes == ("data and timecode streams are not carried into MKV",)
+
+    def test_last_resort_excludes_container_options(self):
+        assert MKV.last_resort is not None
+        assert MKV.last_resort.label == "re-encode"
+        assert "-movflags" not in MKV.last_resort.options
+
+    def test_has_exactly_the_four_stream_rules(self):
+        assert set(MKV.rules) == {"video", "audio", "subtitle", "attachment"}
+
+    def test_video_and_audio_rules_carry_the_position_placeholder(self):
+        for stream_type in ("video", "audio"):
+            rule = MKV.rules[stream_type]
+            assert "{n}" in " ".join(rule.accept_options)
+            assert rule.fallback_options is not None
+            assert "{n}" in " ".join(rule.fallback_options)
+
+    def test_subtitle_rule_copies_in_kind_and_falls_back_to_srt(self):
+        """Matroska rejects a literal mov_text copy (measured), so mov_text is
+        absent from the copy mask and falls to the srt re-encode instead."""
+        rule = MKV.rules["subtitle"]
+
+        assert "mov_text" not in rule.copy_mask
+        assert rule.accept_options == ("-c:s:{n}", "copy")
+        assert rule.fallback_options == ("-c:s:{n}", "srt")
+        assert rule.fallback_name == "subrip"
+
+    def test_subtitle_mask_holds_bitmap_subtitles_too(self):
+        """Unlike MP4's text-only mask -- Matroska is the only container in
+        this phase that holds bitmap subtitles as a literal copy."""
+        rule = MKV.rules["subtitle"]
+
+        assert {"hdmv_pgs_subtitle", "dvd_subtitle", "dvb_subtitle"} <= rule.copy_mask
+
+    def test_attachment_rule_accepts_every_codec_name(self):
+        """ffprobe reports a font/ttf or font/otf attachment's codec_name as
+        "unknown", so a mask enumerating font codec names would drop exactly
+        the fonts it meant to keep (measured, spec-video-formats.md)."""
+        rule = MKV.rules["attachment"]
+
+        assert "unknown" in rule.copy_mask
+        assert "ttf" in rule.copy_mask
+        assert len(rule.copy_mask) == 0
+
+    def test_attachment_rule_copies_unconditionally_with_no_fallback(self):
+        rule = MKV.rules["attachment"]
+
+        assert rule.accept_options == ("-c:t:{n}", "copy")
+        assert rule.fallback_options is None
+        assert rule.stream_limit is None
+
+
 class TestRegistry:
     def test_keys_are_each_profile_s_own_name(self):
-        assert PROFILES == {"mp4": MP4, "wav": WAV}
+        assert PROFILES == {"mp4": MP4, "wav": WAV, "mkv": MKV}
 
 
 class TestResolveTarget:
@@ -405,9 +497,13 @@ class TestResolveTarget:
     def test_resolves_wav_too(self):
         assert resolve_target("wav") is WAV
 
+    @pytest.mark.parametrize("target", ["mkv", "MKV", ".mkv", ".MKV", "Mkv"])
+    def test_accepts_mkv_name_case_and_dot_variants(self, target):
+        assert resolve_target(target) is MKV
+
     def test_unknown_target_raises_value_error_listing_available_targets(self):
-        with pytest.raises(ValueError, match=r"mkv.*available targets: mp4, wav"):
-            resolve_target("mkv")
+        with pytest.raises(ValueError, match=r"webm.*available targets: mkv, mp4, wav"):
+            resolve_target("webm")
 
 
 class TestSourceSuffixes:

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,4 +1,4 @@
-"""Tests for the leaf module and the two profiles it declares."""
+"""Tests for the leaf module and the profiles it declares."""
 
 import ast
 import dataclasses


### PR DESCRIPTION
## Summary
- Adds the `mkv` `Profile` (`converter/profiles.py`): cheap attempt `-map 0:v? -map 0:a? -map 0:s? -map 0:t? -c copy`, video/audio/subtitle/attachment stream rules, an unconditional-accept attachment rule (`_AcceptAnyCodec`) so font attachments whose `codec_name` reads as `unknown` are kept, and a `libx264`/`aac` last resort.
- Re-measured the subtitle mask against real ffmpeg 9.0 while implementing: Matroska rejects a literal `mov_text` copy (exit 127), so `mov_text` is excluded from the copy mask and falls back to `-c:s:{n} srt` (`fallback_name="subrip"`). Corrected the spec's Prior-decisions table in the same PR, with a decision-log entry recording the measurement.
- Registry, `--list-formats`, `README.md` updated; `tests/test_profiles.py` and `tests/test_argv.py` get MKV's own test classes plus additive updates to the shared invariant fixtures (`SHIPPED`, `FORCED_FAILURE_TYPES`, `MUXER_ENFORCED_LIMIT_TYPES`) and the two tests (`TestRegistry`, `TestResolveTarget`) that necessarily change once `mkv` is a real registered target.

## Cheap-attempt invariant
`mkv`'s cheap attempt maps `video`, `audio`, `subtitle` and `attachment`, and the profile declares exactly those four rules -- it satisfies `set(profile.rules) == set(mapped_types(profile))` directly, with no `FORCED_FAILURE_TYPES`/`MUXER_ENFORCED_LIMIT_TYPES` exemption needed (unlike `mov`'s planned shape). `tests/test_profiles.py` adds `MKV` to `SHIPPED` with an empty entry in both exemption dicts so the existing parametrized invariant tests check it machine-side.

## Real-ffmpeg smoke test (ffmpeg 9.0)
Ran through the actual CLI (`--ffmpeg`/`--ffprobe` absolute paths) against fixtures built with ffmpeg:
- An h264/aac MKV source and an msmpeg4v2/mp2 AVI source both stream-copy straight through the cheap attempt (MKV really does accept almost anything raw) -- `0 failed`, exit 0, standing note "data and timecode streams are not carried into MKV" printed for all three inputs of that run.
- An attachment-bearing MKV (`arial.ttf`, `mimetype=font/ttf`, `codec_name` reported by ffprobe as `unknown`) round-trips through `--to mkv`: the font attachment survives the conversion, confirmed with `ffprobe`, not by eye -- the phase's headline behaviour.
- A mov_text-subtitled MP4 source genuinely fails `mkv`'s cheap attempt (Matroska rejects the mov_text copy), reaches the selective rung, and converts with the note `subtitle stream 2 (mov_text) re-encoded to subrip` -- verified the output subtitle stream is `subrip`.
- A second run over the already-converted tree: `0 converted, 3 skipped, 0 failed`, exit 0.

## Test plan
- [x] `.venv/Scripts/python.exe scripts/verify.py` -- lint, format, 341 tests green
- [x] Real-ffmpeg smoke test as described above
- [x] `git diff main...HEAD --stat` touches only `converter/profiles.py`, `README.md`, `docs/specs/spec-video-formats.md`, and `tests/`

Closes #27