### PR TITLE
feat(profiles): mov target

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ installed version supports; today that is:
 Target formats:
   flac  .flac  Audio: single stream, lossless FLAC
   mkv   .mkv  Video: copies almost every codec as-is, keeps font attachments
+  mov   .mov  Video: copies compatible streams, re-encodes the rest to h264/aac; no attachments
   mp3   .mp3  Audio: single stream, MP3 (libmp3lame if re-encoded)
   mp4   .mp4  Video: copies compatible streams, re-encodes the rest to h264/aac
   wav   .wav  Audio: single stream, uncompressed 16-bit PCM

--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -327,6 +327,87 @@ MKV = Profile(
     ),
 )
 
+#: Codecs a MOV container accepts as a stream copy for video, measured against
+#: ffmpeg 9.0. Narrower than MP4's mask in *two* codecs -- vp9 and av1, both
+#: rejected by MOV's muxer ("vp9 only supported in MP4", "av1 only supported
+#: in MP4 and AVIF") -- and also rejects vp8 ("VP8 muxing is currently not
+#: supported"). Adds ffv1 and theora, which MP4 does not carry either, so this
+#: is its own curated set rather than MP4_VIDEO_CODECS with an entry struck.
+MOV_VIDEO_CODECS = frozenset(
+    {"h264", "hevc", "prores", "mpeg4", "mpeg2video", "mjpeg", "ffv1", "theora"}
+)
+#: Codecs a MOV container accepts as a stream copy for audio, measured the same
+#: way -- adds dts and pcm_s16le (tags dtsc, sowt) over MP4's mask.
+MOV_AUDIO_CODECS = frozenset({"aac", "alac", "mp3", "ac3", "eac3", "dts", "pcm_s16le"})
+
+MOV = Profile(
+    label="MOV",
+    name="mov",
+    description="Video: copies compatible streams, re-encodes the rest to h264/aac; no attachments",
+    target_suffix=".mov",
+    container_options=FASTSTART,
+    # Deliberately maps "0:t?" even though MOV holds no attachment rule below:
+    # MOV's muxer rejects any mapped attachment outright ("Could not find tag
+    # for codec ttf", measured), so an attachment-bearing source fails this
+    # cheap attempt and lands on the ladder's failure side instead, where the
+    # missing rule drops it with a real per-stream note -- better than a
+    # blanket standing note for the one case MOV can make loud. Still not
+    # "-map 0": that would also select data and timecode streams, which no
+    # "v/a/s/t" map -- MOV's included -- carries at all (measured).
+    cheap_attempt=Attempt(
+        label="remux",
+        options=flags("-map 0:v? -map 0:a? -map 0:s? -map 0:t? -c copy -c:s mov_text"),
+        notes=("data and timecode streams are not carried into MOV",),
+    ),
+    explicit_streams=False,
+    # The blind "?" selectors carry every video, audio and subtitle stream
+    # MOV's muxer can hold, but never a data or timecode one, and an attachment
+    # only ever forces the cheap attempt to fail -- exactly the standing note's
+    # claim, verified once per successful cheap attempt rather than assumed.
+    partial_mapping=True,
+    rules={
+        "video": StreamRule(
+            copy_mask=MOV_VIDEO_CODECS,
+            accept_options=flags("-c:v:{n} copy"),
+            fallback_options=flags("-c:v:{n} libx264 -crf:v:{n} 18"),
+            fallback_name="h264",
+        ),
+        "audio": StreamRule(
+            copy_mask=MOV_AUDIO_CODECS,
+            accept_options=flags("-c:a:{n} copy"),
+            fallback_options=flags("-c:a:{n} aac -b:a:{n} 192k"),
+            fallback_name="aac",
+        ),
+        "subtitle": StreamRule(
+            copy_mask=TEXT_SUBTITLE_CODECS,
+            # A cheap in-kind transcode, not a literal copy: MOV only holds
+            # text subtitles as its own mov_text, same as MP4.
+            accept_options=flags("-c:s:{n} mov_text"),
+            drop_reason="bitmap subtitles cannot be stored in MOV",
+        ),
+        # No "attachment" rule: MOV's muxer rejects any mapped attachment, so
+        # mapping "0:t?" only ever forces this cheap attempt to fail when the
+        # source has one. The type never reaches the success side, so it is
+        # exempted from the partial_mapping equality (FORCED_FAILURE_TYPES,
+        # docs/design/degradation-ladder.md, issue #39) rather than needing a
+        # drop-only rule here. An attachment-bearing source falls through to
+        # the selective rung, where the missing rule drops it with a real
+        # per-stream note via _structural_drop (converter/jobs.py).
+    },
+    last_resort=Attempt(
+        label="re-encode",
+        options=flags(
+            "-map 0:v:0? -map 0:a? "
+            "-c:v libx264 -crf 18 -preset medium -pix_fmt yuv420p "
+            "-c:a aac -b:a 192k"
+        ),
+        notes=(
+            "re-encoded to h264/aac (lossy); subtitles and extra video streams dropped",
+            "10-bit or HDR sources are reduced to 8-bit yuv420p for player compatibility",
+        ),
+    ),
+)
+
 MP3 = Profile(
     label="MP3",
     name="mp3",
@@ -418,7 +499,9 @@ FLAC = Profile(
 
 #: Target name -> profile. Built from each profile's own ``name`` rather than
 #: repeating it as a literal key, so the two can never drift apart.
-PROFILES: dict[str, Profile] = {profile.name: profile for profile in (MP4, WAV, MKV, MP3, FLAC)}
+PROFILES: dict[str, Profile] = {
+    profile.name: profile for profile in (MP4, WAV, MKV, MP3, FLAC, MOV)
+}
 
 #: The curated set of suffixes discovery walks (`docs/design/source-selection.md`):
 #: a file is a candidate only if its suffix is in this set, never discovered from

--- a/docs/specs/spec-video-formats.md
+++ b/docs/specs/spec-video-formats.md
@@ -363,3 +363,31 @@ New-Item -ItemType Directory -Force in
   (issues #39/#40); `tests/test_profiles.py` adds `MKV` to `SHIPPED` with an
   empty entry in both exemption dicts, so the existing parametrized invariant
   tests check it machine-side rather than by review.
+
+- 2026-08-26 (issue #28): Added the `mov` `Profile` -- THE motivating case for
+  the `FORCED_FAILURE_TYPES` exemption issue #39 wrote (`docs/design/
+  degradation-ladder.md`): its cheap attempt maps `attachment` via `-map 0:t?`
+  deliberately, but declares no `attachment` rule, because MOV's muxer rejects
+  any mapped attachment outright. Re-measured against real ffmpeg 9.0 while
+  implementing, every muxer fact in the Prior decisions table above held
+  exactly as written: the video mask excludes vp9, av1 *and* vp8 while
+  including ffv1 and theora; the audio mask includes dts and pcm_s16le; a
+  mov_text-transcoded subtitle round-trips on the cheap attempt itself; and an
+  attachment-bearing source fails the cheap attempt (`-map 0:t?` plus `-c
+  copy` on a font stream MOV cannot mux) and lands on the selective rung,
+  which drops it with a real per-stream note -- confirmed end-to-end through
+  the CLI against a font-attached MKV source, ffprobing the MOV output to
+  confirm the attachment stream is gone rather than checking by eye. No spec
+  correction was needed this time, unlike issue #27's `mkv` mov_text finding.
+
+  The stand-in fixture `MOV_SHAPED` (`tests/test_profiles.py`) is retired now
+  that the real `mov` profile proves the force-failure exemption directly --
+  `MOV` joins `SHIPPED` and `INVARIANT_CASES`, with
+  `FORCED_FAILURE_TYPES[MOV.name] == frozenset({"attachment"})` and an empty
+  `MUXER_ENFORCED_LIMIT_TYPES` entry -- the same retirement shape PR #53 used
+  for `MP3_SHAPED` once `MP3` and `FLAC` shipped. `jobs.py` needed no change:
+  the missing `attachment` rule already routes through `_structural_drop`'s
+  existing "no rule for this type" branch, so the per-stream drop note falls
+  out of the engine that shipped for `mp4`'s attachment case rather than
+  needing new logic, keeping the PR's diff to `converter/profiles.py`,
+  `README.md`, `docs/specs/spec-video-formats.md` and `tests/`.

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -7,7 +7,7 @@ import pytest
 
 from converter import ffmpegtool, jobs
 from converter.ffmpegtool import Stream, build_argv, cli_path
-from converter.profiles import FLAC, MKV, MP3, MP4, WAV
+from converter.profiles import FLAC, MKV, MOV, MP3, MP4, WAV
 
 
 def options_of(argv: list[str], src: str, dst: str) -> list[str]:
@@ -593,6 +593,176 @@ class TestMkvDegradationNotes:
         )
 
 
+class TestMovRemux:
+    def test_maps_every_stream_type_including_attachments(self):
+        """`0:t?` is mapped deliberately so an attachment-bearing source fails
+        this attempt (Acceptance, spec-video-formats.md)."""
+        options = jobs.first_attempt(MOV).options
+
+        assert options == (
+            "-map",
+            "0:v?",
+            "-map",
+            "0:a?",
+            "-map",
+            "0:s?",
+            "-map",
+            "0:t?",
+            "-c",
+            "copy",
+            "-c:s",
+            "mov_text",
+            "-movflags",
+            "+faststart",
+        )
+
+    def test_does_not_use_bare_map_zero(self):
+        options = list(jobs.first_attempt(MOV).options)
+        mapped = [options[i + 1] for i, flag in enumerate(options) if flag == "-map"]
+
+        assert "0" not in mapped
+        assert mapped == ["0:v?", "0:a?", "0:s?", "0:t?"]
+
+    def test_target_suffix(self):
+        assert MOV.target_suffix == ".mov"
+
+
+class TestMovRetries:
+    def test_ladder_ends_with_a_full_reencode(self):
+        attempts = jobs.retries(MOV, [Stream(0, "video", "h264")])
+
+        assert [a.label for a in attempts] == ["selective", "re-encode"]
+
+    def test_selective_copies_compatible_streams(self):
+        streams = [Stream(0, "video", "h264"), Stream(1, "audio", "aac")]
+
+        selective = jobs.retries(MOV, streams)[0]
+
+        assert selective.options[:8] == (
+            "-map",
+            "0:0",
+            "-map",
+            "0:1",
+            "-c:v:0",
+            "copy",
+            "-c:a:0",
+            "copy",
+        )
+        assert selective.notes == ()
+
+    def test_selective_reencodes_vp9_video_mov_cannot_hold(self):
+        """The likeliest copy-paste mistake in the phase: MOV rejects vp9
+        (and av1, and vp8) unlike MP4 (Acceptance, spec-video-formats.md)."""
+        streams = [Stream(0, "video", "vp9"), Stream(1, "audio", "aac")]
+
+        selective = jobs.retries(MOV, streams)[0]
+
+        assert "-c:v:0" in selective.options
+        assert selective.options[selective.options.index("-c:v:0") + 1] == "libx264"
+        assert selective.notes == ("video stream 0 (vp9) re-encoded to h264",)
+
+    def test_selective_reencodes_audio_mov_cannot_hold(self):
+        streams = [Stream(0, "video", "h264"), Stream(1, "audio", "opus")]
+
+        selective = jobs.retries(MOV, streams)[0]
+
+        assert "-c:a:0" in selective.options
+        assert selective.options[selective.options.index("-c:a:0") + 1] == "aac"
+        assert selective.notes == ("audio stream 1 (opus) re-encoded to aac",)
+
+    def test_selective_transcodes_text_subtitle_to_mov_text(self):
+        streams = [Stream(0, "video", "h264"), Stream(1, "subtitle", "subrip")]
+
+        selective = jobs.retries(MOV, streams)[0]
+
+        assert "-c:s:0" in selective.options
+        assert selective.options[selective.options.index("-c:s:0") + 1] == "mov_text"
+        assert selective.notes == ()
+
+    def test_selective_drops_bitmap_subtitles_with_a_note(self):
+        streams = [
+            Stream(0, "video", "h264"),
+            Stream(1, "audio", "aac"),
+            Stream(2, "subtitle", "hdmv_pgs_subtitle"),
+        ]
+
+        selective = jobs.retries(MOV, streams)[0]
+
+        assert "0:2" not in selective.options
+        assert selective.notes == (
+            "subtitle stream 2 (hdmv_pgs_subtitle) dropped: "
+            "bitmap subtitles cannot be stored in MOV",
+        )
+
+    def test_selective_drops_an_attachment_via_the_ladder_with_a_note(self):
+        """The point of the phase: MOV has no `attachment` rule, so an
+        attachment that reached the ladder (because the cheap attempt's
+        mapped `0:t?` made MOV reject it outright) is dropped here with a
+        real per-stream note instead of a blanket one."""
+        streams = [Stream(0, "video", "h264"), Stream(1, "attachment", "unknown")]
+
+        selective = jobs.retries(MOV, streams)[0]
+
+        assert "0:1" not in selective.options
+        assert selective.notes == ("attachment stream 1 (unknown) dropped: not supported by MOV",)
+
+    def test_reencode_states_what_it_sacrifices(self):
+        reencode = jobs.retries(MOV, [])[-1]
+
+        assert "libx264" in reencode.options
+        assert "aac" in reencode.options
+        assert reencode.notes
+        assert any("lossy" in note for note in reencode.notes)
+
+
+class TestMovDegradationNotes:
+    """Verification (spec-video-formats): one test per degradation branch this
+    profile introduces, each pinning the exact note."""
+
+    def test_video_reencode_note_is_exact(self):
+        streams = [Stream(0, "video", "vp9"), Stream(1, "audio", "aac")]
+
+        selective = jobs.retries(MOV, streams)[0]
+
+        assert selective.notes == ("video stream 0 (vp9) re-encoded to h264",)
+
+    def test_audio_reencode_note_is_exact(self):
+        streams = [Stream(0, "video", "h264"), Stream(1, "audio", "opus")]
+
+        selective = jobs.retries(MOV, streams)[0]
+
+        assert selective.notes == ("audio stream 1 (opus) re-encoded to aac",)
+
+    def test_bitmap_subtitle_drop_note_is_exact(self):
+        streams = [
+            Stream(0, "video", "h264"),
+            Stream(1, "audio", "aac"),
+            Stream(2, "subtitle", "hdmv_pgs_subtitle"),
+        ]
+
+        selective = jobs.retries(MOV, streams)[0]
+
+        assert selective.notes == (
+            "subtitle stream 2 (hdmv_pgs_subtitle) dropped: "
+            "bitmap subtitles cannot be stored in MOV",
+        )
+
+    def test_attachment_drop_note_is_exact(self):
+        streams = [Stream(0, "video", "h264"), Stream(1, "attachment", "unknown")]
+
+        selective = jobs.retries(MOV, streams)[0]
+
+        assert selective.notes == ("attachment stream 1 (unknown) dropped: not supported by MOV",)
+
+    def test_last_resort_notes_are_pinned(self):
+        reencode = jobs.retries(MOV, [])[-1]
+
+        assert reencode.notes == (
+            "re-encoded to h264/aac (lossy); subtitles and extra video streams dropped",
+            "10-bit or HDR sources are reduced to 8-bit yuv420p for player compatibility",
+        )
+
+
 class TestProfileArgvPinning:
     """Verification: the full argv each profile builds, pinned byte-for-byte
     (docs/specs/spec-profile-registry.md)."""
@@ -730,6 +900,66 @@ class TestProfileArgvPinning:
             "-b:a:0",
             "192k",
             "out.mkv",
+        ]
+
+    def test_mov_copyable_source(self):
+        streams = [Stream(0, "video", "h264"), Stream(1, "audio", "aac")]
+        selective = jobs.retries(MOV, streams)[0]
+
+        argv = build_argv("ffmpeg", "in.mts", selective.options, "out.mov")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mts",
+            "-map",
+            "0:0",
+            "-map",
+            "0:1",
+            "-c:v:0",
+            "copy",
+            "-c:a:0",
+            "copy",
+            "-movflags",
+            "+faststart",
+            "out.mov",
+        ]
+
+    def test_mov_non_copyable_source(self):
+        streams = [Stream(0, "video", "vp9"), Stream(1, "audio", "opus")]
+        selective = jobs.retries(MOV, streams)[0]
+
+        argv = build_argv("ffmpeg", "in.mts", selective.options, "out.mov")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mts",
+            "-map",
+            "0:0",
+            "-map",
+            "0:1",
+            "-c:v:0",
+            "libx264",
+            "-crf:v:0",
+            "18",
+            "-c:a:0",
+            "aac",
+            "-b:a:0",
+            "192k",
+            "-movflags",
+            "+faststart",
+            "out.mov",
         ]
 
     def test_wav_two_audio_source(self):
@@ -924,6 +1154,7 @@ class TestSuccessSideVerification:
         assert jobs.needs_verification(MP4) is True
         assert jobs.needs_verification(WAV) is True
         assert jobs.needs_verification(MKV) is True
+        assert jobs.needs_verification(MOV) is True
 
     def test_an_exhaustive_profile_does_not(self):
         """`False` is what keeps the probe off an exhaustive profile's happy path."""
@@ -941,7 +1172,7 @@ class TestSuccessSideVerification:
 
         assert notes == ("audio stream 1 (opus) dropped: WAV holds 1 audio stream",)
 
-    @pytest.mark.parametrize("profile", [MP4, WAV, MKV], ids=lambda profile: profile.label)
+    @pytest.mark.parametrize("profile", [MP4, WAV, MKV, MOV], ids=lambda profile: profile.label)
     def test_no_profile_invents_a_loss_for_a_source_it_fully_maps(self, profile):
         """One stream of each type the profile declares a rule for, and never more
         than one, so nothing in this source can have been left behind.
@@ -949,9 +1180,9 @@ class TestSuccessSideVerification:
         Built from ``profile.rules`` rather than the cheap attempt's own
         ``mapped_types`` (`tests/test_profiles.py`), which is sound only because
         ``TestPartialMappingInvariant`` there pins the two as equal for every
-        shipped profile -- if that equality ever broke for `MP4`, `WAV` or `MKV`,
-        this source would silently stop matching what the cheap attempt actually
-        maps.
+        shipped profile (modulo `MOV`'s force-failure exemption for
+        `attachment`) -- if that equality ever broke, this source would
+        silently stop matching what the cheap attempt actually maps.
         """
         streams = [Stream(i, kind, "whatever") for i, kind in enumerate(profile.rules)]
 

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -11,6 +11,7 @@ from converter import profiles
 from converter.profiles import (
     FLAC,
     MKV,
+    MOV,
     MP3,
     MP4,
     PROFILES,
@@ -30,47 +31,26 @@ from converter.profiles import (
 MAP_LETTERS = {"v": "video", "a": "audio", "s": "subtitle", "t": "attachment", "d": "data"}
 
 #: Every profile the registry ships. A new one joins the invariant checks here.
-SHIPPED = [MP4, WAV, MKV, MP3, FLAC]
-
-#: A stand-in for the not-yet-shipped `mov` profile (`docs/specs/spec-video-formats.md`),
-#: shaped only enough to prove the degradation-ladder invariant's narrowed form:
-#: it maps `attachment` via `-map 0:t?` -- exactly `mov`'s pinned cheap attempt --
-#: but declares no `attachment` rule, because MOV's muxer rejects any mapped
-#: attachment outright. An attachment-bearing source fails the cheap attempt and
-#: is routed into the ladder instead of reaching the success-side check, so the
-#: type never needs a rule to keep that check honest (issue #39).
-MOV_SHAPED = Profile(
-    label="MOV (shaped)",
-    name="mov-shaped",
-    description="Stand-in for the invariant test, not a shipped profile",
-    target_suffix=".mov",
-    container_options=(),
-    cheap_attempt=Attempt(
-        label="remux",
-        options=flags("-map 0:v? -map 0:a? -map 0:s? -map 0:t? -c copy -c:s mov_text"),
-    ),
-    explicit_streams=False,
-    partial_mapping=True,
-    rules={
-        "video": StreamRule(copy_mask=frozenset({"h264"}), accept_options=flags("-c:v:{n} copy")),
-        "audio": StreamRule(copy_mask=frozenset({"aac"}), accept_options=flags("-c:a:{n} copy")),
-        "subtitle": StreamRule(
-            copy_mask=frozenset(), accept_options=(), drop_reason="not modelled here"
-        ),
-    },
-)
+SHIPPED = [MP4, WAV, MKV, MP3, FLAC, MOV]
 
 #: Stream types each profile maps only to *force* the cheap attempt to fail when
 #: the source carries one -- never to carry it on the success side. The narrowed
 #: invariant (`docs/design/degradation-ladder.md`) exempts these from needing a
 #: rule: a type mapped to force a failure never reaches the success-side check.
+#: `mov` is THE motivating case for this exemption (issue #39): it maps
+#: `attachment` via `-map 0:t?` -- MOV's muxer rejects any mapped attachment
+#: outright -- but declares no `attachment` rule, since an attachment-bearing
+#: source fails the cheap attempt and is routed into the ladder instead of
+#: reaching the success-side check. Previously proven by a stand-in fixture,
+#: `MOV_SHAPED`; retired now that the real profile proves it directly, the same
+#: way `MP3_SHAPED` was retired by PR #53.
 FORCED_FAILURE_TYPES: dict[str, frozenset[str]] = {
     MP4.name: frozenset(),
     WAV.name: frozenset(),
     MKV.name: frozenset(),
     MP3.name: frozenset(),
     FLAC.name: frozenset(),
-    MOV_SHAPED.name: frozenset({"attachment"}),
+    MOV.name: frozenset({"attachment"}),
 }
 
 #: Stream types whose `stream_limit` is enforced by the container's own muxer
@@ -91,7 +71,7 @@ MUXER_ENFORCED_LIMIT_TYPES: dict[str, frozenset[str]] = {
     MKV.name: frozenset(),
     MP3.name: frozenset({"audio"}),
     FLAC.name: frozenset({"audio"}),
-    MOV_SHAPED.name: frozenset(),
+    MOV.name: frozenset(),
 }
 
 
@@ -149,13 +129,12 @@ def named_index_counts(profile: Profile) -> dict[str, int]:
     return counts
 
 
-#: `SHIPPED` plus the one remaining stand-in, so the invariant is checked
-#: against profiles that actually exercise both exemptions -- otherwise the
-#: narrowed reading and a stricter one would agree on every case tested. The
-#: muxer-enforced `stream_limit` exemption no longer needs a stand-in of its
-#: own: `MP3` and `FLAC` now prove it directly (`docs/specs/spec-audio-formats.md`),
-#: which is what retired the `MP3_SHAPED` fixture this list used to carry.
-INVARIANT_CASES = [*SHIPPED, MOV_SHAPED]
+#: Exactly `SHIPPED`: both exemptions are now proven by shipped profiles rather
+#: than a stand-in -- `MP3` and `FLAC` prove the muxer-enforced `stream_limit`
+#: exemption (`docs/specs/spec-audio-formats.md`, which retired `MP3_SHAPED`),
+#: and `MOV` now proves the force-failure exemption the same way, retiring
+#: `MOV_SHAPED`.
+INVARIANT_CASES = SHIPPED
 
 
 @pytest.mark.parametrize("profile", INVARIANT_CASES, ids=lambda profile: profile.label)
@@ -469,6 +448,90 @@ class TestMkvProfile:
         assert rule.stream_limit is None
 
 
+class TestMovProfile:
+    """Pins the shape Acceptance fixes for `mov` (issue #28,
+    `docs/specs/spec-video-formats.md`)."""
+
+    def test_label_and_suffix(self):
+        assert MOV.label == "MOV"
+        assert MOV.target_suffix == ".mov"
+
+    def test_name_and_description(self):
+        assert MOV.name == "mov"
+        assert MOV.description
+
+    def test_container_options_carry_faststart_once(self):
+        assert MOV.container_options == ("-movflags", "+faststart")
+
+    def test_cheap_attempt_selects_streams_blindly(self):
+        assert MOV.explicit_streams is False
+
+    def test_cheap_attempt_maps_every_stream_type_including_attachments(self):
+        """`0:t?` is mapped deliberately: MOV rejects a mapped attachment, so
+        an attachment-bearing source fails into the ladder instead of being
+        carried (Acceptance, spec-video-formats.md)."""
+        assert MOV.cheap_attempt.options == (
+            "-map",
+            "0:v?",
+            "-map",
+            "0:a?",
+            "-map",
+            "0:s?",
+            "-map",
+            "0:t?",
+            "-c",
+            "copy",
+            "-c:s",
+            "mov_text",
+        )
+
+    def test_cheap_attempt_is_declared_partial(self):
+        assert MOV.partial_mapping is True
+
+    def test_cheap_attempt_carries_the_standing_note(self):
+        assert MOV.cheap_attempt.notes == ("data and timecode streams are not carried into MOV",)
+
+    def test_last_resort_excludes_container_options(self):
+        assert MOV.last_resort is not None
+        assert MOV.last_resort.label == "re-encode"
+        assert "-movflags" not in MOV.last_resort.options
+
+    def test_has_exactly_the_three_stream_rules(self):
+        """No `attachment` rule: mapping `0:t?` only ever forces a failure,
+        never carries one on the success side (FORCED_FAILURE_TYPES above)."""
+        assert set(MOV.rules) == {"video", "audio", "subtitle"}
+
+    def test_video_and_audio_rules_carry_the_position_placeholder(self):
+        for stream_type in ("video", "audio"):
+            rule = MOV.rules[stream_type]
+            assert "{n}" in " ".join(rule.accept_options)
+            assert rule.fallback_options is not None
+            assert "{n}" in " ".join(rule.fallback_options)
+
+    def test_video_mask_excludes_vp9_and_av1_unlike_mp4(self):
+        """The likeliest copy-paste mistake in the phase (Acceptance,
+        spec-video-formats.md): MOV rejects vp9, av1 *and* vp8, while MP4
+        accepts vp9 and av1."""
+        assert "vp9" not in MOV.rules["video"].copy_mask
+        assert "av1" not in MOV.rules["video"].copy_mask
+        assert "vp8" not in MOV.rules["video"].copy_mask
+        assert "vp9" in MP4.rules["video"].copy_mask
+        assert "av1" in MP4.rules["video"].copy_mask
+
+    def test_video_mask_includes_ffv1_and_theora(self):
+        assert {"ffv1", "theora"} <= MOV.rules["video"].copy_mask
+
+    def test_audio_mask_includes_dts_and_pcm_s16le(self):
+        assert {"dts", "pcm_s16le"} <= MOV.rules["audio"].copy_mask
+
+    def test_subtitle_rule_transcodes_to_mov_text_and_has_no_fallback(self):
+        rule = MOV.rules["subtitle"]
+
+        assert rule.accept_options == ("-c:s:{n}", "mov_text")
+        assert rule.fallback_options is None
+        assert rule.drop_reason == "bitmap subtitles cannot be stored in MOV"
+
+
 class TestMp3Profile:
     """Pins the shape Acceptance fixes for `mp3` (issue #21,
     `docs/specs/spec-audio-formats.md`)."""
@@ -576,6 +639,7 @@ class TestRegistry:
             "mkv": MKV,
             "mp3": MP3,
             "flac": FLAC,
+            "mov": MOV,
         }
 
 
@@ -595,8 +659,14 @@ class TestResolveTarget:
         assert resolve_target("mp3") is MP3
         assert resolve_target("flac") is FLAC
 
+    @pytest.mark.parametrize("target", ["mov", "MOV", ".mov", ".MOV", "Mov"])
+    def test_accepts_mov_name_case_and_dot_variants(self, target):
+        assert resolve_target(target) is MOV
+
     def test_unknown_target_raises_value_error_listing_available_targets(self):
-        with pytest.raises(ValueError, match=r"webm.*available targets: flac, mkv, mp3, mp4, wav"):
+        with pytest.raises(
+            ValueError, match=r"webm.*available targets: flac, mkv, mov, mp3, mp4, wav"
+        ):
             resolve_target("webm")
 
 


### PR DESCRIPTION
## Summary
- Adds the `mov` `Profile`: video mask excludes vp9/av1/vp8 (keeps ffv1/theora), audio mask adds dts/pcm_s16le over MP4's, subtitle rule transcodes text in kind to `mov_text` and drops bitmap with a note.
- `0:t?` is mapped deliberately: MOV rejects a mapped attachment outright, so an attachment-bearing source fails the cheap attempt into the ladder, where the missing `attachment` rule drops it with a real per-stream note — `mov` is THE motivating case for the `FORCED_FAILURE_TYPES` exemption (issue #39).
- Retires the `MOV_SHAPED` stand-in fixture in `tests/test_profiles.py` now that the real profile proves the exemption directly (same shape as `MP3_SHAPED`'s retirement in #53).
- Decision-log entry in `docs/specs/spec-video-formats.md` records the real-ffmpeg 9.0 re-measurement: every Prior-decisions muxer fact held as written, no spec correction needed this time.

## Test plan
- [x] `scripts/verify.py` green (lint, format, 431 tests)
- [x] Real ffmpeg 9.0 smoke test via the CLI: copyable h264/aac source, a vp9/opus non-copyable source, and a font-attachment-bearing source, plus a subrip-subtitled source
  - copyable source: cheap attempt succeeds, standing note printed
  - non-copyable source: video+audio re-encoded, notes match
  - attachment-bearing source: cheap attempt fails, ladder names `attachment stream 2 (ttf) dropped: not supported by MOV`; confirmed via `ffprobe` that the output MOV has no attachment stream
  - subtitled source: `mov_text` transcode succeeds on the cheap attempt itself
  - re-run over the converted tree: `0 converted, 3 skipped`, exit 0
- [x] Diff touches only `converter/profiles.py`, `README.md`, `docs/specs/spec-video-formats.md` and `tests/`

Closes #28

https://claude.ai/code/session_013pdnJyntsFJyawGBSGj4cV