### PR TITLE
feat(profiles): gif, webp and avif targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ installed version supports; today that is:
 
 ```
 Target formats:
+  avif  .avif  Image: force-encoded to AVIF; a multi-frame source is reduced to a single frame
   bmp   .bmp  Image: force-encoded to BMP, lossless
   flac  .flac  Audio: single stream, lossless FLAC
+  gif   .gif  Image: force-encoded to GIF, animated; a photograph is reduced to 256 colours
   jpg   .jpg  Image: force-encoded to JPEG; transparency is not carried
   mkv   .mkv  Video: copies almost every codec as-is, keeps font attachments
   mov   .mov  Video: copies compatible streams, re-encodes the rest to h264/aac; no attachments
@@ -25,6 +27,7 @@ Target formats:
   png   .png  Image: force-encoded to PNG, lossless
   tiff  .tiff  Image: force-encoded to TIFF, lossless
   wav   .wav  Audio: single stream, uncompressed 16-bit PCM
+  webp  .webp  Image: copies compatible streams, animated; falls back to WebP re-encode
 ```
 
 More target formats can be added — see [Contributing](#contributing).

--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -648,10 +648,156 @@ BMP = Profile(
     ),
 )
 
+#: Phase 5 (`docs/specs/spec-image-formats.md`): the animated-capable trio.
+#: ``gif`` and ``webp`` write every frame of a multi-frame source -- an
+#: animation, not a still -- so unlike the image2 four above, neither carries a
+#: frame limit anywhere. ``avif``'s muxer silently keeps only one frame no
+#: matter what is asked of it (measured: dropping ``-still-picture 1`` still
+#: yields one frame), so its reduction can only ever be *named*, never avoided,
+#: which is why it carries a standing note instead of a `last_resort` shaped
+#: around extraction.
+#:
+#: ``webp``'s muxer self-polices (a non-matching codec copy exits 127, "webp
+#: muxer supports only codec webp"), so it keeps a bare ``-c copy`` cheap
+#: attempt safely -- it loses neither alpha nor frames, so no standing note's
+#: reachability depends on which rung wins. ``gif`` and ``avif`` are different:
+#: their drafted copy-based cheap attempt only ever won for a source already in
+#: that format, the one input with nothing to lose, so both force their encoder
+#: instead -- the cheap attempt then always wins and both standing notes always
+#: print. Measured, this costs `gif` only CPU (a GIF source re-encodes through
+#: `-c:v gif` pixel-identically) and costs `avif` a real generation loss plus
+#: several seconds per already-AVIF file, accepted so its transparency and
+#: frame losses are named rather than left silent.
+#:
+#: All three still declare `stream_limit=1`: none of these muxers holds more
+#: than one video *stream* (a second one -- cover art beside an animation --
+#: fails the cheap attempt outright), which is orthogonal to how many *frames*
+#: the one stream it does hold may carry.
+GIF = Profile(
+    label="GIF",
+    name="gif",
+    description="Image: force-encoded to GIF, animated; a photograph is reduced to 256 colours",
+    target_suffix=".gif",
+    container_options=(),
+    cheap_attempt=Attempt(
+        label="force-encode",
+        options=flags("-map 0:v? -c:v gif"),
+        # Standing notes, not fallback-branch ones: this cheap attempt always
+        # wins (it forces the encoder unconditionally), so it is the only rung
+        # whose notes are ever actually reported for the overwhelming majority
+        # of inputs -- the same shape JPG's cheap-attempt note is.
+        notes=(
+            "transparency is not carried by GIF",
+            "colours are reduced to GIF's 256-colour palette",
+        ),
+    ),
+    explicit_streams=False,
+    partial_mapping=True,
+    rules={
+        "video": StreamRule(
+            copy_mask=frozenset({"gif"}),
+            accept_options=flags("-c:v copy"),
+            fallback_options=flags("-c:v gif"),
+            # Declared, unlike PNG/TIFF/BMP: GIF is a 256-colour palette format,
+            # not a lossless one, so the selective rung's re-encode branch must
+            # name the quantisation the same way JPG's "mjpeg" does.
+            fallback_name="gif",
+            stream_limit=1,
+        ),
+    },
+    last_resort=Attempt(
+        label="re-encode",
+        options=flags("-map 0:v:0 -c:v gif"),
+        notes=(
+            # Repeats the cheap attempt's own standing notes: this rung is only
+            # reached when that attempt failed, so its notes never printed --
+            # the same reasoning JPG's last_resort carries its transparency
+            # note for.
+            "transparency is not carried by GIF",
+            "the image was re-quantised to GIF's 256-colour palette",
+            "non-video streams, and any video stream beyond the first, are not carried into GIF",
+        ),
+    ),
+)
+
+#: WebP's muxer self-polices and loses neither alpha nor frames (measured), so
+#: it is the one target in this trio that keeps a bare copy-based cheap
+#: attempt -- see the block comment above GIF for the full reasoning.
+WEBP = Profile(
+    label="WEBP",
+    name="webp",
+    description="Image: copies compatible streams, animated; falls back to WebP re-encode",
+    target_suffix=".webp",
+    container_options=(),
+    cheap_attempt=Attempt(label="remux", options=flags("-map 0:v? -c copy")),
+    explicit_streams=False,
+    partial_mapping=True,
+    rules={
+        "video": StreamRule(
+            copy_mask=frozenset({"webp"}),
+            accept_options=flags("-c:v copy"),
+            fallback_options=flags("-c:v libwebp -quality:v 80"),
+            # Declared: the fallback is a real, lossy re-encode (quality 80),
+            # unlike PNG/TIFF/BMP's lossless one, so it must be named.
+            fallback_name="webp",
+            stream_limit=1,
+        ),
+    },
+    last_resort=Attempt(
+        label="re-encode",
+        options=flags("-map 0:v:0 -c:v libwebp -quality:v 80"),
+        notes=(
+            "the image was re-encoded to WebP (lossy)",
+            "non-video streams, and any video stream beyond the first, are not carried into WEBP",
+        ),
+    ),
+)
+
+AVIF = Profile(
+    label="AVIF",
+    name="avif",
+    description="Image: force-encoded to AVIF; a multi-frame source is reduced to a single frame",
+    target_suffix=".avif",
+    container_options=(),
+    cheap_attempt=Attempt(
+        label="force-encode",
+        options=flags("-map 0:v? -c:v libaom-av1 -crf:v 30 -still-picture 1"),
+        # Standing notes: the cheap attempt always wins (forced encoder), so
+        # this is the only place AVIF's one silent loss this phase cannot
+        # avoid -- the muxer keeps one frame no matter what is asked of it --
+        # is ever actually named.
+        notes=(
+            "transparency is not carried by AVIF",
+            "a multi-frame source is reduced to a single frame",
+        ),
+    ),
+    explicit_streams=False,
+    partial_mapping=True,
+    rules={
+        "video": StreamRule(
+            copy_mask=frozenset({"av1"}),
+            accept_options=flags("-c:v copy"),
+            fallback_options=flags("-c:v libaom-av1 -crf:v 30 -still-picture 1"),
+            fallback_name="av1",
+            stream_limit=1,
+        ),
+    },
+    last_resort=Attempt(
+        label="re-encode",
+        options=flags("-map 0:v:0 -c:v libaom-av1 -crf 30 -still-picture 1"),
+        notes=(
+            "transparency is not carried by AVIF",
+            "a multi-frame source is reduced to a single frame",
+            "non-video streams, and any video stream beyond the first, are not carried into AVIF",
+        ),
+    ),
+)
+
 #: Target name -> profile. Built from each profile's own ``name`` rather than
 #: repeating it as a literal key, so the two can never drift apart.
 PROFILES: dict[str, Profile] = {
-    profile.name: profile for profile in (MP4, WAV, MKV, MOV, MP3, FLAC, PNG, JPG, TIFF, BMP)
+    profile.name: profile
+    for profile in (MP4, WAV, MKV, MOV, MP3, FLAC, PNG, JPG, TIFF, BMP, GIF, WEBP, AVIF)
 }
 
 #: The curated set of suffixes discovery walks (`docs/design/source-selection.md`):

--- a/docs/specs/spec-image-formats.md
+++ b/docs/specs/spec-image-formats.md
@@ -384,3 +384,35 @@ New-Item -ItemType Directory -Force in
   attempt whose standing note would otherwise have named it. Re-verified
   against real ffmpeg 9.0 with an h264+aac source: the audio-drop note now
   prints where it previously printed nothing.
+- 2026-08-26: Issue #35 landed the animated-capable trio -- `gif`, `webp`,
+  `avif` -- exactly as this spec's resolved decisions pin: `gif` and `avif`
+  force their encoder (`-map 0:v? -c:v gif` /
+  `-map 0:v? -c:v libaom-av1 -crf:v 30 -still-picture 1`) so their standing
+  notes always print; `webp` alone keeps `-map 0:v? -c copy`; masks
+  `{gif}`/`{av1}`/`{webp}`, `accept_options=flags("-c:v copy")`,
+  `stream_limit=1` (muxer-enforced, not mapping-enforced -- added to
+  `MUXER_ENFORCED_LIMIT_TYPES` alongside the image2 four, since none of these
+  three muxers holds more than one video *stream* either), `container_options
+  =()`, and `fallback_name` declared for all three (`"gif"`, `"webp"`,
+  `"av1"`). Neither `gif` nor `webp` carries a frame limit anywhere. Each
+  `last_resort` repeats its cheap attempt's standing notes plus what the
+  explicit `-map 0:v:0` index cannot reach, the same shape issue #34's review
+  established. Re-verified against real ffmpeg 9.0 with four fixtures (a flat
+  still, an alpha still, a 20-frame h264 clip, and a 20-frame GIF source):
+  `--to gif` and `--to webp` both write all 20 frames of the video source
+  (`ffprobe -count_frames` confirms it), `--to avif` writes a single-frame
+  primary item for every source and both standing notes print unconditionally
+  as designed. One thing this measurement adds to the muxer-facts table:
+  ffmpeg 9's AVIF muxer, given a multi-frame source with `-still-picture 1`,
+  writes the primary displayed item as one frame but *also* retains the full
+  encoded frame sequence in a second, non-primary stream inside the same file
+  (`ffprobe -show_streams` lists it as stream index 1, `nb_frames=20`,
+  `DISPOSITION:still_image=0`) -- not exposed as the picture an AVIF viewer
+  shows, so the "reduced to a single frame" note still describes what is
+  actually displayed accurately, and if anything undersells what the file
+  retains on disk rather than overselling it. The `last_resort` argv pinned
+  above uses `-crf 30` (no `:v`) rather than the cheap attempt's `-crf:v 30`,
+  per this spec's own Decision row -- confirmed non-cosmetic and equally
+  valid against real ffmpeg (`-map 0:v:0` already selects the one stream a
+  bare `-crf` would apply to). A second run over the converted fixtures
+  reports `0 converted, 4 skipped`, exit 0.

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -7,7 +7,7 @@ import pytest
 
 from converter import ffmpegtool, jobs
 from converter.ffmpegtool import Stream, build_argv, cli_path
-from converter.profiles import BMP, FLAC, JPG, MKV, MOV, MP3, MP4, PNG, TIFF, WAV
+from converter.profiles import AVIF, BMP, FLAC, GIF, JPG, MKV, MOV, MP3, MP4, PNG, TIFF, WAV, WEBP
 
 
 def options_of(argv: list[str], src: str, dst: str) -> list[str]:
@@ -1499,6 +1499,317 @@ class TestImageProfileArgvPinning:
         assert last_resort.notes == (
             "only the first frame was kept; BMP cannot hold more than one image",
             "non-video streams, and any video stream beyond the first, are not carried into BMP",
+        )
+
+
+class TestAnimatedProfileArgvPinning:
+    """Verification (spec-image-formats.md): the full argv `gif`, `webp` and
+    `avif` build, pinned byte-for-byte, for a copyable and a non-copyable
+    input each. `gif` and `avif` force their encoder on the cheap attempt, the
+    same exception png/jpg/tiff/bmp carry; `webp` alone keeps a real copy
+    there, so its copyable case is reached on the cheap attempt itself rather
+    than only on the selective rung. All three reach their selective rung the
+    same way png/jpg/tiff/bmp do: a second video stream trips the
+    muxer-enforced `stream_limit=1` and forces the cheap attempt to fail."""
+
+    def test_gif_cheap_attempt_forces_the_encoder(self):
+        argv = build_argv("ffmpeg", "in.png", jobs.first_attempt(GIF).options, "out.gif")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.png",
+            "-map",
+            "0:v?",
+            "-c:v",
+            "gif",
+            "out.gif",
+        ]
+
+    def test_gif_copyable_source_on_the_selective_rung(self):
+        streams = [Stream(0, "video", "gif"), Stream(1, "video", "h264")]
+        selective = jobs.retries(GIF, streams)[0]
+
+        argv = build_argv("ffmpeg", "in.mkv", selective.options, "out.gif")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:0",
+            "-c:v",
+            "copy",
+            "out.gif",
+        ]
+        assert selective.notes == ("video stream 1 (h264) dropped: GIF holds 1 video stream",)
+
+    def test_gif_non_copyable_source_on_the_selective_rung(self):
+        streams = [Stream(0, "video", "h264"), Stream(1, "video", "h264")]
+        selective = jobs.retries(GIF, streams)[0]
+
+        argv = build_argv("ffmpeg", "in.mkv", selective.options, "out.gif")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:0",
+            "-c:v",
+            "gif",
+            "out.gif",
+        ]
+        assert selective.notes == (
+            "video stream 0 (h264) re-encoded to gif",
+            "video stream 1 (h264) dropped: GIF holds 1 video stream",
+        )
+
+    def test_gif_last_resort_argv(self):
+        streams = [Stream(0, "video", "h264"), Stream(1, "video", "h264")]
+        last_resort = jobs.retries(GIF, streams)[-1]
+
+        argv = build_argv("ffmpeg", "in.mkv", last_resort.options, "out.gif")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:v:0",
+            "-c:v",
+            "gif",
+            "out.gif",
+        ]
+        assert last_resort.notes == (
+            "transparency is not carried by GIF",
+            "the image was re-quantised to GIF's 256-colour palette",
+            "non-video streams, and any video stream beyond the first, are not carried into GIF",
+        )
+
+    def test_webp_cheap_attempt_keeps_a_real_copy(self):
+        argv = build_argv("ffmpeg", "in.webp", jobs.first_attempt(WEBP).options, "out.webp")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.webp",
+            "-map",
+            "0:v?",
+            "-c",
+            "copy",
+            "out.webp",
+        ]
+
+    def test_webp_copyable_source_on_the_selective_rung(self):
+        streams = [Stream(0, "video", "webp"), Stream(1, "video", "h264")]
+        selective = jobs.retries(WEBP, streams)[0]
+
+        argv = build_argv("ffmpeg", "in.mkv", selective.options, "out.webp")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:0",
+            "-c:v",
+            "copy",
+            "out.webp",
+        ]
+        assert selective.notes == ("video stream 1 (h264) dropped: WEBP holds 1 video stream",)
+
+    def test_webp_non_copyable_source_on_the_selective_rung(self):
+        streams = [Stream(0, "video", "h264"), Stream(1, "video", "h264")]
+        selective = jobs.retries(WEBP, streams)[0]
+
+        argv = build_argv("ffmpeg", "in.mkv", selective.options, "out.webp")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:0",
+            "-c:v",
+            "libwebp",
+            "-quality:v",
+            "80",
+            "out.webp",
+        ]
+        assert selective.notes == (
+            "video stream 0 (h264) re-encoded to webp",
+            "video stream 1 (h264) dropped: WEBP holds 1 video stream",
+        )
+
+    def test_webp_last_resort_argv(self):
+        streams = [Stream(0, "video", "h264"), Stream(1, "video", "h264")]
+        last_resort = jobs.retries(WEBP, streams)[-1]
+
+        argv = build_argv("ffmpeg", "in.mkv", last_resort.options, "out.webp")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:v:0",
+            "-c:v",
+            "libwebp",
+            "-quality:v",
+            "80",
+            "out.webp",
+        ]
+        assert last_resort.notes == (
+            "the image was re-encoded to WebP (lossy)",
+            "non-video streams, and any video stream beyond the first, are not carried into WEBP",
+        )
+
+    def test_avif_cheap_attempt_forces_the_encoder(self):
+        argv = build_argv("ffmpeg", "in.png", jobs.first_attempt(AVIF).options, "out.avif")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.png",
+            "-map",
+            "0:v?",
+            "-c:v",
+            "libaom-av1",
+            "-crf:v",
+            "30",
+            "-still-picture",
+            "1",
+            "out.avif",
+        ]
+
+    def test_avif_copyable_source_on_the_selective_rung(self):
+        streams = [Stream(0, "video", "av1"), Stream(1, "video", "h264")]
+        selective = jobs.retries(AVIF, streams)[0]
+
+        argv = build_argv("ffmpeg", "in.mkv", selective.options, "out.avif")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:0",
+            "-c:v",
+            "copy",
+            "out.avif",
+        ]
+        assert selective.notes == ("video stream 1 (h264) dropped: AVIF holds 1 video stream",)
+
+    def test_avif_non_copyable_source_on_the_selective_rung(self):
+        streams = [Stream(0, "video", "h264"), Stream(1, "video", "h264")]
+        selective = jobs.retries(AVIF, streams)[0]
+
+        argv = build_argv("ffmpeg", "in.mkv", selective.options, "out.avif")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:0",
+            "-c:v",
+            "libaom-av1",
+            "-crf:v",
+            "30",
+            "-still-picture",
+            "1",
+            "out.avif",
+        ]
+        assert selective.notes == (
+            "video stream 0 (h264) re-encoded to av1",
+            "video stream 1 (h264) dropped: AVIF holds 1 video stream",
+        )
+
+    def test_avif_last_resort_argv(self):
+        streams = [Stream(0, "video", "h264"), Stream(1, "video", "h264")]
+        last_resort = jobs.retries(AVIF, streams)[-1]
+
+        argv = build_argv("ffmpeg", "in.mkv", last_resort.options, "out.avif")
+
+        assert argv == [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:v:0",
+            "-c:v",
+            "libaom-av1",
+            "-crf",
+            "30",
+            "-still-picture",
+            "1",
+            "out.avif",
+        ]
+        assert last_resort.notes == (
+            "transparency is not carried by AVIF",
+            "a multi-frame source is reduced to a single frame",
+            "non-video streams, and any video stream beyond the first, are not carried into AVIF",
         )
 
 

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -9,8 +9,10 @@ import pytest
 
 from converter import profiles
 from converter.profiles import (
+    AVIF,
     BMP,
     FLAC,
+    GIF,
     JPG,
     MKV,
     MOV,
@@ -21,6 +23,7 @@ from converter.profiles import (
     SOURCE_SUFFIXES,
     TIFF,
     WAV,
+    WEBP,
     Attempt,
     Profile,
     StreamRule,
@@ -35,7 +38,7 @@ from converter.profiles import (
 MAP_LETTERS = {"v": "video", "a": "audio", "s": "subtitle", "t": "attachment", "d": "data"}
 
 #: Every profile the registry ships. A new one joins the invariant checks here.
-SHIPPED = [MP4, WAV, MKV, MOV, MP3, FLAC, PNG, JPG, TIFF, BMP]
+SHIPPED = [MP4, WAV, MKV, MOV, MP3, FLAC, PNG, JPG, TIFF, BMP, GIF, WEBP, AVIF]
 
 #: Stream types each profile maps only to *force* the cheap attempt to fail when
 #: the source carries one -- never to carry it on the success side. The narrowed
@@ -59,6 +62,9 @@ FORCED_FAILURE_TYPES: dict[str, frozenset[str]] = {
     JPG.name: frozenset(),
     TIFF.name: frozenset(),
     BMP.name: frozenset(),
+    GIF.name: frozenset(),
+    WEBP.name: frozenset(),
+    AVIF.name: frozenset(),
 }
 
 #: Stream types whose `stream_limit` is enforced by the container's own muxer
@@ -88,6 +94,16 @@ MUXER_ENFORCED_LIMIT_TYPES: dict[str, frozenset[str]] = {
     JPG.name: frozenset({"video"}),
     TIFF.name: frozenset({"video"}),
     BMP.name: frozenset({"video"}),
+    # gif, webp and avif self-police the same way: none of these muxers holds
+    # more than one video *stream* (a second one -- cover art beside an
+    # animation -- fails the cheap attempt outright), so a source that would
+    # trip the limit never reaches the success side either. Orthogonal to how
+    # many *frames* the one stream they do hold may carry -- gif and webp
+    # write every frame, and neither carries a frame limit anywhere
+    # (spec-image-formats.md).
+    GIF.name: frozenset({"video"}),
+    WEBP.name: frozenset({"video"}),
+    AVIF.name: frozenset({"video"}),
 }
 
 
@@ -823,6 +839,195 @@ class TestBmpProfile:
         assert BMP.cheap_attempt.options == ("-map", "0:v?", "-c:v", "bmp")
 
 
+#: The animated-capable trio: unlike the image2 four, none of these carries a
+#: frame limit anywhere -- `gif` and `webp` write every frame of a multi-frame
+#: source, and `avif`'s reduction to one frame is the muxer's own doing, not
+#: something a `-frames:v` flag chooses.
+ANIMATED_CASES = [GIF, WEBP, AVIF]
+
+
+@pytest.mark.parametrize("profile", ANIMATED_CASES, ids=lambda profile: profile.label)
+class TestAnimatedTrioShape:
+    """Shared shape across gif, webp and avif (spec-image-formats.md)."""
+
+    def test_cheap_attempt_maps_video_blindly(self, profile):
+        assert profile.cheap_attempt.options[:2] == ("-map", "0:v?")
+
+    def test_cheap_attempt_selects_streams_blindly(self, profile):
+        assert profile.explicit_streams is False
+
+    def test_cheap_attempt_is_declared_partial(self, profile):
+        assert profile.partial_mapping is True
+
+    def test_has_exactly_one_video_rule(self, profile):
+        assert set(profile.rules) == {"video"}
+
+    def test_video_rule_accept_options_force_a_real_copy(self, profile):
+        assert profile.rules["video"].accept_options == ("-c:v", "copy")
+
+    def test_video_rule_is_placeholder_free(self, profile):
+        rule = profile.rules["video"]
+
+        assert "{n}" not in " ".join(rule.accept_options)
+        assert rule.fallback_options is not None
+        assert "{n}" not in " ".join(rule.fallback_options)
+
+    def test_video_rule_stream_limit_is_one(self, profile):
+        """Muxer-enforced, not mapping-enforced: none of these three holds more
+        than one video *stream* -- orthogonal to how many frames that one
+        stream may carry (MUXER_ENFORCED_LIMIT_TYPES above)."""
+        assert profile.rules["video"].stream_limit == 1
+
+    def test_no_container_options(self, profile):
+        assert profile.container_options == ()
+
+    def test_last_resort_carries_no_frame_limit(self, profile):
+        """Verification: neither gif nor webp carries a frame limit anywhere,
+        and avif's reduction to one frame is the muxer's own doing -- none of
+        the three last resorts adds a `-frames:v` flag."""
+        assert profile.last_resort is not None
+        assert "-frames:v" not in profile.last_resort.options
+
+    def test_last_resort_names_what_the_explicit_index_cannot_reach(self, profile):
+        assert any("non-video streams" in note for note in profile.last_resort.notes)
+
+
+class TestGifProfile:
+    def test_label_and_suffix(self):
+        assert GIF.label == "GIF"
+        assert GIF.target_suffix == ".gif"
+
+    def test_name_and_description(self):
+        assert GIF.name == "gif"
+        assert GIF.description
+
+    def test_cheap_attempt_argv(self):
+        assert GIF.cheap_attempt.options == ("-map", "0:v?", "-c:v", "gif")
+
+    def test_cheap_attempt_always_wins_so_its_standing_notes_always_print(self):
+        """Forces the encoder unconditionally, so this is the rung whose notes
+        actually print for the overwhelming majority of inputs."""
+        assert GIF.cheap_attempt.notes == (
+            "transparency is not carried by GIF",
+            "colours are reduced to GIF's 256-colour palette",
+        )
+
+    def test_video_rule_copy_mask_is_its_own_codec(self):
+        assert GIF.rules["video"].copy_mask == frozenset({"gif"})
+
+    def test_fallback_name_is_declared(self):
+        """GIF is a 256-colour palette format, not a lossless one, unlike
+        png/tiff/bmp -- the quantisation must be named."""
+        assert GIF.rules["video"].fallback_name == "gif"
+
+    def test_last_resort_argv(self):
+        assert GIF.last_resort is not None
+        assert GIF.last_resort.options == ("-map", "0:v:0", "-c:v", "gif")
+
+    def test_last_resort_repeats_the_standing_notes(self):
+        """Only reached when the cheap attempt failed, so its standing notes
+        never printed -- the same reasoning JPG's last_resort repeats its
+        transparency note for."""
+        assert GIF.last_resort is not None
+        assert "transparency is not carried by GIF" in GIF.last_resort.notes
+        assert any("re-quantised" in note for note in GIF.last_resort.notes)
+
+
+class TestWebpProfile:
+    def test_label_and_suffix(self):
+        assert WEBP.label == "WEBP"
+        assert WEBP.target_suffix == ".webp"
+
+    def test_name_and_description(self):
+        assert WEBP.name == "webp"
+        assert WEBP.description
+
+    def test_cheap_attempt_keeps_a_real_copy(self):
+        """The one target in this trio whose muxer self-polices cleanly enough
+        (a non-matching codec copy exits 127) to keep a bare copy, unlike gif
+        and avif which force their encoder instead."""
+        assert WEBP.cheap_attempt.options == ("-map", "0:v?", "-c", "copy")
+
+    def test_cheap_attempt_carries_no_standing_note(self):
+        """Loses neither alpha nor frames, so no note's reachability depends
+        on which rung wins."""
+        assert WEBP.cheap_attempt.notes == ()
+
+    def test_video_rule_copy_mask_is_its_own_codec(self):
+        assert WEBP.rules["video"].copy_mask == frozenset({"webp"})
+
+    def test_fallback_name_is_declared(self):
+        """The fallback is a real, lossy re-encode (quality 80), unlike
+        png/tiff/bmp's lossless one."""
+        assert WEBP.rules["video"].fallback_name == "webp"
+
+    def test_last_resort_argv(self):
+        assert WEBP.last_resort is not None
+        assert WEBP.last_resort.options == (
+            "-map",
+            "0:v:0",
+            "-c:v",
+            "libwebp",
+            "-quality:v",
+            "80",
+        )
+
+
+class TestAvifProfile:
+    def test_label_and_suffix(self):
+        assert AVIF.label == "AVIF"
+        assert AVIF.target_suffix == ".avif"
+
+    def test_name_and_description(self):
+        assert AVIF.name == "avif"
+        assert AVIF.description
+
+    def test_cheap_attempt_argv(self):
+        assert AVIF.cheap_attempt.options == (
+            "-map",
+            "0:v?",
+            "-c:v",
+            "libaom-av1",
+            "-crf:v",
+            "30",
+            "-still-picture",
+            "1",
+        )
+
+    def test_cheap_attempt_always_wins_so_its_standing_notes_always_print(self):
+        """The one loss in this phase no failure path can hang a per-stream
+        note on: the muxer keeps one frame no matter what is asked of it, even
+        on the cheap attempt for an AV1-in-MP4 source."""
+        assert AVIF.cheap_attempt.notes == (
+            "transparency is not carried by AVIF",
+            "a multi-frame source is reduced to a single frame",
+        )
+
+    def test_video_rule_copy_mask_is_its_own_codec(self):
+        assert AVIF.rules["video"].copy_mask == frozenset({"av1"})
+
+    def test_fallback_name_is_declared(self):
+        assert AVIF.rules["video"].fallback_name == "av1"
+
+    def test_last_resort_argv(self):
+        assert AVIF.last_resort is not None
+        assert AVIF.last_resort.options == (
+            "-map",
+            "0:v:0",
+            "-c:v",
+            "libaom-av1",
+            "-crf",
+            "30",
+            "-still-picture",
+            "1",
+        )
+
+    def test_last_resort_repeats_the_standing_notes(self):
+        assert AVIF.last_resort is not None
+        assert "transparency is not carried by AVIF" in AVIF.last_resort.notes
+        assert "a multi-frame source is reduced to a single frame" in AVIF.last_resort.notes
+
+
 class TestRegistry:
     def test_keys_are_each_profile_s_own_name(self):
         assert PROFILES == {
@@ -836,6 +1041,9 @@ class TestRegistry:
             "jpg": JPG,
             "tiff": TIFF,
             "bmp": BMP,
+            "gif": GIF,
+            "webp": WEBP,
+            "avif": AVIF,
         }
 
 
@@ -860,7 +1068,16 @@ class TestResolveTarget:
         assert resolve_target(target) is MOV
 
     @pytest.mark.parametrize(
-        ("target", "profile"), [("png", PNG), ("jpg", JPG), ("tiff", TIFF), ("bmp", BMP)]
+        ("target", "profile"),
+        [
+            ("png", PNG),
+            ("jpg", JPG),
+            ("tiff", TIFF),
+            ("bmp", BMP),
+            ("gif", GIF),
+            ("webp", WEBP),
+            ("avif", AVIF),
+        ],
     )
     def test_resolves_the_image_targets(self, target, profile):
         assert resolve_target(target) is profile
@@ -868,7 +1085,10 @@ class TestResolveTarget:
     def test_unknown_target_raises_value_error_listing_available_targets(self):
         with pytest.raises(
             ValueError,
-            match=r"webm.*available targets: bmp, flac, jpg, mkv, mov, mp3, mp4, png, tiff, wav",
+            match=(
+                r"webm.*available targets: avif, bmp, flac, gif, jpg, mkv, mov, "
+                r"mp3, mp4, png, tiff, wav, webp"
+            ),
         ):
             resolve_target("webm")
 


### PR DESCRIPTION
## Summary

- Adds the animated-capable trio -- `gif`, `webp`, `avif` -- completing all
  seven image profiles this milestone (`docs/specs/spec-image-formats.md`)
  covers.
- `gif` and `avif` force their encoder in the cheap attempt so their standing
  notes always print; `webp` alone keeps a bare `-c copy` since its muxer
  self-polices and it loses neither alpha nor frames.
- Neither `gif` nor `webp` carries a frame limit anywhere -- both write every
  frame of a multi-frame source, unlike the image2 four already shipped.

## Test plan

- [x] `scripts/verify.py` green (lint, format, 627 tests).
- [x] Argv pinned for a copyable and a non-copyable input, per target
      (`tests/test_argv.py::TestAnimatedProfileArgvPinning`).
- [x] Standing-note wording pinned per target
      (`tests/test_profiles.py::TestGifProfile` /
      `TestWebpProfile` / `TestAvifProfile`).
- [x] Smoke-tested against real ffmpeg 9.0 with four fixtures (flat still,
      alpha still, 20-frame h264 clip, 20-frame GIF source): `--to gif` and
      `--to webp` both write genuinely animated 20-frame outputs
      (`ffprobe -count_frames`), `--to avif` reduces to a one-frame primary
      item with both losses named, and a second run reports
      `0 converted, 4 skipped`, exit 0. Findings recorded in the spec's
      decision log.
- [x] Diff touches only `converter/profiles.py`, `README.md`,
      `docs/specs/spec-image-formats.md` (decision log) and `tests/`.

Closes #35