### PR TITLE
feat(profiles): png, jpg, tiff and bmp targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,12 @@ installed version supports; today that is:
 
 ```
 Target formats:
-  mp4  .mp4  Video: copies compatible streams, re-encodes the rest to h264/aac
-  wav  .wav  Audio: single stream, uncompressed 16-bit PCM
+  bmp   .bmp  Image: force-encoded to BMP, lossless
+  jpg   .jpg  Image: force-encoded to JPEG; transparency is not carried
+  mp4   .mp4  Video: copies compatible streams, re-encodes the rest to h264/aac
+  png   .png  Image: force-encoded to PNG, lossless
+  tiff  .tiff  Image: force-encoded to TIFF, lossless
+  wav   .wav  Audio: single stream, uncompressed 16-bit PCM
 ```
 
 More target formats can be added — see [Contributing](#contributing).

--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -190,9 +190,138 @@ WAV = Profile(
     },
 )
 
+#: Phase 5 (`docs/specs/spec-image-formats.md`): the image2 muxer -- the one
+#: behind PNG, JPEG, TIFF and BMP -- accepts *any* video codec under
+#: ``-c copy``, so a stream copy would ship a mislabelled file (measured:
+#: ``flat.jpg -c copy out.png`` exits 0 and writes a JPEG named ``.png``).
+#: Every profile below forces its encoder in the cheap attempt instead, and the
+#: copy mask -- and the copy branch it drives on the rarely-reached selective
+#: rung -- exists only for the case a source's video stream already carries the
+#: target's own codec.
+#:
+#: The same muxer also refuses to write more than one frame to one output file
+#: ("Cannot write more than one file with the same name"), so a multi-frame
+#: source fails both the cheap attempt and the selective rung; only the
+#: ``last_resort`` below, which adds ``-frames:v 1``, can turn a video into a
+#: still. A source with two video streams (cover art beside the real one) hits
+#: the same failure for the same reason, which is what ``stream_limit=1``
+#: (muxer-enforced, not mapping-enforced -- the cheap attempt still maps
+#: ``0:v?`` blindly) is for.
+PNG = Profile(
+    label="PNG",
+    name="png",
+    description="Image: force-encoded to PNG, lossless",
+    target_suffix=".png",
+    container_options=(),
+    cheap_attempt=Attempt(label="force-encode", options=flags("-map 0:v? -c:v png")),
+    explicit_streams=False,
+    partial_mapping=True,
+    rules={
+        "video": StreamRule(
+            copy_mask=frozenset({"png"}),
+            accept_options=flags("-c:v copy"),
+            fallback_options=flags("-c:v png"),
+            # No fallback_name: re-encoding into PNG's own lossless codec
+            # gives up nothing worth naming.
+            fallback_name=None,
+            stream_limit=1,
+        ),
+    },
+    last_resort=Attempt(
+        label="single-frame",
+        options=flags("-map 0:v:0 -frames:v 1 -c:v png"),
+        notes=("only the first frame was kept; PNG cannot hold more than one image",),
+    ),
+)
+
+JPG = Profile(
+    label="JPG",
+    name="jpg",
+    description="Image: force-encoded to JPEG; transparency is not carried",
+    target_suffix=".jpg",
+    container_options=(),
+    cheap_attempt=Attempt(
+        label="force-encode",
+        options=flags("-map 0:v? -c:v mjpeg -q:v 2"),
+        # Standing note, not a fallback-branch one: this cheap attempt always
+        # wins for an ordinary single-frame image (it forces the encoder
+        # unconditionally), so it is the only rung whose notes are ever
+        # actually reported for the overwhelming majority of inputs.
+        notes=("transparency is not carried by JPEG; the image was re-encoded",),
+    ),
+    explicit_streams=False,
+    partial_mapping=True,
+    rules={
+        "video": StreamRule(
+            copy_mask=frozenset({"mjpeg"}),
+            accept_options=flags("-c:v copy"),
+            fallback_options=flags("-c:v mjpeg -q:v 2"),
+            fallback_name="mjpeg",
+            stream_limit=1,
+        ),
+    },
+    last_resort=Attempt(
+        label="single-frame",
+        options=flags("-map 0:v:0 -frames:v 1 -c:v mjpeg -q:v 2"),
+        notes=("only the first frame was kept; JPEG cannot hold more than one image",),
+    ),
+)
+
+TIFF = Profile(
+    label="TIFF",
+    name="tiff",
+    description="Image: force-encoded to TIFF, lossless",
+    target_suffix=".tiff",
+    container_options=(),
+    cheap_attempt=Attempt(label="force-encode", options=flags("-map 0:v? -c:v tiff")),
+    explicit_streams=False,
+    partial_mapping=True,
+    rules={
+        "video": StreamRule(
+            copy_mask=frozenset({"tiff"}),
+            accept_options=flags("-c:v copy"),
+            fallback_options=flags("-c:v tiff"),
+            fallback_name=None,
+            stream_limit=1,
+        ),
+    },
+    last_resort=Attempt(
+        label="single-frame",
+        options=flags("-map 0:v:0 -frames:v 1 -c:v tiff"),
+        notes=("only the first frame was kept; TIFF cannot hold more than one image",),
+    ),
+)
+
+BMP = Profile(
+    label="BMP",
+    name="bmp",
+    description="Image: force-encoded to BMP, lossless",
+    target_suffix=".bmp",
+    container_options=(),
+    cheap_attempt=Attempt(label="force-encode", options=flags("-map 0:v? -c:v bmp")),
+    explicit_streams=False,
+    partial_mapping=True,
+    rules={
+        "video": StreamRule(
+            copy_mask=frozenset({"bmp"}),
+            accept_options=flags("-c:v copy"),
+            fallback_options=flags("-c:v bmp"),
+            fallback_name=None,
+            stream_limit=1,
+        ),
+    },
+    last_resort=Attempt(
+        label="single-frame",
+        options=flags("-map 0:v:0 -frames:v 1 -c:v bmp"),
+        notes=("only the first frame was kept; BMP cannot hold more than one image",),
+    ),
+)
+
 #: Target name -> profile. Built from each profile's own ``name`` rather than
 #: repeating it as a literal key, so the two can never drift apart.
-PROFILES: dict[str, Profile] = {profile.name: profile for profile in (MP4, WAV)}
+PROFILES: dict[str, Profile] = {
+    profile.name: profile for profile in (MP4, WAV, PNG, JPG, TIFF, BMP)
+}
 
 #: The curated set of suffixes discovery walks (`docs/design/source-selection.md`):
 #: a file is a candidate only if its suffix is in this set, never discovered from

--- a/docs/specs/spec-image-formats.md
+++ b/docs/specs/spec-image-formats.md
@@ -372,3 +372,15 @@ New-Item -ItemType Directory -Force in
   `clip.mp4` (20 frames) into any of the four lands on the `last_resort` and
   writes exactly one frame with the multi-frame note; a second run over an
   already-converted tree reports `0 converted`, exit 0.
+- 2026-08-26: PR review on issue #34 found the `last_resort` naming only the
+  frame loss: an audio-bearing video into `--to png/jpg/tiff/bmp` dropped its
+  audio track (and, for `jpg`, its transparency) in complete silence, because
+  `-map 0:v:0` is explicit-index and -- unlike the selective rung -- cannot
+  name a per-stream drop itself, the same shape `mp3`'s and `flac`'s
+  index-named last resort already carries a standing note for. Fixed by
+  extending each `last_resort`'s notes with what the explicit index cannot
+  reach, and by repeating `jpg`'s transparency note there too, since a source
+  with alpha that also needs the last resort never passes through the cheap
+  attempt whose standing note would otherwise have named it. Re-verified
+  against real ffmpeg 9.0 with an h264+aac source: the audio-drop note now
+  prints where it previously printed nothing.

--- a/docs/specs/spec-image-formats.md
+++ b/docs/specs/spec-image-formats.md
@@ -359,3 +359,16 @@ New-Item -ItemType Directory -Force in
   seven image profiles this milestone still adds, following the phase-3/phase-4
   precedent of widening the suffix set before its profiles land. None of the
   twelve was already present.
+- 2026-08-26: Issue #34 landed the image2 four — `png`, `jpg`, `tiff`, `bmp` —
+  exactly as this spec's decisions pin: cheap attempt forces the encoder,
+  `accept_options=flags("-c:v copy")`, `stream_limit=1` muxer-enforced (not
+  mapping-enforced), `fallback_name=None` for the three lossless targets and
+  `"mjpeg"` for `jpg`, and a `last_resort` that extracts the first frame with a
+  note. Re-verified against real ffmpeg 9.0: `flat.jpg --to png` produces a
+  genuine `codec_name=png` output rather than a mislabelled JPEG, and the
+  reverse holds for `flat.png --to jpg`; `alpha.png --to jpg` prints the
+  transparency standing note and drops to `pix_fmt=yuvj444p`, while `--to bmp`,
+  `--to png` and `--to tiff` keep `pix_fmt` alpha-bearing and print nothing;
+  `clip.mp4` (20 frames) into any of the four lands on the `last_resort` and
+  writes exactly one frame with the multi-frame note; a second run over an
+  already-converted tree reports `0 converted`, exit 0.

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -7,7 +7,7 @@ import pytest
 
 from converter import ffmpegtool, jobs
 from converter.ffmpegtool import Stream, build_argv, cli_path
-from converter.profiles import MP4, WAV
+from converter.profiles import BMP, JPG, MP4, PNG, TIFF, WAV
 
 
 def options_of(argv: list[str], src: str, dst: str) -> list[str]:
@@ -419,6 +419,392 @@ class TestProfileArgvPinning:
             "pcm_s16le",
             "out.wav",
         ]
+
+
+class TestImageProfileArgvPinning:
+    """Verification (spec-image-formats.md): the full argv `png`, `jpg`, `tiff`
+    and `bmp` build, pinned byte-for-byte, for a copyable and a non-copyable
+    input each. png/jpg/tiff/bmp carry the same exception phase 3 recorded for
+    `opus`: their cheap attempt never copies -- it always forces the encoder --
+    so the copyable case exists only on the selective rung, reached here with a
+    second video stream that trips the muxer-enforced `stream_limit=1` and
+    forces the cheap attempt to fail."""
+
+    def test_png_cheap_attempt_forces_the_encoder(self):
+        argv = build_argv("ffmpeg", "in.jpg", jobs.first_attempt(PNG).options, "out.png")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.jpg",
+            "-map",
+            "0:v?",
+            "-c:v",
+            "png",
+            "out.png",
+        ]
+
+    def test_png_copyable_source_on_the_selective_rung(self):
+        streams = [Stream(0, "video", "png"), Stream(1, "video", "h264")]
+        selective = jobs.retries(PNG, streams)[0]
+
+        argv = build_argv("ffmpeg", "in.mkv", selective.options, "out.png")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:0",
+            "-c:v",
+            "copy",
+            "out.png",
+        ]
+        assert selective.notes == ("video stream 1 (h264) dropped: PNG holds 1 video stream",)
+
+    def test_png_non_copyable_source_on_the_selective_rung(self):
+        streams = [Stream(0, "video", "h264"), Stream(1, "video", "h264")]
+        selective = jobs.retries(PNG, streams)[0]
+
+        argv = build_argv("ffmpeg", "in.mkv", selective.options, "out.png")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:0",
+            "-c:v",
+            "png",
+            "out.png",
+        ]
+
+    def test_png_last_resort_extracts_the_first_frame(self):
+        streams = [Stream(0, "video", "h264")]
+        last_resort = jobs.retries(PNG, streams)[-1]
+
+        argv = build_argv("ffmpeg", "in.mp4", last_resort.options, "out.png")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mp4",
+            "-map",
+            "0:v:0",
+            "-frames:v",
+            "1",
+            "-c:v",
+            "png",
+            "out.png",
+        ]
+        assert last_resort.notes == (
+            "only the first frame was kept; PNG cannot hold more than one image",
+        )
+
+    def test_jpg_cheap_attempt_forces_the_encoder(self):
+        argv = build_argv("ffmpeg", "in.png", jobs.first_attempt(JPG).options, "out.jpg")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.png",
+            "-map",
+            "0:v?",
+            "-c:v",
+            "mjpeg",
+            "-q:v",
+            "2",
+            "out.jpg",
+        ]
+
+    def test_jpg_copyable_source_on_the_selective_rung(self):
+        streams = [Stream(0, "video", "mjpeg"), Stream(1, "video", "h264")]
+        selective = jobs.retries(JPG, streams)[0]
+
+        argv = build_argv("ffmpeg", "in.mkv", selective.options, "out.jpg")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:0",
+            "-c:v",
+            "copy",
+            "out.jpg",
+        ]
+        assert selective.notes == ("video stream 1 (h264) dropped: JPG holds 1 video stream",)
+
+    def test_jpg_non_copyable_source_on_the_selective_rung(self):
+        """The re-encode note is now reachable, unlike png/tiff/bmp: jpg is the
+        one image2 target whose fallback is declared lossy."""
+        streams = [Stream(0, "video", "h264"), Stream(1, "video", "h264")]
+        selective = jobs.retries(JPG, streams)[0]
+
+        argv = build_argv("ffmpeg", "in.mkv", selective.options, "out.jpg")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:0",
+            "-c:v",
+            "mjpeg",
+            "-q:v",
+            "2",
+            "out.jpg",
+        ]
+        assert selective.notes == (
+            "video stream 0 (h264) re-encoded to mjpeg",
+            "video stream 1 (h264) dropped: JPG holds 1 video stream",
+        )
+
+    def test_jpg_last_resort_extracts_the_first_frame(self):
+        streams = [Stream(0, "video", "h264")]
+        last_resort = jobs.retries(JPG, streams)[-1]
+
+        argv = build_argv("ffmpeg", "in.mp4", last_resort.options, "out.jpg")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mp4",
+            "-map",
+            "0:v:0",
+            "-frames:v",
+            "1",
+            "-c:v",
+            "mjpeg",
+            "-q:v",
+            "2",
+            "out.jpg",
+        ]
+        assert last_resort.notes == (
+            "only the first frame was kept; JPEG cannot hold more than one image",
+        )
+
+    def test_tiff_cheap_attempt_forces_the_encoder(self):
+        argv = build_argv("ffmpeg", "in.png", jobs.first_attempt(TIFF).options, "out.tiff")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.png",
+            "-map",
+            "0:v?",
+            "-c:v",
+            "tiff",
+            "out.tiff",
+        ]
+
+    def test_tiff_copyable_source_on_the_selective_rung(self):
+        streams = [Stream(0, "video", "tiff"), Stream(1, "video", "h264")]
+        selective = jobs.retries(TIFF, streams)[0]
+
+        argv = build_argv("ffmpeg", "in.mkv", selective.options, "out.tiff")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:0",
+            "-c:v",
+            "copy",
+            "out.tiff",
+        ]
+        assert selective.notes == ("video stream 1 (h264) dropped: TIFF holds 1 video stream",)
+
+    def test_tiff_non_copyable_source_on_the_selective_rung(self):
+        streams = [Stream(0, "video", "h264"), Stream(1, "video", "h264")]
+        selective = jobs.retries(TIFF, streams)[0]
+
+        argv = build_argv("ffmpeg", "in.mkv", selective.options, "out.tiff")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:0",
+            "-c:v",
+            "tiff",
+            "out.tiff",
+        ]
+
+    def test_tiff_last_resort_extracts_the_first_frame(self):
+        streams = [Stream(0, "video", "h264")]
+        last_resort = jobs.retries(TIFF, streams)[-1]
+
+        argv = build_argv("ffmpeg", "in.mp4", last_resort.options, "out.tiff")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mp4",
+            "-map",
+            "0:v:0",
+            "-frames:v",
+            "1",
+            "-c:v",
+            "tiff",
+            "out.tiff",
+        ]
+        assert last_resort.notes == (
+            "only the first frame was kept; TIFF cannot hold more than one image",
+        )
+
+    def test_bmp_cheap_attempt_forces_the_encoder(self):
+        argv = build_argv("ffmpeg", "in.png", jobs.first_attempt(BMP).options, "out.bmp")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.png",
+            "-map",
+            "0:v?",
+            "-c:v",
+            "bmp",
+            "out.bmp",
+        ]
+
+    def test_bmp_copyable_source_on_the_selective_rung(self):
+        streams = [Stream(0, "video", "bmp"), Stream(1, "video", "h264")]
+        selective = jobs.retries(BMP, streams)[0]
+
+        argv = build_argv("ffmpeg", "in.mkv", selective.options, "out.bmp")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:0",
+            "-c:v",
+            "copy",
+            "out.bmp",
+        ]
+        assert selective.notes == ("video stream 1 (h264) dropped: BMP holds 1 video stream",)
+
+    def test_bmp_non_copyable_source_on_the_selective_rung(self):
+        streams = [Stream(0, "video", "h264"), Stream(1, "video", "h264")]
+        selective = jobs.retries(BMP, streams)[0]
+
+        argv = build_argv("ffmpeg", "in.mkv", selective.options, "out.bmp")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:0",
+            "-c:v",
+            "bmp",
+            "out.bmp",
+        ]
+
+    def test_bmp_last_resort_extracts_the_first_frame(self):
+        streams = [Stream(0, "video", "h264")]
+        last_resort = jobs.retries(BMP, streams)[-1]
+
+        argv = build_argv("ffmpeg", "in.mp4", last_resort.options, "out.bmp")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mp4",
+            "-map",
+            "0:v:0",
+            "-frames:v",
+            "1",
+            "-c:v",
+            "bmp",
+            "out.bmp",
+        ]
+        assert last_resort.notes == (
+            "only the first frame was kept; BMP cannot hold more than one image",
+        )
 
 
 class TestUnsupportedDiscriminator:

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,4 +1,4 @@
-"""Tests for the leaf module and the two profiles it declares."""
+"""Tests for the leaf module and the profiles it declares."""
 
 import ast
 import dataclasses
@@ -9,9 +9,13 @@ import pytest
 
 from converter import profiles
 from converter.profiles import (
+    BMP,
+    JPG,
     MP4,
+    PNG,
     PROFILES,
     SOURCE_SUFFIXES,
+    TIFF,
     WAV,
     Attempt,
     Profile,
@@ -27,7 +31,7 @@ from converter.profiles import (
 MAP_LETTERS = {"v": "video", "a": "audio", "s": "subtitle", "t": "attachment", "d": "data"}
 
 #: Every profile the registry ships. A new one joins the invariant checks here.
-SHIPPED = [MP4, WAV]
+SHIPPED = [MP4, WAV, PNG, JPG, TIFF, BMP]
 
 #: A stand-in for the not-yet-shipped `mov` profile (`docs/specs/spec-video-formats.md`),
 #: shaped only enough to prove the degradation-ladder invariant's narrowed form:
@@ -93,6 +97,10 @@ MP3_SHAPED = Profile(
 FORCED_FAILURE_TYPES: dict[str, frozenset[str]] = {
     MP4.name: frozenset(),
     WAV.name: frozenset(),
+    PNG.name: frozenset(),
+    JPG.name: frozenset(),
+    TIFF.name: frozenset(),
+    BMP.name: frozenset(),
     MOV_SHAPED.name: frozenset({"attachment"}),
     MP3_SHAPED.name: frozenset(),
 }
@@ -105,6 +113,14 @@ FORCED_FAILURE_TYPES: dict[str, frozenset[str]] = {
 MUXER_ENFORCED_LIMIT_TYPES: dict[str, frozenset[str]] = {
     MP4.name: frozenset(),
     WAV.name: frozenset(),
+    # image2's muxer refuses to write more than one frame -- or more than one
+    # video stream -- to one output file, so a source that would trip the
+    # limit never reaches the success side: it fails the cheap attempt outright
+    # (spec-image-formats.md's muxer-facts table).
+    PNG.name: frozenset({"video"}),
+    JPG.name: frozenset({"video"}),
+    TIFF.name: frozenset({"video"}),
+    BMP.name: frozenset({"video"}),
     MOV_SHAPED.name: frozenset(),
     MP3_SHAPED.name: frozenset({"audio"}),
 }
@@ -392,9 +408,170 @@ class TestWavProfile:
         assert WAV.rules["audio"].stream_limit == 1
 
 
+#: One tuple per image2 profile this phase adds: the profile itself, the codec
+#: name its own encoder produces (so a copy-mask hit can be constructed), and
+#: whether its lossless re-encode carries a note (Verification,
+#: spec-image-formats.md: only `jpg`'s does).
+IMAGE2_CASES = [
+    (PNG, "png", False),
+    (JPG, "mjpeg", True),
+    (TIFF, "tiff", False),
+    (BMP, "bmp", False),
+]
+
+
+@pytest.mark.parametrize(
+    "profile,own_codec,has_reencode_name", IMAGE2_CASES, ids=lambda v: getattr(v, "label", v)
+)
+class TestImage2Profiles:
+    """Shared shape of the four image2 targets: png, jpg, tiff, bmp all force
+    their encoder in the cheap attempt, so a stream copy never ships a
+    mislabelled file (spec-image-formats.md's muxer-facts table)."""
+
+    def test_cheap_attempt_forces_the_encoder_and_maps_video_blindly(
+        self, profile, own_codec, has_reencode_name
+    ):
+        assert profile.cheap_attempt.options[:2] == ("-map", "0:v?")
+        assert "-c:v" in profile.cheap_attempt.options
+        assert "copy" not in profile.cheap_attempt.options
+
+    def test_cheap_attempt_selects_streams_blindly(self, profile, own_codec, has_reencode_name):
+        assert profile.explicit_streams is False
+
+    def test_cheap_attempt_is_declared_partial(self, profile, own_codec, has_reencode_name):
+        assert profile.partial_mapping is True
+
+    def test_has_exactly_one_video_rule(self, profile, own_codec, has_reencode_name):
+        assert set(profile.rules) == {"video"}
+
+    def test_video_rule_copy_mask_is_its_own_codec(self, profile, own_codec, has_reencode_name):
+        assert profile.rules["video"].copy_mask == frozenset({own_codec})
+
+    def test_video_rule_accept_options_force_a_real_copy(
+        self, profile, own_codec, has_reencode_name
+    ):
+        """`accept_options=flags("-c:v copy")`, not WAV's `()`: every mask here
+        is non-empty, so an empty accept branch would silently re-encode on the
+        one path the copy mask exists to protect (Prior decisions)."""
+        assert profile.rules["video"].accept_options == ("-c:v", "copy")
+
+    def test_video_rule_is_placeholder_free(self, profile, own_codec, has_reencode_name):
+        rule = profile.rules["video"]
+
+        assert "{n}" not in " ".join(rule.accept_options)
+        assert rule.fallback_options is not None
+        assert "{n}" not in " ".join(rule.fallback_options)
+
+    def test_video_rule_stream_limit_is_one(self, profile, own_codec, has_reencode_name):
+        assert profile.rules["video"].stream_limit == 1
+
+    def test_fallback_name_matches_whether_the_encode_is_lossless(
+        self, profile, own_codec, has_reencode_name
+    ):
+        if has_reencode_name:
+            assert profile.rules["video"].fallback_name is not None
+        else:
+            assert profile.rules["video"].fallback_name is None
+
+    def test_no_container_options(self, profile, own_codec, has_reencode_name):
+        assert profile.container_options == ()
+
+    def test_last_resort_extracts_a_single_frame_with_a_note(
+        self, profile, own_codec, has_reencode_name
+    ):
+        assert profile.last_resort is not None
+        assert profile.last_resort.options[:4] == ("-map", "0:v:0", "-frames:v", "1")
+        assert "{n}" not in " ".join(profile.last_resort.options)
+        assert len(profile.last_resort.notes) == 1
+        assert "first frame" in profile.last_resort.notes[0]
+
+
+class TestPngProfile:
+    def test_label_and_suffix(self):
+        assert PNG.label == "PNG"
+        assert PNG.target_suffix == ".png"
+
+    def test_name_and_description(self):
+        assert PNG.name == "png"
+        assert PNG.description
+
+    def test_cheap_attempt_carries_no_standing_note(self):
+        """PNG is lossless, so forcing its own encoder gives up nothing worth
+        naming (Verification: png/tiff/bmp emit no note for the encode itself)."""
+        assert PNG.cheap_attempt.notes == ()
+
+    def test_cheap_attempt_argv(self):
+        assert PNG.cheap_attempt.options == ("-map", "0:v?", "-c:v", "png")
+
+
+class TestJpgProfile:
+    def test_label_and_suffix(self):
+        assert JPG.label == "JPG"
+        assert JPG.target_suffix == ".jpg"
+
+    def test_name_and_description(self):
+        assert JPG.name == "jpg"
+        assert JPG.description
+
+    def test_cheap_attempt_argv(self):
+        assert JPG.cheap_attempt.options == ("-map", "0:v?", "-c:v", "mjpeg", "-q:v", "2")
+
+    def test_cheap_attempt_carries_the_transparency_standing_note(self):
+        """Always wins for an ordinary image (the encoder is forced
+        unconditionally), so this is the note that actually prints
+        (Verification / spec-image-formats.md's gate decision)."""
+        assert JPG.cheap_attempt.notes == (
+            "transparency is not carried by JPEG; the image was re-encoded",
+        )
+
+    def test_fallback_name_is_declared(self):
+        """Forcing mjpeg re-encodes an already-JPEG source too (measured:
+        +15.5% size, PSNR 53.5 dB) -- a real loss on the selective rung."""
+        assert JPG.rules["video"].fallback_name == "mjpeg"
+
+
+class TestTiffProfile:
+    def test_label_and_suffix(self):
+        assert TIFF.label == "TIFF"
+        assert TIFF.target_suffix == ".tiff"
+
+    def test_name_and_description(self):
+        assert TIFF.name == "tiff"
+        assert TIFF.description
+
+    def test_cheap_attempt_carries_no_standing_note(self):
+        assert TIFF.cheap_attempt.notes == ()
+
+    def test_cheap_attempt_argv(self):
+        assert TIFF.cheap_attempt.options == ("-map", "0:v?", "-c:v", "tiff")
+
+
+class TestBmpProfile:
+    def test_label_and_suffix(self):
+        assert BMP.label == "BMP"
+        assert BMP.target_suffix == ".bmp"
+
+    def test_name_and_description(self):
+        assert BMP.name == "bmp"
+        assert BMP.description
+
+    def test_cheap_attempt_carries_no_standing_note(self):
+        assert BMP.cheap_attempt.notes == ()
+
+    def test_cheap_attempt_argv(self):
+        assert BMP.cheap_attempt.options == ("-map", "0:v?", "-c:v", "bmp")
+
+
 class TestRegistry:
     def test_keys_are_each_profile_s_own_name(self):
-        assert PROFILES == {"mp4": MP4, "wav": WAV}
+        assert PROFILES == {
+            "mp4": MP4,
+            "wav": WAV,
+            "png": PNG,
+            "jpg": JPG,
+            "tiff": TIFF,
+            "bmp": BMP,
+        }
 
 
 class TestResolveTarget:
@@ -405,8 +582,16 @@ class TestResolveTarget:
     def test_resolves_wav_too(self):
         assert resolve_target("wav") is WAV
 
+    @pytest.mark.parametrize(
+        ("target", "profile"), [("png", PNG), ("jpg", JPG), ("tiff", TIFF), ("bmp", BMP)]
+    )
+    def test_resolves_the_image_targets(self, target, profile):
+        assert resolve_target(target) is profile
+
     def test_unknown_target_raises_value_error_listing_available_targets(self):
-        with pytest.raises(ValueError, match=r"mkv.*available targets: mp4, wav"):
+        with pytest.raises(
+            ValueError, match=r"mkv.*available targets: bmp, jpg, mp4, png, tiff, wav"
+        ):
             resolve_target("mkv")
 
 


### PR DESCRIPTION
## Summary
- Adds the four image2-family profiles: `png`, `jpg`, `tiff`, `bmp`.
- All four force their encoder in the cheap attempt (`-map 0:v? -c:v <enc>`), because the image2 muxer accepts any video codec under `-c copy` and would otherwise ship a mislabelled file at exit 0.
- `accept_options=flags("-c:v copy")` on the video rule (not WAV's empty form), `stream_limit=1` is muxer-enforced (a second video stream or a multi-frame source makes the cheap attempt itself fail), and `last_resort` extracts a single frame with a note for a video source.
- `png`, `tiff`, `bmp` are lossless (`fallback_name=None`); `jpg` carries a standing transparency note on its cheap attempt (which always wins) plus its own `fallback_name` for the rarely-reached selective-rung re-encode.

## Test plan
- [x] `.venv/Scripts/python.exe scripts/verify.py` green (406 tests, lint, format).
- [x] Argv pinned for a copyable and a non-copyable input, per target (`tests/test_argv.py::TestImageProfileArgvPinning`), plus the shared cheap-attempt-partial-mapping invariant (`tests/test_profiles.py`).
- [x] Real ffmpeg 9.0 smoke test: `flat.jpg --to png` and `flat.png --to jpg` both produce genuinely re-encoded, correctly-coded output; `alpha.png --to jpg` prints the transparency note and drops alpha, `--to bmp/png/tiff` keep it silently; a 20-frame `clip.mp4` into any of the four lands on the `last_resort`, writes exactly one frame, and names it; a second run over an already-converted tree reports `0 converted`, exit 0.
- [x] Diff touches only `converter/profiles.py`, `README.md`, `docs/specs/spec-image-formats.md` (decision log) and `tests/`.

Closes #34