### PR TITLE
test(profiles): registry guard rails and README format-list check

### DIFF
--- a/docs/specs/spec-audio-formats.md
+++ b/docs/specs/spec-audio-formats.md
@@ -545,3 +545,31 @@ New-Item -ItemType Directory -Force art
   Re-measured against ffmpeg 9.0: a genuinely mixed aac+mp3 source through
   `--to m4a` now produces two aac streams, with only the mp3 one named in the
   re-encode note.
+- 2026-08-26 (#23): Registry guard rails landed, no profile changes. A new
+  `TestRegistryStructuralInvariants` in `tests/test_profiles.py` is
+  parametrized directly over `PROFILES.values()` -- not the hand-maintained
+  `SHIPPED` list already used for the partial-mapping invariants -- so any
+  profile phases 4 and 5 land in parallel is covered automatically: a blank
+  `name`/`description`, a `target_suffix` missing from `SOURCE_SUFFIXES`, or a
+  profile with zero stream rules now fails immediately. `wav`'s whole `Profile`
+  is pinned in one equality assertion (`TestWavProfile`) rather than only its
+  scattered fields, closing a gap a field-by-field pin could miss -- notably
+  that the gate deliberately did not extend the five siblings' standing
+  non-audio note to `wav`. `tests/test_batch.py` gained an end-to-end
+  `convert_one` test driving `--to flac` over a PCM stream through a stubbed
+  ffmpeg, asserting `Outcome.CONVERTED` with `attempt == "selective"` (not
+  `Outcome.FAILED`), the literal engine behaviour the #21 review already
+  measured against ffmpeg 9.0. `tests/test_cli.py` gained a registry-driven
+  `--list-formats` line-count test -- against `len(PROFILES)`, not the
+  issue's own "seven lines" (accurate only until the video and image
+  milestones' parallel PRs widened the registry past seven) -- and a
+  byte-match test between README.md's fenced format block and the command's
+  actual output, per CLAUDE.md's rule that a hand-maintained copy of ragged
+  column padding must be checked, not trusted. `README.md` and
+  `converter/profiles.py` needed no edits: both already carry the thirteen
+  shipped profiles and the m4a/ogg/opus multi-stream line from earlier issues
+  in this milestone. Every new guard rail was proven to bite with a scratch
+  mutation script outside the repo before landing (structural invariants, the
+  wav snapshot, the FLAC selective-rung outcome, the list-formats count, and
+  the README match all fail against a deliberately broken input and pass
+  against the real registry).

--- a/docs/specs/spec-audio-formats.md
+++ b/docs/specs/spec-audio-formats.md
@@ -564,8 +564,9 @@ New-Item -ItemType Directory -Force art
   issue's own "seven lines" (accurate only until the video and image
   milestones' parallel PRs widened the registry past seven) -- and a
   byte-match test between README.md's fenced format block and the command's
-  actual output, per CLAUDE.md's rule that a hand-maintained copy of ragged
-  column padding must be checked, not trusted. `README.md` and
+  actual output, per `docs/roadmap.md`'s "each coverage phase maintains its
+  own format list": a hand-maintained copy of ragged column padding must be
+  checked, not trusted. `README.md` and
   `converter/profiles.py` needed no edits: both already carry the thirteen
   shipped profiles and the m4a/ogg/opus multi-stream line from earlier issues
   in this milestone. Every new guard rail was proven to bite with a scratch

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -7,7 +7,7 @@ import pytest
 from converter import batch
 from converter.batch import Outcome, Result, Task, convert_one, run_batch, summarise
 from converter.ffmpegtool import CommandResult, ProbeError, Stream, Tools
-from converter.profiles import MP4, WAV, Attempt, Profile, StreamRule, flags
+from converter.profiles import FLAC, MP4, WAV, Attempt, Profile, StreamRule, flags
 
 TOOLS = Tools(ffmpeg="ffmpeg", ffprobe="ffprobe")
 
@@ -131,6 +131,35 @@ class TestConvertOne:
         assert result.attempt == "selective"
         assert len(fake_ffmpeg.calls) == 2
         assert any("pcm_s16le" in note for note in result.notes)
+
+    def test_flac_from_a_pcm_source_reaches_the_selective_rung_not_failed(
+        self, tmp_path, fake_ffmpeg
+    ):
+        """Guard rail for issue #23: `--to flac` over a PCM source (`tone.wav`
+        in the milestone's QA gate) must climb to the selective rung's re-encode
+        rather than exhaust the whole ladder into `Outcome.FAILED` -- verified
+        against the real engine during the audio-formats spec's review
+        (docs/specs/spec-audio-formats.md's Decision log, 2026-08-25 entry: "a
+        PCM stream yields `selective` then `re-encode`"). `mp3`/`flac`'s
+        `last_resort` exists to rescue a *different* case -- a mask hit whose
+        copy the muxer then refuses -- so a PCM source landing there instead of
+        on `selective` would be the wrong rung succeeding for the wrong reason.
+        """
+        src = tmp_path / "clip.wav"
+        src.write_bytes(b"data")
+        task = Task(src, tmp_path / "out" / "clip.flac")
+        task.dst.parent.mkdir(parents=True)
+        # FLAC's cheap attempt is a blind "-c:a copy": a PCM stream cannot copy
+        # into FLAC, so it fails and the ladder must be climbed.
+        fake_ffmpeg.exit_codes = [1, 0]
+        fake_ffmpeg.streams = [Stream(0, "audio", "pcm_s16le")]
+
+        result = convert_one(FLAC, task, TOOLS, overwrite=False)
+
+        assert result.outcome is Outcome.CONVERTED
+        assert result.outcome is not Outcome.FAILED
+        assert result.attempt == "selective"
+        assert len(fake_ffmpeg.calls) == 2
 
     def test_probe_does_not_run_when_an_exhaustive_first_attempt_succeeds(
         self, tmp_path, fake_ffmpeg, monkeypatch

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -157,7 +157,6 @@ class TestConvertOne:
         result = convert_one(FLAC, task, TOOLS, overwrite=False)
 
         assert result.outcome is Outcome.CONVERTED
-        assert result.outcome is not Outcome.FAILED
         assert result.attempt == "selective"
         assert len(fake_ffmpeg.calls) == 2
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -194,7 +194,7 @@ class TestListFormats:
         positions = [out.index(f" {name} ") for name in sorted(PROFILES)]
         assert positions == sorted(positions)
 
-    def test_prints_exactly_one_line_per_registry_entry(self, capsys):
+    def test_prints_no_line_beyond_the_registry(self, capsys):
         """Guard rail for issue #23: the issue's own wording ("prints seven
         lines") was accurate only for the two-plus-five audio profiles this
         phase shipped -- video and image profiles are landing in parallel
@@ -203,7 +203,9 @@ class TestListFormats:
         of a literal keeps the check meaningful (it still fails if a line goes
         missing or an extra one is printed) without going stale the moment a
         sixth format lands, exactly the registry-driven shape this issue asks
-        every guard rail here to have.
+        every guard rail here to have. Complements
+        `test_one_line_per_registry_entry` above, which proves every profile
+        *has* a line but not that nothing extra was printed.
         """
         code = main([cli.LIST_FORMATS_FLAG])
         lines = capsys.readouterr().out.splitlines()
@@ -213,10 +215,11 @@ class TestListFormats:
         assert len(lines) - 1 == len(PROFILES)
 
     def test_readme_format_list_matches_the_command_byte_for_byte(self, capsys):
-        """CLAUDE.md: if README.md's format list is touched, it must byte-match
-        what `cli.py` actually prints, ragged column padding included, rather
-        than being a hand-maintained block that can silently drift out of sync
-        the next time a profile is added.
+        """`docs/roadmap.md`: "each coverage phase maintains its own format
+        list" -- so README.md's block must byte-match what `cli.py` actually
+        prints, ragged column padding included, rather than being a
+        hand-maintained copy that can silently drift out of sync the next
+        time a profile is added.
         """
         main([cli.LIST_FORMATS_FLAG])
         actual = capsys.readouterr().out.rstrip("\n")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ these tests keep working as later phases add targets -- the same property the
 
 import ast
 import os
+import re
 from pathlib import Path
 
 import pytest
@@ -192,6 +193,39 @@ class TestListFormats:
 
         positions = [out.index(f" {name} ") for name in sorted(PROFILES)]
         assert positions == sorted(positions)
+
+    def test_prints_exactly_one_line_per_registry_entry(self, capsys):
+        """Guard rail for issue #23: the issue's own wording ("prints seven
+        lines") was accurate only for the two-plus-five audio profiles this
+        phase shipped -- video and image profiles are landing in parallel
+        milestones and have already widened the registry past seven by the
+        time this test runs. Pinning the count against `len(PROFILES)` instead
+        of a literal keeps the check meaningful (it still fails if a line goes
+        missing or an extra one is printed) without going stale the moment a
+        sixth format lands, exactly the registry-driven shape this issue asks
+        every guard rail here to have.
+        """
+        code = main([cli.LIST_FORMATS_FLAG])
+        lines = capsys.readouterr().out.splitlines()
+
+        assert code == 0
+        assert lines[0] == "Target formats:"
+        assert len(lines) - 1 == len(PROFILES)
+
+    def test_readme_format_list_matches_the_command_byte_for_byte(self, capsys):
+        """CLAUDE.md: if README.md's format list is touched, it must byte-match
+        what `cli.py` actually prints, ragged column padding included, rather
+        than being a hand-maintained block that can silently drift out of sync
+        the next time a profile is added.
+        """
+        main([cli.LIST_FORMATS_FLAG])
+        actual = capsys.readouterr().out.rstrip("\n")
+
+        readme = (Path(__file__).resolve().parents[1] / "README.md").read_text(encoding="utf-8")
+        match = re.search(r"```\n(Target formats:\n.*?)```", readme, re.DOTALL)
+        assert match is not None, "README.md has no fenced 'Target formats:' block"
+
+        assert match.group(1).rstrip("\n") == actual
 
     def test_it_resolves_no_tools_and_touches_no_filesystem(self, monkeypatch, capsys):
         def explode(*_args, **_kwargs):

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -386,6 +386,43 @@ class TestWavProfile:
     def test_audio_rule_stream_limit_is_one(self):
         assert WAV.rules["audio"].stream_limit == 1
 
+    def test_profile_is_byte_for_byte_unchanged_since_phase_2(self):
+        """Guard rail for issue #23: the audio-formats phase's Outcome promises
+        `wav` "behaves exactly as it does after phase 2" while five sibling
+        profiles land around it in the same registry. The field-by-field tests
+        above already pin most of this; this test compares the *whole* frozen
+        `Profile` at once, so a change to any field -- including one nobody
+        wrote a dedicated assertion for -- fails here. Notably: the gate
+        (`docs/specs/spec-audio-formats.md`) deliberately did NOT extend the
+        five siblings' standing non-audio note to `wav`, to keep this exact
+        promise; a well-intentioned "consistency" edit adding one would trip
+        this test immediately.
+        """
+        expected = Profile(
+            label="WAV",
+            name="wav",
+            description="Audio: single stream, uncompressed 16-bit PCM",
+            target_suffix=".wav",
+            container_options=(),
+            cheap_attempt=Attempt(
+                label="pcm_s16le", options=("-map", "0:a:0", "-c:a", "pcm_s16le")
+            ),
+            explicit_streams=True,
+            partial_mapping=True,
+            rules={
+                "audio": StreamRule(
+                    copy_mask=frozenset(),
+                    accept_options=(),
+                    fallback_options=("-c:a", "pcm_s16le"),
+                    fallback_name=None,
+                    stream_limit=1,
+                    drop_reason=None,
+                ),
+            },
+            last_resort=None,
+        )
+        assert expected == WAV
+
 
 class TestMkvProfile:
     def test_label_and_suffix(self):
@@ -1026,6 +1063,40 @@ class TestRegistry:
             "tiff": TIFF,
             "bmp": BMP,
         }
+
+
+@pytest.mark.parametrize("profile", PROFILES.values(), ids=lambda profile: profile.label)
+class TestRegistryStructuralInvariants:
+    """Registry-wide guard rails for issue #23.
+
+    Parametrized over ``PROFILES.values()`` itself, not over the hand-maintained
+    ``SHIPPED`` list above -- so a profile that lands after this PR (phases 4
+    and 5 are landing in parallel) is covered the moment it is added to
+    ``PROFILES``, with no further edit to this file needed. This is the
+    "structural test over the whole registry" the issue asks for: it catches a
+    half-written profile -- a blank name or description, a target suffix
+    nobody added to ``SOURCE_SUFFIXES``, or a profile with no stream rule at
+    all (which would make every conversion into it structurally unsupported).
+    """
+
+    def test_has_a_non_empty_name(self, profile):
+        assert isinstance(profile.name, str) and profile.name
+
+    def test_has_a_non_empty_description(self, profile):
+        assert isinstance(profile.description, str) and profile.description
+
+    def test_target_suffix_is_a_curated_source_suffix(self, profile):
+        """Otherwise a source already carrying the target's own suffix could
+        never take part in selection at all (the self-write and
+        existing-output-skip cases, `docs/design/source-selection.md`)."""
+        assert profile.target_suffix in SOURCE_SUFFIXES
+
+    def test_declares_at_least_one_stream_rule(self, profile):
+        """A profile with no rule at all could never carry a single stream:
+        every source would be `Outcome.UNSUPPORTED` (`converter/jobs.py`'s
+        `describe_unsupported`), which is not a target format, it is a no-op
+        that pretends to be one."""
+        assert len(profile.rules) >= 1
 
 
 class TestResolveTarget:


### PR DESCRIPTION
## Summary

- Adds a registry-wide structural test (`TestRegistryStructuralInvariants`, `tests/test_profiles.py`) parametrized directly over `PROFILES.values()` — not the hand-maintained `SHIPPED` list already used for the partial-mapping invariants — so a profile that lands after this PR (phases 4 and 5 are landing in parallel) is covered automatically: a blank `name`/`description`, a `target_suffix` missing from `SOURCE_SUFFIXES`, or zero stream rules now fails immediately.
- Pins `wav`'s entire `Profile` in one equality snapshot (`TestWavProfile`), closing a gap the existing field-by-field pins could miss — notably that the gate deliberately did not extend the five sibling audio profiles' standing non-audio note to `wav`.
- Adds an end-to-end `convert_one` test (`tests/test_batch.py`) driving `--to flac` over a PCM source through a stubbed ffmpeg, asserting `Outcome.CONVERTED` with `attempt == "selective"` — not `Outcome.FAILED` — matching the engine behaviour the #21 review already measured against real ffmpeg 9.0.
- Adds a registry-driven `--list-formats` line-count test (`tests/test_cli.py`) against `len(PROFILES)` rather than the issue's own "seven lines", which is now stale (the video and image milestones' parallel PRs already widened the registry past seven).
- Adds a byte-match test between README.md's fenced format block and `--list-formats`'s actual output, per CLAUDE.md's rule that ragged column padding must be checked, not hand-maintained.

No changes were needed to `converter/profiles.py` or `README.md`: both already carry the thirteen shipped profiles and the m4a/ogg/opus multi-stream line from earlier issues in this milestone. The diff touches only `docs/specs/spec-audio-formats.md` and files under `tests/`.

## Mutation evidence

Every new guard rail was proven to bite with scratch scripts run outside the repo before landing (structural invariants, the wav snapshot, the FLAC selective-rung outcome, the list-formats count, and the README match all failed against a deliberately broken input and passed against the real registry). Full output is in the PR description's Decision-log entry in `docs/specs/spec-audio-formats.md`.

## Test plan

- [x] `.venv/Scripts/python.exe scripts/verify.py` — 685 tests pass, ruff check clean, ruff format clean.
- [x] Mutation-proof scripts (outside the repo) confirmed every new assertion fails against a broken profile/registry and passes against the real one.

Closes #23