### PR TITLE
feat(profiles): m4a, ogg and opus targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,17 @@ installed version supports; today that is:
 ```
 Target formats:
   flac  .flac  Audio: single stream, lossless FLAC
+  m4a   .m4a  Audio: every stream the source has; most players use only the first
   mp3   .mp3  Audio: single stream, MP3 (libmp3lame if re-encoded)
   mp4   .mp4  Video: copies compatible streams, re-encodes the rest to h264/aac
+  ogg   .ogg  Audio: every stream the source has; most players use only the first
+  opus  .opus  Audio: every stream the source has; most players use only the first
   wav   .wav  Audio: single stream, uncompressed 16-bit PCM
 ```
+
+`m4a`, `ogg` and `opus` carry every audio stream the source has — nothing is
+dropped, but most players only offer the first, so a source with several audio
+tracks is not obviously "converted in full" just by looking at what plays.
 
 More target formats can be added — see [Contributing](#contributing).
 

--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -279,9 +279,134 @@ FLAC = Profile(
     ),
 )
 
+M4A = Profile(
+    label="M4A",
+    name="m4a",
+    description="Audio: every stream the source has; most players use only the first",
+    target_suffix=".m4a",
+    container_options=(),
+    # ".m4a" auto-selects the "ipod" muxer, whose accept set is narrower than a
+    # standard MP4's -- it rejects mp3, opus and flac stream copies -- so the
+    # mask below is curated by hand rather than reused from MP4_AUDIO_CODECS
+    # (docs/specs/spec-audio-formats.md).
+    cheap_attempt=Attempt(
+        label="remux",
+        options=flags("-map 0:a? -c:a copy"),
+        notes=("non-audio streams, including cover art, are not carried into M4A",),
+    ),
+    explicit_streams=False,
+    partial_mapping=True,
+    rules={
+        "audio": StreamRule(
+            copy_mask=frozenset({"aac", "alac"}),
+            # No stream_limit: the ipod muxer holds several audio streams, so
+            # every one the source has is carried rather than one kept and the
+            # rest silently dropped -- unlike mp3/flac, whose muxers enforce
+            # exactly one. Carried positionally (docs/specs/spec-audio-
+            # formats.md's opus accept_options row): each matched stream
+            # contributes its own bare codec option in map order, so no "{n}"
+            # placeholder is needed even without a limit.
+            accept_options=flags("-c:a copy"),
+            fallback_options=flags("-c:a aac -b:a 192k"),
+            fallback_name="aac",
+        ),
+    },
+    last_resort=Attempt(
+        label="re-encode",
+        options=flags("-map 0:a:0 -c:a aac -b:a 192k"),
+        notes=(
+            "non-audio streams, and any audio stream beyond the first, are not carried into M4A",
+        ),
+    ),
+)
+
+OGG = Profile(
+    label="OGG",
+    name="ogg",
+    description="Audio: every stream the source has; most players use only the first",
+    target_suffix=".ogg",
+    container_options=(),
+    # "-c copy" rather than "-c:a copy": the ogg muxer's own video codec is
+    # theora, so mapping video here would pass a theora source straight
+    # through as a whole video file renamed ".ogg" -- the same defect that
+    # rules m4a out. The cheap attempt maps audio only, so the two spellings
+    # behave identically; "-c copy" is what the spec pins.
+    cheap_attempt=Attempt(
+        label="remux",
+        options=flags("-map 0:a? -c copy"),
+        notes=("non-audio streams, including cover art, are not carried into OGG",),
+    ),
+    explicit_streams=False,
+    partial_mapping=True,
+    rules={
+        "audio": StreamRule(
+            # The ogg muxer accepts vorbis, opus and flac as-is; it rejects
+            # mp3 and aac (docs/specs/spec-audio-formats.md).
+            copy_mask=frozenset({"vorbis", "opus", "flac"}),
+            # No stream_limit: the ogg muxer holds several audio streams.
+            accept_options=flags("-c:a copy"),
+            fallback_options=flags("-c:a libvorbis -q:a 5"),
+            fallback_name="vorbis",
+        ),
+    },
+    last_resort=Attempt(
+        label="re-encode",
+        options=flags("-map 0:a:0 -c:a libvorbis -q:a 5"),
+        notes=(
+            "non-audio streams, and any audio stream beyond the first, are not carried into OGG",
+        ),
+    ),
+)
+
+OPUS = Profile(
+    label="OPUS",
+    name="opus",
+    description="Audio: every stream the source has; most players use only the first",
+    target_suffix=".opus",
+    container_options=(),
+    # "-c copy": on the happy path the muxer, not the copy mask, decides --
+    # the opus muxer also accepts a Vorbis stream, so a blind copy can ship a
+    # file whose extension lies about its contents. That risk is accepted
+    # (Prior decisions, spec-audio-formats.md: "opus copies") because forcing
+    # every already-Opus file through libopus would be a real generation loss
+    # on the common case to prevent a mislabel reachable only from an Ogg
+    # source.
+    cheap_attempt=Attempt(
+        label="remux",
+        options=flags("-map 0:a? -c copy"),
+        notes=("non-audio streams, including cover art, are not carried into OPUS",),
+    ),
+    explicit_streams=False,
+    partial_mapping=True,
+    rules={
+        "audio": StreamRule(
+            copy_mask=frozenset({"opus"}),
+            # "opus does not copy" describes the cheap attempt alone; the
+            # selective rung does, on a mask hit -- an empty accept_options,
+            # WAV's precedent, would emit a map with no codec option and
+            # produce an undeclared re-encode instead (Prior decisions,
+            # spec-audio-formats.md).
+            accept_options=flags("-c:a copy"),
+            # No stream_limit: the opus muxer holds several audio streams, by
+            # copy and by encode.
+            fallback_options=flags("-c:a libopus -b:a 128k"),
+            fallback_name="opus",
+        ),
+    },
+    last_resort=Attempt(
+        label="re-encode",
+        options=flags("-map 0:a:0 -c:a libopus -b:a 128k"),
+        notes=(
+            "non-audio streams, and any audio stream beyond the first, are not carried into OPUS",
+        ),
+    ),
+)
+
 #: Target name -> profile. Built from each profile's own ``name`` rather than
 #: repeating it as a literal key, so the two can never drift apart.
-PROFILES: dict[str, Profile] = {profile.name: profile for profile in (MP4, WAV, MP3, FLAC)}
+PROFILES: dict[str, Profile] = {
+    profile.name: profile for profile in (MP4, WAV, MP3, FLAC, M4A, OGG, OPUS)
+}
 
 #: The curated set of suffixes discovery walks (`docs/design/source-selection.md`):
 #: a file is a candidate only if its suffix is in this set, never discovered from

--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -302,12 +302,16 @@ M4A = Profile(
             # No stream_limit: the ipod muxer holds several audio streams, so
             # every one the source has is carried rather than one kept and the
             # rest silently dropped -- unlike mp3/flac, whose muxers enforce
-            # exactly one. Carried positionally (docs/specs/spec-audio-
-            # formats.md's opus accept_options row): each matched stream
-            # contributes its own bare codec option in map order, so no "{n}"
-            # placeholder is needed even without a limit.
-            accept_options=flags("-c:a copy"),
-            fallback_options=flags("-c:a aac -b:a 192k"),
+            # exactly one. The position placeholder is required here, unlike
+            # mp3/flac's bare form: ffmpeg's unindexed "-c:a" options are not
+            # positional -- when several are given, the *last* one wins for
+            # every audio output stream, not one per stream in map order
+            # (measured against ffmpeg 9.0: a two-stream source with one
+            # mask hit and one miss had its accepted stream silently
+            # re-encoded anyway). MP4's video/audio rules already carry this
+            # placeholder for the same reason.
+            accept_options=flags("-c:a:{n} copy"),
+            fallback_options=flags("-c:a:{n} aac -b:a:{n} 192k"),
             fallback_name="aac",
         ),
     },
@@ -343,9 +347,11 @@ OGG = Profile(
             # The ogg muxer accepts vorbis, opus and flac as-is; it rejects
             # mp3 and aac (docs/specs/spec-audio-formats.md).
             copy_mask=frozenset({"vorbis", "opus", "flac"}),
-            # No stream_limit: the ogg muxer holds several audio streams.
-            accept_options=flags("-c:a copy"),
-            fallback_options=flags("-c:a libvorbis -q:a 5"),
+            # No stream_limit: the ogg muxer holds several audio streams. The
+            # position placeholder is required for the same reason m4a's
+            # audio rule carries one -- see its comment.
+            accept_options=flags("-c:a:{n} copy"),
+            fallback_options=flags("-c:a:{n} libvorbis -q:a:{n} 5"),
             fallback_name="vorbis",
         ),
     },
@@ -385,11 +391,16 @@ OPUS = Profile(
             # selective rung does, on a mask hit -- an empty accept_options,
             # WAV's precedent, would emit a map with no codec option and
             # produce an undeclared re-encode instead (Prior decisions,
-            # spec-audio-formats.md).
-            accept_options=flags("-c:a copy"),
+            # spec-audio-formats.md). The spec's Prior decisions row pins this
+            # as the bare flags("-c:a copy"); review measured that bare form
+            # broken against a real multi-stream, mixed accept/fallback
+            # source (see m4a's audio rule comment) and the spec was amended
+            # accordingly -- this carries the position placeholder like the
+            # other two new profiles rather than the row's original text.
+            accept_options=flags("-c:a:{n} copy"),
             # No stream_limit: the opus muxer holds several audio streams, by
             # copy and by encode.
-            fallback_options=flags("-c:a libopus -b:a 128k"),
+            fallback_options=flags("-c:a:{n} libopus -b:a:{n} 128k"),
             fallback_name="opus",
         ),
     },

--- a/docs/specs/spec-audio-formats.md
+++ b/docs/specs/spec-audio-formats.md
@@ -488,3 +488,27 @@ New-Item -ItemType Directory -Force art
   `stream_limit` exemption directly, so `SHIPPED` and `INVARIANT_CASES` carry
   them instead of a shape-alike fixture describing a profile that no longer
   needs standing in for.
+- 2026-08-26 (#22): `m4a`, `ogg` and `opus` landed exactly as the fixed table
+  pins them: cheap attempts read `-map 0:a? -c:a copy` for `m4a` and
+  `-map 0:a? -c copy` for `ogg` and `opus`, matching the per-profile table
+  rather than the issue's own "all three: `-c copy`" paraphrase, which the
+  spec's own fixed table (the authority per this issue's "Read first") only
+  gives to `ogg` and `opus`. None declares a `stream_limit` -- their muxers
+  hold several audio streams, so `MUXER_ENFORCED_LIMIT_TYPES` gets no new
+  entries and the equality invariant is proven the ordinary way for all
+  three. `opus`'s `accept_options` is the bare `flags("-c:a copy")` the Prior
+  decisions row pins, with no `"{n}"` placeholder despite no `stream_limit`;
+  `m4a` and `ogg` follow the same bare shape for consistency with it and with
+  `mp3`/`flac`'s own accept_options, relying on ffmpeg's positional per-type
+  stream-option matching (each matched stream's codec option is appended in
+  the same order its `-map` is, which is what makes the unindexed form
+  correct for more than one output stream of the same type). Measured
+  against ffmpeg 9.0 through the CLI with `--ffmpeg`/`--ffprobe`: an
+  already-aac `.aac` copies straight into `m4a` and an already-vorbis `.ogg`
+  copies straight into `ogg`; a non-mask codec (`mp3`) re-encodes into all
+  three with the exact re-encode note; and `--to opus` on an already-vorbis
+  `.ogg` reproduces the accepted mislabel from the "opus copies" decision --
+  the cheap attempt's blind `-c copy` succeeds, and `ffprobe` on the result
+  confirms the stream inside `tone-vorbis.opus` is still `vorbis`, not
+  `opus`. A second run over the same tree reported `0 converted, 4 skipped`,
+  exit 0, for all three targets.

--- a/docs/specs/spec-audio-formats.md
+++ b/docs/specs/spec-audio-formats.md
@@ -151,6 +151,23 @@ reader should re-verify rather than trust the table.
 | **No generation-loss note** (a "your FLAC came from a 128 kbit/s MP3" warning) in this phase | It would need a lossy-codec set plus a new branch in `jobs.py`, and `Stream` carries no such notion — an engine change, which this phase's headline outcome forbids. Recorded below as a roadmap candidate rather than smuggled in | 2026-08-25 |
 | No audio profile declares a **video rule**, so any video stream — cover art included — is dropped by the selective rung with the engine's existing "not supported by TARGET" note | Keeping cover art needs the `attached_pic` disposition, which `probe_streams` does not request and `Stream` does not carry, so the engine cannot tell a picture from a real video stream. The muxer table shows what happens if you guess: `m4a` hard-fails on a real MJPEG while succeeding on a picture, and `mp3` silently truncates it to one frame | 2026-08-25 |
 
+> **Amended, 2026-08-26 (issue #22 review).** Row 145's `opus` `accept_options`
+> pin (`flags("-c:a copy")`, no `"{n}"` position placeholder) is corrected: it
+> is safe only for `mp3`/`flac`, whose `stream_limit=1` guarantees at most one
+> output stream of the type, and does not transfer to a profile with none.
+> Measured against ffmpeg 9.0: ffmpeg's unindexed `-c:a` is **not** applied
+> positionally to successive output streams in map order -- when several are
+> given, the *last* one wins for every audio output stream. On a two-stream
+> source with one mask hit and one miss (e.g. an aac stream plus an mp3
+> stream converting `--to m4a`), the bare form silently re-encoded the
+> stream that should have copied, with no note naming the loss -- a breach
+> of `docs/constitution.md`'s "never report success for a conversion that
+> silently dropped something". `m4a`, `ogg` and `opus` all carry the
+> `"{n}"` placeholder instead, the same shape `MP4`'s video/audio rules
+> already use, which substitutes the correct per-stream index
+> (`converter/jobs.py::_substitute_position`) rather than relying on
+> ffmpeg's option order.
+
 ### The five new profiles, fixed
 
 `wav` is not in this table: it keeps phase 2's shape unchanged.
@@ -496,19 +513,35 @@ New-Item -ItemType Directory -Force art
   gives to `ogg` and `opus`. None declares a `stream_limit` -- their muxers
   hold several audio streams, so `MUXER_ENFORCED_LIMIT_TYPES` gets no new
   entries and the equality invariant is proven the ordinary way for all
-  three. `opus`'s `accept_options` is the bare `flags("-c:a copy")` the Prior
-  decisions row pins, with no `"{n}"` placeholder despite no `stream_limit`;
-  `m4a` and `ogg` follow the same bare shape for consistency with it and with
-  `mp3`/`flac`'s own accept_options, relying on ffmpeg's positional per-type
-  stream-option matching (each matched stream's codec option is appended in
-  the same order its `-map` is, which is what makes the unindexed form
-  correct for more than one output stream of the same type). Measured
-  against ffmpeg 9.0 through the CLI with `--ffmpeg`/`--ffprobe`: an
-  already-aac `.aac` copies straight into `m4a` and an already-vorbis `.ogg`
-  copies straight into `ogg`; a non-mask codec (`mp3`) re-encodes into all
-  three with the exact re-encode note; and `--to opus` on an already-vorbis
-  `.ogg` reproduces the accepted mislabel from the "opus copies" decision --
-  the cheap attempt's blind `-c copy` succeeds, and `ffprobe` on the result
-  confirms the stream inside `tone-vorbis.opus` is still `vorbis`, not
-  `opus`. A second run over the same tree reported `0 converted, 4 skipped`,
-  exit 0, for all three targets.
+  three. Measured against ffmpeg 9.0 through the CLI with
+  `--ffmpeg`/`--ffprobe`: an already-aac `.aac` copies straight into `m4a`
+  and an already-vorbis `.ogg` copies straight into `ogg`; a non-mask codec
+  (`mp3`) re-encodes into all three with the exact re-encode note; and
+  `--to opus` on an already-vorbis `.ogg` reproduces the accepted mislabel
+  from the "opus copies" decision -- the cheap attempt's blind `-c copy`
+  succeeds, and `ffprobe` on the result confirms the stream inside
+  `tone-vorbis.opus` is still `vorbis`, not `opus`. A second run over the
+  same tree reported `0 converted, 4 skipped`, exit 0, for all three
+  targets.
+- 2026-08-26 (#22 review): the first pass shipped `opus`'s `accept_options`
+  as the Prior decisions row's bare `flags("-c:a copy")`, and gave `m4a` and
+  `ogg` the same bare shape for consistency, reasoning that ffmpeg applies
+  repeated unindexed `-c:a` options positionally to successive output
+  streams in map order. Review measured that this is false: ffmpeg's own
+  stderr says so directly ("Multiple -codec/-c/-acodec options specified for
+  stream 0, only the last option ... will be used"), hidden in production by
+  `-loglevel error`. On a real two-stream source (one mask hit, one miss),
+  the bare form silently re-encoded the stream that should have copied, with
+  no note naming the loss. `mp3`/`flac`'s existing bare form is unaffected --
+  their `stream_limit=1` guarantees at most one output stream, so the bug
+  cannot occur -- but it does not transfer to a profile with none. All three
+  new profiles now carry the `"{n}"` position placeholder instead (see the
+  amendment above the "five new profiles, fixed" table), the shape `MP4`'s
+  own audio/video rules already use. Added a mixed-stream test per profile in
+  `tests/test_argv.py` (each named
+  `test_mixed_accept_and_fallback_streams_each_take_their_own_fate`) after
+  confirming the existing `test_second_matching_audio_stream_is_also_carried`
+  tests used two same-outcome streams and so could not have caught this.
+  Re-measured against ffmpeg 9.0: a genuinely mixed aac+mp3 source through
+  `--to m4a` now produces two aac streams, with only the mp3 one named in the
+  re-encode note.

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -300,7 +300,7 @@ class TestM4aJob:
         attempts = jobs.retries(M4A, streams)
 
         assert [a.label for a in attempts] == ["selective", "re-encode"]
-        assert attempts[0].options == ("-map", "0:0", "-c:a", "copy")
+        assert attempts[0].options == ("-map", "0:0", "-c:a:0", "copy")
         assert attempts[0].notes == ()
 
     def test_non_matching_audio_reencodes_with_a_note(self):
@@ -308,7 +308,7 @@ class TestM4aJob:
 
         selective = jobs.retries(M4A, streams)[0]
 
-        assert selective.options == ("-map", "0:0", "-c:a", "aac", "-b:a", "192k")
+        assert selective.options == ("-map", "0:0", "-c:a:0", "aac", "-b:a:0", "192k")
         assert selective.notes == ("audio stream 0 (mp3) re-encoded to aac",)
 
     def test_second_matching_audio_stream_is_also_carried(self):
@@ -318,8 +318,40 @@ class TestM4aJob:
 
         selective = jobs.retries(M4A, streams)[0]
 
-        assert selective.options == ("-map", "0:0", "-map", "0:1", "-c:a", "copy", "-c:a", "copy")
+        assert selective.options == (
+            "-map",
+            "0:0",
+            "-map",
+            "0:1",
+            "-c:a:0",
+            "copy",
+            "-c:a:1",
+            "copy",
+        )
         assert selective.notes == ()
+
+    def test_mixed_accept_and_fallback_streams_each_take_their_own_fate(self):
+        """The position placeholder is what makes this safe: ffmpeg's
+        unindexed "-c:a" is not positional (measured against ffmpeg 9.0) --
+        without "{n}", the second "-c:a" given would win for *both* output
+        streams, silently re-encoding the one that should have been copied."""
+        streams = [Stream(0, "audio", "aac"), Stream(1, "audio", "mp3")]
+
+        selective = jobs.retries(M4A, streams)[0]
+
+        assert selective.options == (
+            "-map",
+            "0:0",
+            "-map",
+            "0:1",
+            "-c:a:0",
+            "copy",
+            "-c:a:1",
+            "aac",
+            "-b:a:1",
+            "192k",
+        )
+        assert selective.notes == ("audio stream 1 (mp3) re-encoded to aac",)
 
     def test_video_only_source_skips_straight_to_the_last_resort(self):
         attempts = jobs.retries(M4A, [Stream(0, "video", "h264")])
@@ -363,7 +395,7 @@ class TestOggJob:
         attempts = jobs.retries(OGG, streams)
 
         assert [a.label for a in attempts] == ["selective", "re-encode"]
-        assert attempts[0].options == ("-map", "0:0", "-c:a", "copy")
+        assert attempts[0].options == ("-map", "0:0", "-c:a:0", "copy")
         assert attempts[0].notes == ()
 
     def test_non_matching_audio_reencodes_with_a_note(self):
@@ -372,7 +404,7 @@ class TestOggJob:
 
         selective = jobs.retries(OGG, streams)[0]
 
-        assert selective.options == ("-map", "0:0", "-c:a", "libvorbis", "-q:a", "5")
+        assert selective.options == ("-map", "0:0", "-c:a:0", "libvorbis", "-q:a:0", "5")
         assert selective.notes == ("audio stream 0 (aac) re-encoded to vorbis",)
 
     def test_second_matching_audio_stream_is_also_carried(self):
@@ -380,8 +412,37 @@ class TestOggJob:
 
         selective = jobs.retries(OGG, streams)[0]
 
-        assert selective.options == ("-map", "0:0", "-map", "0:1", "-c:a", "copy", "-c:a", "copy")
+        assert selective.options == (
+            "-map",
+            "0:0",
+            "-map",
+            "0:1",
+            "-c:a:0",
+            "copy",
+            "-c:a:1",
+            "copy",
+        )
         assert selective.notes == ()
+
+    def test_mixed_accept_and_fallback_streams_each_take_their_own_fate(self):
+        """See `TestM4aJob`'s equivalent test for why the placeholder matters."""
+        streams = [Stream(0, "audio", "vorbis"), Stream(1, "audio", "aac")]
+
+        selective = jobs.retries(OGG, streams)[0]
+
+        assert selective.options == (
+            "-map",
+            "0:0",
+            "-map",
+            "0:1",
+            "-c:a:0",
+            "copy",
+            "-c:a:1",
+            "libvorbis",
+            "-q:a:1",
+            "5",
+        )
+        assert selective.notes == ("audio stream 1 (aac) re-encoded to vorbis",)
 
     def test_video_only_source_skips_straight_to_the_last_resort(self):
         attempts = jobs.retries(OGG, [Stream(0, "video", "h264")])
@@ -426,7 +487,7 @@ class TestOpusJob:
         attempts = jobs.retries(OPUS, streams)
 
         assert [a.label for a in attempts] == ["selective", "re-encode"]
-        assert attempts[0].options == ("-map", "0:0", "-c:a", "copy")
+        assert attempts[0].options == ("-map", "0:0", "-c:a:0", "copy")
         assert attempts[0].notes == ()
 
     def test_non_matching_audio_reencodes_with_a_note(self):
@@ -437,7 +498,7 @@ class TestOpusJob:
 
         selective = jobs.retries(OPUS, streams)[0]
 
-        assert selective.options == ("-map", "0:0", "-c:a", "libopus", "-b:a", "128k")
+        assert selective.options == ("-map", "0:0", "-c:a:0", "libopus", "-b:a:0", "128k")
         assert selective.notes == ("audio stream 0 (vorbis) re-encoded to opus",)
 
     def test_second_matching_audio_stream_is_also_carried(self):
@@ -445,8 +506,39 @@ class TestOpusJob:
 
         selective = jobs.retries(OPUS, streams)[0]
 
-        assert selective.options == ("-map", "0:0", "-map", "0:1", "-c:a", "copy", "-c:a", "copy")
+        assert selective.options == (
+            "-map",
+            "0:0",
+            "-map",
+            "0:1",
+            "-c:a:0",
+            "copy",
+            "-c:a:1",
+            "copy",
+        )
         assert selective.notes == ()
+
+    def test_mixed_accept_and_fallback_streams_each_take_their_own_fate(self):
+        """See `TestM4aJob`'s equivalent test for why the placeholder matters
+        -- and, for `opus`, the specific reason the spec's original bare-form
+        pin was amended after this was measured against ffmpeg 9.0."""
+        streams = [Stream(0, "audio", "opus"), Stream(1, "audio", "vorbis")]
+
+        selective = jobs.retries(OPUS, streams)[0]
+
+        assert selective.options == (
+            "-map",
+            "0:0",
+            "-map",
+            "0:1",
+            "-c:a:0",
+            "copy",
+            "-c:a:1",
+            "libopus",
+            "-b:a:1",
+            "128k",
+        )
+        assert selective.notes == ("audio stream 1 (vorbis) re-encoded to opus",)
 
     def test_video_only_source_skips_straight_to_the_last_resort(self):
         attempts = jobs.retries(OPUS, [Stream(0, "video", "h264")])
@@ -910,7 +1002,7 @@ class TestProfileArgvPinning:
             "in.mkv",
             "-map",
             "0:0",
-            "-c:a",
+            "-c:a:0",
             "copy",
             "out.m4a",
         ]
@@ -931,9 +1023,9 @@ class TestProfileArgvPinning:
             "in.mp3",
             "-map",
             "0:0",
-            "-c:a",
+            "-c:a:0",
             "aac",
-            "-b:a",
+            "-b:a:0",
             "192k",
             "out.m4a",
         ]
@@ -973,7 +1065,7 @@ class TestProfileArgvPinning:
             "in.mkv",
             "-map",
             "0:0",
-            "-c:a",
+            "-c:a:0",
             "copy",
             "out.ogg",
         ]
@@ -994,9 +1086,9 @@ class TestProfileArgvPinning:
             "in.m4a",
             "-map",
             "0:0",
-            "-c:a",
+            "-c:a:0",
             "libvorbis",
-            "-q:a",
+            "-q:a:0",
             "5",
             "out.ogg",
         ]
@@ -1036,7 +1128,7 @@ class TestProfileArgvPinning:
             "in.ogg",
             "-map",
             "0:0",
-            "-c:a",
+            "-c:a:0",
             "copy",
             "out.opus",
         ]
@@ -1059,9 +1151,9 @@ class TestProfileArgvPinning:
             "in.ogg",
             "-map",
             "0:0",
-            "-c:a",
+            "-c:a:0",
             "libopus",
-            "-b:a",
+            "-b:a:0",
             "128k",
             "out.opus",
         ]

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -7,7 +7,7 @@ import pytest
 
 from converter import ffmpegtool, jobs
 from converter.ffmpegtool import Stream, build_argv, cli_path
-from converter.profiles import FLAC, MP3, MP4, WAV
+from converter.profiles import FLAC, M4A, MP3, MP4, OGG, OPUS, WAV
 
 
 def options_of(argv: list[str], src: str, dst: str) -> list[str]:
@@ -279,6 +279,196 @@ class TestFlacJob:
 
     def test_target_suffix(self):
         assert FLAC.target_suffix == ".flac"
+
+
+class TestM4aJob:
+    """Issue #22, `docs/specs/spec-audio-formats.md`: same blind-mapping shape
+    as `MP3`/`FLAC`, but `m4a` declares no `stream_limit` -- the ipod muxer
+    holds several audio streams, so every one the source has is carried."""
+
+    def test_first_attempt_carries_the_standing_note(self):
+        attempt = jobs.first_attempt(M4A)
+
+        assert attempt.options == ("-map", "0:a?", "-c:a", "copy")
+        assert attempt.notes == (
+            "non-audio streams, including cover art, are not carried into M4A",
+        )
+
+    def test_single_matching_stream_reaches_a_selective_copy(self):
+        streams = [Stream(0, "audio", "aac")]
+
+        attempts = jobs.retries(M4A, streams)
+
+        assert [a.label for a in attempts] == ["selective", "re-encode"]
+        assert attempts[0].options == ("-map", "0:0", "-c:a", "copy")
+        assert attempts[0].notes == ()
+
+    def test_non_matching_audio_reencodes_with_a_note(self):
+        streams = [Stream(0, "audio", "mp3")]
+
+        selective = jobs.retries(M4A, streams)[0]
+
+        assert selective.options == ("-map", "0:0", "-c:a", "aac", "-b:a", "192k")
+        assert selective.notes == ("audio stream 0 (mp3) re-encoded to aac",)
+
+    def test_second_matching_audio_stream_is_also_carried(self):
+        """Unlike mp3/flac's muxer-enforced limit, m4a declares none: a
+        second aac/alac stream is copied too, not dropped."""
+        streams = [Stream(0, "audio", "aac"), Stream(1, "audio", "alac")]
+
+        selective = jobs.retries(M4A, streams)[0]
+
+        assert selective.options == ("-map", "0:0", "-map", "0:1", "-c:a", "copy", "-c:a", "copy")
+        assert selective.notes == ()
+
+    def test_video_only_source_skips_straight_to_the_last_resort(self):
+        attempts = jobs.retries(M4A, [Stream(0, "video", "h264")])
+
+        assert [a.label for a in attempts] == ["re-encode"]
+
+    def test_video_stream_alongside_audio_is_dropped_with_a_note(self):
+        streams = [Stream(0, "audio", "aac"), Stream(1, "video", "h264")]
+
+        selective = jobs.retries(M4A, streams)[0]
+
+        assert selective.notes == ("video stream 1 (h264) dropped: not supported by M4A",)
+
+    def test_last_resort_notes_are_pinned(self):
+        reencode = jobs.retries(M4A, [])[-1]
+
+        assert reencode.notes == (
+            "non-audio streams, and any audio stream beyond the first, are not carried into M4A",
+        )
+
+    def test_target_suffix(self):
+        assert M4A.target_suffix == ".m4a"
+
+
+class TestOggJob:
+    """Issue #22, `docs/specs/spec-audio-formats.md`: same shape as `M4A`,
+    with a wider copy mask and no stream limit either -- the ogg muxer holds
+    several audio streams too."""
+
+    def test_first_attempt_carries_the_standing_note(self):
+        attempt = jobs.first_attempt(OGG)
+
+        assert attempt.options == ("-map", "0:a?", "-c", "copy")
+        assert attempt.notes == (
+            "non-audio streams, including cover art, are not carried into OGG",
+        )
+
+    def test_single_matching_stream_reaches_a_selective_copy(self):
+        streams = [Stream(0, "audio", "vorbis")]
+
+        attempts = jobs.retries(OGG, streams)
+
+        assert [a.label for a in attempts] == ["selective", "re-encode"]
+        assert attempts[0].options == ("-map", "0:0", "-c:a", "copy")
+        assert attempts[0].notes == ()
+
+    def test_non_matching_audio_reencodes_with_a_note(self):
+        """The ogg muxer rejects mp3 and aac (docs/specs/spec-audio-formats.md)."""
+        streams = [Stream(0, "audio", "aac")]
+
+        selective = jobs.retries(OGG, streams)[0]
+
+        assert selective.options == ("-map", "0:0", "-c:a", "libvorbis", "-q:a", "5")
+        assert selective.notes == ("audio stream 0 (aac) re-encoded to vorbis",)
+
+    def test_second_matching_audio_stream_is_also_carried(self):
+        streams = [Stream(0, "audio", "vorbis"), Stream(1, "audio", "opus")]
+
+        selective = jobs.retries(OGG, streams)[0]
+
+        assert selective.options == ("-map", "0:0", "-map", "0:1", "-c:a", "copy", "-c:a", "copy")
+        assert selective.notes == ()
+
+    def test_video_only_source_skips_straight_to_the_last_resort(self):
+        attempts = jobs.retries(OGG, [Stream(0, "video", "h264")])
+
+        assert [a.label for a in attempts] == ["re-encode"]
+
+    def test_video_stream_alongside_audio_is_dropped_with_a_note(self):
+        streams = [Stream(0, "audio", "vorbis"), Stream(1, "video", "h264")]
+
+        selective = jobs.retries(OGG, streams)[0]
+
+        assert selective.notes == ("video stream 1 (h264) dropped: not supported by OGG",)
+
+    def test_last_resort_notes_are_pinned(self):
+        reencode = jobs.retries(OGG, [])[-1]
+
+        assert reencode.notes == (
+            "non-audio streams, and any audio stream beyond the first, are not carried into OGG",
+        )
+
+    def test_target_suffix(self):
+        assert OGG.target_suffix == ".ogg"
+
+
+class TestOpusJob:
+    """Issue #22, `docs/specs/spec-audio-formats.md`: `opus` copies on the
+    happy path even though its own muxer also accepts a Vorbis stream (Prior
+    decisions) -- the mask below governs only the failure-side selective rung,
+    where a Vorbis stream is re-encoded rather than copied."""
+
+    def test_first_attempt_carries_the_standing_note(self):
+        attempt = jobs.first_attempt(OPUS)
+
+        assert attempt.options == ("-map", "0:a?", "-c", "copy")
+        assert attempt.notes == (
+            "non-audio streams, including cover art, are not carried into OPUS",
+        )
+
+    def test_single_matching_stream_reaches_a_selective_copy(self):
+        streams = [Stream(0, "audio", "opus")]
+
+        attempts = jobs.retries(OPUS, streams)
+
+        assert [a.label for a in attempts] == ["selective", "re-encode"]
+        assert attempts[0].options == ("-map", "0:0", "-c:a", "copy")
+        assert attempts[0].notes == ()
+
+    def test_non_matching_audio_reencodes_with_a_note(self):
+        """A Vorbis stream is accepted by the opus muxer itself but not by
+        the mask, so the selective rung re-encodes it rather than shipping a
+        `.opus` file that is secretly Vorbis."""
+        streams = [Stream(0, "audio", "vorbis")]
+
+        selective = jobs.retries(OPUS, streams)[0]
+
+        assert selective.options == ("-map", "0:0", "-c:a", "libopus", "-b:a", "128k")
+        assert selective.notes == ("audio stream 0 (vorbis) re-encoded to opus",)
+
+    def test_second_matching_audio_stream_is_also_carried(self):
+        streams = [Stream(0, "audio", "opus"), Stream(1, "audio", "opus")]
+
+        selective = jobs.retries(OPUS, streams)[0]
+
+        assert selective.options == ("-map", "0:0", "-map", "0:1", "-c:a", "copy", "-c:a", "copy")
+        assert selective.notes == ()
+
+    def test_video_only_source_skips_straight_to_the_last_resort(self):
+        attempts = jobs.retries(OPUS, [Stream(0, "video", "h264")])
+
+        assert [a.label for a in attempts] == ["re-encode"]
+
+    def test_video_stream_alongside_audio_is_dropped_with_a_note(self):
+        streams = [Stream(0, "audio", "opus"), Stream(1, "video", "h264")]
+
+        selective = jobs.retries(OPUS, streams)[0]
+
+        assert selective.notes == ("video stream 1 (h264) dropped: not supported by OPUS",)
+
+    def test_last_resort_notes_are_pinned(self):
+        reencode = jobs.retries(OPUS, [])[-1]
+
+        assert reencode.notes == (
+            "non-audio streams, and any audio stream beyond the first, are not carried into OPUS",
+        )
+
+    def test_target_suffix(self):
+        assert OPUS.target_suffix == ".opus"
 
 
 class TestMp4Remux:
@@ -683,6 +873,197 @@ class TestProfileArgvPinning:
             "-c:a",
             "flac",
             "out.flac",
+        ]
+
+    def test_m4a_cheap_attempt(self):
+        argv = build_argv("ffmpeg", "in.wav", jobs.first_attempt(M4A).options, "out.m4a")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.wav",
+            "-map",
+            "0:a?",
+            "-c:a",
+            "copy",
+            "out.m4a",
+        ]
+
+    def test_m4a_copyable_source(self):
+        selective = jobs.retries(M4A, [Stream(0, "audio", "aac")])[0]
+
+        argv = build_argv("ffmpeg", "in.mkv", selective.options, "out.m4a")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:0",
+            "-c:a",
+            "copy",
+            "out.m4a",
+        ]
+
+    def test_m4a_non_copyable_source(self):
+        selective = jobs.retries(M4A, [Stream(0, "audio", "mp3")])[0]
+
+        argv = build_argv("ffmpeg", "in.mp3", selective.options, "out.m4a")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mp3",
+            "-map",
+            "0:0",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "192k",
+            "out.m4a",
+        ]
+
+    def test_ogg_cheap_attempt(self):
+        argv = build_argv("ffmpeg", "in.wav", jobs.first_attempt(OGG).options, "out.ogg")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.wav",
+            "-map",
+            "0:a?",
+            "-c",
+            "copy",
+            "out.ogg",
+        ]
+
+    def test_ogg_copyable_source(self):
+        selective = jobs.retries(OGG, [Stream(0, "audio", "vorbis")])[0]
+
+        argv = build_argv("ffmpeg", "in.mkv", selective.options, "out.ogg")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:0",
+            "-c:a",
+            "copy",
+            "out.ogg",
+        ]
+
+    def test_ogg_non_copyable_source(self):
+        selective = jobs.retries(OGG, [Stream(0, "audio", "aac")])[0]
+
+        argv = build_argv("ffmpeg", "in.m4a", selective.options, "out.ogg")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.m4a",
+            "-map",
+            "0:0",
+            "-c:a",
+            "libvorbis",
+            "-q:a",
+            "5",
+            "out.ogg",
+        ]
+
+    def test_opus_cheap_attempt(self):
+        argv = build_argv("ffmpeg", "in.wav", jobs.first_attempt(OPUS).options, "out.opus")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.wav",
+            "-map",
+            "0:a?",
+            "-c",
+            "copy",
+            "out.opus",
+        ]
+
+    def test_opus_copyable_source(self):
+        selective = jobs.retries(OPUS, [Stream(0, "audio", "opus")])[0]
+
+        argv = build_argv("ffmpeg", "in.ogg", selective.options, "out.opus")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.ogg",
+            "-map",
+            "0:0",
+            "-c:a",
+            "copy",
+            "out.opus",
+        ]
+
+    def test_opus_non_copyable_source(self):
+        """A Vorbis stream is accepted by the opus muxer itself but not the
+        mask, so it is re-encoded rather than copied under a lying extension."""
+        selective = jobs.retries(OPUS, [Stream(0, "audio", "vorbis")])[0]
+
+        argv = build_argv("ffmpeg", "in.ogg", selective.options, "out.opus")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.ogg",
+            "-map",
+            "0:0",
+            "-c:a",
+            "libopus",
+            "-b:a",
+            "128k",
+            "out.opus",
         ]
 
 

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -10,8 +10,11 @@ import pytest
 from converter import profiles
 from converter.profiles import (
     FLAC,
+    M4A,
     MP3,
     MP4,
+    OGG,
+    OPUS,
     PROFILES,
     SOURCE_SUFFIXES,
     WAV,
@@ -29,7 +32,7 @@ from converter.profiles import (
 MAP_LETTERS = {"v": "video", "a": "audio", "s": "subtitle", "t": "attachment", "d": "data"}
 
 #: Every profile the registry ships. A new one joins the invariant checks here.
-SHIPPED = [MP4, WAV, MP3, FLAC]
+SHIPPED = [MP4, WAV, MP3, FLAC, M4A, OGG, OPUS]
 
 #: A stand-in for the not-yet-shipped `mov` profile (`docs/specs/spec-video-formats.md`),
 #: shaped only enough to prove the degradation-ladder invariant's narrowed form:
@@ -68,6 +71,9 @@ FORCED_FAILURE_TYPES: dict[str, frozenset[str]] = {
     WAV.name: frozenset(),
     MP3.name: frozenset(),
     FLAC.name: frozenset(),
+    M4A.name: frozenset(),
+    OGG.name: frozenset(),
+    OPUS.name: frozenset(),
     MOV_SHAPED.name: frozenset({"attachment"}),
 }
 
@@ -88,6 +94,12 @@ MUXER_ENFORCED_LIMIT_TYPES: dict[str, frozenset[str]] = {
     WAV.name: frozenset(),
     MP3.name: frozenset({"audio"}),
     FLAC.name: frozenset({"audio"}),
+    # No entry: m4a, ogg and opus declare no stream_limit at all -- their
+    # muxers hold several audio streams, so there is nothing for a muxer to
+    # enforce here.
+    M4A.name: frozenset(),
+    OGG.name: frozenset(),
+    OPUS.name: frozenset(),
     MOV_SHAPED.name: frozenset(),
 }
 
@@ -476,9 +488,166 @@ class TestFlacProfile:
         assert FLAC.last_resort.options == ("-map", "0:a:0", "-c:a", "flac")
 
 
+class TestM4aProfile:
+    """Pins the shape Acceptance fixes for `m4a` (issue #22,
+    `docs/specs/spec-audio-formats.md`)."""
+
+    def test_label_and_suffix(self):
+        assert M4A.label == "M4A"
+        assert M4A.target_suffix == ".m4a"
+
+    def test_name_and_description(self):
+        assert M4A.name == "m4a"
+        assert M4A.description
+
+    def test_no_container_options(self):
+        assert M4A.container_options == ()
+
+    def test_cheap_attempt_maps_audio_blindly(self):
+        assert M4A.explicit_streams is False
+        assert M4A.cheap_attempt.options == ("-map", "0:a?", "-c:a", "copy")
+
+    def test_cheap_attempt_carries_the_standing_non_audio_note(self):
+        assert M4A.cheap_attempt.notes == (
+            "non-audio streams, including cover art, are not carried into M4A",
+        )
+
+    def test_cheap_attempt_is_declared_partial(self):
+        assert M4A.partial_mapping is True
+
+    def test_declares_only_an_audio_rule(self):
+        assert set(M4A.rules) == {"audio"}
+
+    def test_audio_rule_mask_and_fallback(self):
+        """The mask is `{aac, alac}`, not `MP4_AUDIO_CODECS`: `.m4a` selects
+        the narrower `ipod` muxer, which rejects mp3, opus and flac stream
+        copies (docs/specs/spec-audio-formats.md)."""
+        rule = M4A.rules["audio"]
+
+        assert rule.copy_mask == frozenset({"aac", "alac"})
+        assert rule.accept_options == ("-c:a", "copy")
+        assert rule.fallback_options == ("-c:a", "aac", "-b:a", "192k")
+        assert rule.fallback_name == "aac"
+
+    def test_audio_rule_declares_no_stream_limit(self):
+        """The ipod muxer holds several audio streams, so every one the
+        source has is carried rather than one kept and the rest dropped."""
+        assert M4A.rules["audio"].stream_limit is None
+
+    def test_declares_the_pinned_last_resort(self):
+        assert M4A.last_resort is not None
+        assert M4A.last_resort.options == ("-map", "0:a:0", "-c:a", "aac", "-b:a", "192k")
+
+
+class TestOggProfile:
+    """Pins the shape Acceptance fixes for `ogg` (issue #22,
+    `docs/specs/spec-audio-formats.md`)."""
+
+    def test_label_and_suffix(self):
+        assert OGG.label == "OGG"
+        assert OGG.target_suffix == ".ogg"
+
+    def test_name_and_description(self):
+        assert OGG.name == "ogg"
+        assert OGG.description
+
+    def test_no_container_options(self):
+        assert OGG.container_options == ()
+
+    def test_cheap_attempt_maps_audio_blindly(self):
+        """ "-c copy", not "-c:a copy": the spec pins this exact spelling
+        (docs/specs/spec-audio-formats.md's fixed-profiles table)."""
+        assert OGG.explicit_streams is False
+        assert OGG.cheap_attempt.options == ("-map", "0:a?", "-c", "copy")
+
+    def test_cheap_attempt_carries_the_standing_non_audio_note(self):
+        assert OGG.cheap_attempt.notes == (
+            "non-audio streams, including cover art, are not carried into OGG",
+        )
+
+    def test_cheap_attempt_is_declared_partial(self):
+        assert OGG.partial_mapping is True
+
+    def test_declares_only_an_audio_rule(self):
+        assert set(OGG.rules) == {"audio"}
+
+    def test_audio_rule_mask_and_fallback(self):
+        rule = OGG.rules["audio"]
+
+        assert rule.copy_mask == frozenset({"vorbis", "opus", "flac"})
+        assert rule.accept_options == ("-c:a", "copy")
+        assert rule.fallback_options == ("-c:a", "libvorbis", "-q:a", "5")
+        assert rule.fallback_name == "vorbis"
+
+    def test_audio_rule_declares_no_stream_limit(self):
+        assert OGG.rules["audio"].stream_limit is None
+
+    def test_declares_the_pinned_last_resort(self):
+        assert OGG.last_resort is not None
+        assert OGG.last_resort.options == ("-map", "0:a:0", "-c:a", "libvorbis", "-q:a", "5")
+
+
+class TestOpusProfile:
+    """Pins the shape Acceptance fixes for `opus` (issue #22,
+    `docs/specs/spec-audio-formats.md`)."""
+
+    def test_label_and_suffix(self):
+        assert OPUS.label == "OPUS"
+        assert OPUS.target_suffix == ".opus"
+
+    def test_name_and_description(self):
+        assert OPUS.name == "opus"
+        assert OPUS.description
+
+    def test_no_container_options(self):
+        assert OPUS.container_options == ()
+
+    def test_cheap_attempt_maps_audio_blindly(self):
+        """ "-c copy", like ogg's: the muxer, not the mask, decides the happy
+        path (Prior decisions, spec-audio-formats.md)."""
+        assert OPUS.explicit_streams is False
+        assert OPUS.cheap_attempt.options == ("-map", "0:a?", "-c", "copy")
+
+    def test_cheap_attempt_carries_the_standing_non_audio_note(self):
+        assert OPUS.cheap_attempt.notes == (
+            "non-audio streams, including cover art, are not carried into OPUS",
+        )
+
+    def test_cheap_attempt_is_declared_partial(self):
+        assert OPUS.partial_mapping is True
+
+    def test_declares_only_an_audio_rule(self):
+        assert set(OPUS.rules) == {"audio"}
+
+    def test_audio_rule_mask_and_fallback(self):
+        rule = OPUS.rules["audio"]
+
+        assert rule.copy_mask == frozenset({"opus"})
+        assert rule.accept_options == ("-c:a", "copy")
+        assert rule.fallback_options == ("-c:a", "libopus", "-b:a", "128k")
+        assert rule.fallback_name == "opus"
+
+    def test_audio_rule_declares_no_stream_limit(self):
+        """The opus muxer holds several audio streams, by copy and by
+        encode (docs/specs/spec-audio-formats.md)."""
+        assert OPUS.rules["audio"].stream_limit is None
+
+    def test_declares_the_pinned_last_resort(self):
+        assert OPUS.last_resort is not None
+        assert OPUS.last_resort.options == ("-map", "0:a:0", "-c:a", "libopus", "-b:a", "128k")
+
+
 class TestRegistry:
     def test_keys_are_each_profile_s_own_name(self):
-        assert PROFILES == {"mp4": MP4, "wav": WAV, "mp3": MP3, "flac": FLAC}
+        assert PROFILES == {
+            "mp4": MP4,
+            "wav": WAV,
+            "mp3": MP3,
+            "flac": FLAC,
+            "m4a": M4A,
+            "ogg": OGG,
+            "opus": OPUS,
+        }
 
 
 class TestResolveTarget:
@@ -493,8 +662,16 @@ class TestResolveTarget:
         assert resolve_target("mp3") is MP3
         assert resolve_target("flac") is FLAC
 
+    def test_resolves_m4a_ogg_and_opus_too(self):
+        assert resolve_target("m4a") is M4A
+        assert resolve_target("ogg") is OGG
+        assert resolve_target("opus") is OPUS
+
     def test_unknown_target_raises_value_error_listing_available_targets(self):
-        with pytest.raises(ValueError, match=r"mkv.*available targets: flac, mp3, mp4, wav"):
+        with pytest.raises(
+            ValueError,
+            match=r"mkv.*available targets: flac, m4a, mp3, mp4, ogg, opus, wav",
+        ):
             resolve_target("mkv")
 
 

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -525,14 +525,25 @@ class TestM4aProfile:
         rule = M4A.rules["audio"]
 
         assert rule.copy_mask == frozenset({"aac", "alac"})
-        assert rule.accept_options == ("-c:a", "copy")
-        assert rule.fallback_options == ("-c:a", "aac", "-b:a", "192k")
+        assert rule.accept_options == ("-c:a:{n}", "copy")
+        assert rule.fallback_options == ("-c:a:{n}", "aac", "-b:a:{n}", "192k")
         assert rule.fallback_name == "aac"
 
     def test_audio_rule_declares_no_stream_limit(self):
         """The ipod muxer holds several audio streams, so every one the
         source has is carried rather than one kept and the rest dropped."""
         assert M4A.rules["audio"].stream_limit is None
+
+    def test_audio_rule_carries_the_position_placeholder(self):
+        """No stream_limit means more than one output audio stream is
+        possible, and ffmpeg's unindexed "-c:a" is not positional -- the last
+        one given wins for every audio stream, not one per stream in map
+        order (measured against ffmpeg 9.0). The placeholder is required for
+        the same reason MP4's video/audio rules carry one."""
+        rule = M4A.rules["audio"]
+
+        assert "{n}" in " ".join(rule.accept_options)
+        assert "{n}" in " ".join(rule.fallback_options)
 
     def test_declares_the_pinned_last_resort(self):
         assert M4A.last_resort is not None
@@ -575,12 +586,19 @@ class TestOggProfile:
         rule = OGG.rules["audio"]
 
         assert rule.copy_mask == frozenset({"vorbis", "opus", "flac"})
-        assert rule.accept_options == ("-c:a", "copy")
-        assert rule.fallback_options == ("-c:a", "libvorbis", "-q:a", "5")
+        assert rule.accept_options == ("-c:a:{n}", "copy")
+        assert rule.fallback_options == ("-c:a:{n}", "libvorbis", "-q:a:{n}", "5")
         assert rule.fallback_name == "vorbis"
 
     def test_audio_rule_declares_no_stream_limit(self):
         assert OGG.rules["audio"].stream_limit is None
+
+    def test_audio_rule_carries_the_position_placeholder(self):
+        """See `TestM4aProfile`'s equivalent test for why."""
+        rule = OGG.rules["audio"]
+
+        assert "{n}" in " ".join(rule.accept_options)
+        assert "{n}" in " ".join(rule.fallback_options)
 
     def test_declares_the_pinned_last_resort(self):
         assert OGG.last_resort is not None
@@ -623,14 +641,21 @@ class TestOpusProfile:
         rule = OPUS.rules["audio"]
 
         assert rule.copy_mask == frozenset({"opus"})
-        assert rule.accept_options == ("-c:a", "copy")
-        assert rule.fallback_options == ("-c:a", "libopus", "-b:a", "128k")
+        assert rule.accept_options == ("-c:a:{n}", "copy")
+        assert rule.fallback_options == ("-c:a:{n}", "libopus", "-b:a:{n}", "128k")
         assert rule.fallback_name == "opus"
 
     def test_audio_rule_declares_no_stream_limit(self):
         """The opus muxer holds several audio streams, by copy and by
         encode (docs/specs/spec-audio-formats.md)."""
         assert OPUS.rules["audio"].stream_limit is None
+
+    def test_audio_rule_carries_the_position_placeholder(self):
+        """See `TestM4aProfile`'s equivalent test for why."""
+        rule = OPUS.rules["audio"]
+
+        assert "{n}" in " ".join(rule.accept_options)
+        assert "{n}" in " ".join(rule.fallback_options)
 
     def test_declares_the_pinned_last_resort(self):
         assert OPUS.last_resort is not None


### PR DESCRIPTION
## Summary
- Adds the three remaining multi-stream-capable audio profiles: `m4a` (ipod muxer, mask `{aac, alac}`), `ogg` (mask `{vorbis, opus, flac}`) and `opus` (mask `{opus}`, muxer-authoritative happy path).
- None declares a `stream_limit` -- their muxers hold several audio streams, unlike `mp3`/`flac`, so every audio stream the source has is carried rather than one kept and the rest silently dropped.
- Per `docs/specs/spec-audio-formats.md`'s fixed table: cheap attempts map audio blindly (`-c:a copy` for `m4a`, `-c copy` for `ogg`/`opus`), each carries the standing non-audio note, and each declares a pinned single-index `last_resort`.
- Decision-log entry added to the spec recording the implementation, including the exact-argv choice for `m4a`/`ogg` (spec table over the issue's own paraphrase) and the bare `accept_options` shape.

## Test plan
- [x] `scripts/verify.py` green (ruff check, ruff format --check, pytest -- 433 tests)
- [x] argv pinned for a copyable and a non-copyable input, per target (`tests/test_argv.py::TestProfileArgvPinning`)
- [x] Per-profile shape tests (`tests/test_profiles.py::TestM4aProfile`/`TestOggProfile`/`TestOpusProfile`) and degradation-branch note tests (`tests/test_argv.py::TestM4aJob`/`TestOggJob`/`TestOpusJob`)
- [x] `TestPartialMappingInvariant`'s equality invariant holds for all three via `SHIPPED`/`INVARIANT_CASES`
- [x] Smoke-tested against real ffmpeg 9.0 through the CLI with absolute `--ffmpeg`/`--ffprobe`: a copyable source copies, a non-copyable one re-encodes with the exact note, `--to opus` on an already-vorbis `.ogg` reproduces the accepted mislabel (verified via `ffprobe` that the resulting `.opus` still contains a vorbis stream), and a second run over the converted tree reports `0 converted, 4 skipped`, exit 0, for all three targets

Closes #22