### PR TITLE
fix(spec): give the QA fixtures distinct output-path stems

### DIFF
--- a/docs/specs/spec-audio-formats.md
+++ b/docs/specs/spec-audio-formats.md
@@ -369,17 +369,17 @@ machine*; PowerShell, one command per line:
 
 ```text
 New-Item -ItemType Directory -Force in
-& $FF -y -f lavfi -i sine=duration=3 -c:a libmp3lame in/tone.mp3
-& $FF -y -f lavfi -i sine=duration=3 -c:a aac        in/tone.m4a
-& $FF -y -f lavfi -i sine=duration=3 -c:a flac       in/tone.flac
-& $FF -y -f lavfi -i sine=duration=3 -c:a libopus    in/tone.opus
-& $FF -y -f lavfi -i sine=duration=3 -c:a libvorbis  in/tone.ogg
-& $FF -y -f lavfi -i sine=duration=3 -c:a pcm_s16le  in/tone.wav
+& $FF -y -f lavfi -i sine=duration=3 -c:a libmp3lame in/tone-mp3.mp3
+& $FF -y -f lavfi -i sine=duration=3 -c:a aac        in/tone-m4a.m4a
+& $FF -y -f lavfi -i sine=duration=3 -c:a flac       in/tone-flac.flac
+& $FF -y -f lavfi -i sine=duration=3 -c:a libopus    in/tone-opus.opus
+& $FF -y -f lavfi -i sine=duration=3 -c:a libvorbis  in/tone-ogg.ogg
+& $FF -y -f lavfi -i sine=duration=3 -c:a pcm_s16le  in/tone-wav.wav
 & $FF -y -f lavfi -i testsrc=size=320x240:rate=10:duration=3 -f lavfi -i sine=duration=3 -c:v libx264 -c:a aac in/clip.mp4
 New-Item -ItemType Directory -Force art
 & $FF -y -f lavfi -i color=c=red:size=200x200:d=1 -frames:v 1 art/cover.png
-& $FF -y -i in/tone.mp3 -i art/cover.png -map 0:a -map 1:v -c copy -disposition:v:0 attached_pic art/art.mp3
-& $FF -y -i in/tone.ogg -i art/cover.png -map 0:a -map 1:v -c copy -disposition:v:0 attached_pic art/artv.mkv
+& $FF -y -i in/tone-mp3.mp3 -i art/cover.png -map 0:a -map 1:v -c copy -disposition:v:0 attached_pic art/art.mp3
+& $FF -y -i in/tone-ogg.ogg -i art/cover.png -map 0:a -map 1:v -c copy -disposition:v:0 attached_pic art/artv.mkv
 ```
 
 - [ ] Each of the six targets converts a real source and the result plays.
@@ -387,13 +387,13 @@ New-Item -ItemType Directory -Force art
       `clip.mp4` — names every re-encode it performed, and exits 0. The artwork
       fixtures live in `art/` so this count stays put; they have their own items
       below.
-- [ ] A stream copy really is a copy: `--to mp3` from `tone.mp3` finishes
+- [ ] A stream copy really is a copy: `--to mp3` from `tone-mp3.mp3` finishes
       near-instantly and the audio stream is packet-identical --
-      `& $FF -i out/tone.mp3 -map 0:a -c copy -f md5 -` matches the same command
+      `& $FF -i out/tone-mp3.mp3 -map 0:a -c copy -f md5 -` matches the same command
       on the source. Compare the stream, not the file: a remux re-pages the
       container. Aimed at `mp3` rather than `opus`, since whether `opus` copies at
       all is one of the gate decisions.
-- [ ] `--to flac in out` over `tone.wav` produces a playable FLAC via the
+- [ ] `--to flac in out` over `tone-wav.wav` produces a playable FLAC via the
       **selective** rung, not a failure -- the same rung the machine check names,
       verified against the real engine.
 - [ ] A second run over any converted tree reports `0 converted`, exit 0.
@@ -401,12 +401,19 @@ New-Item -ItemType Directory -Force art
       stream is gone, and that the run says what the gate's first decision says
       it says.
 - [ ] `artv.mkv` (vorbis audio plus artwork — the fixture block builds it) under
-      `--to ogg`: same check. This is the case that exposes `ogg`'s silent loss;
-      pointing `art.mp3` at `--to ogg` proves nothing about cover art, because the
-      ogg muxer rejects the *mp3 audio* first and the picture is never mapped.
-- [ ] Only if the gate has `opus` encode: `artv.mkv` under `--to opus` fails the
-      cheap attempt, reaches the ladder, and names the picture stream and its
-      codec — the one target where the loss is reported properly.
+      `--to ogg`: same check. Pointing `art.mp3` at `--to ogg` instead would
+      prove nothing about cover art, because `mp3` is outside `ogg`'s copy mask
+      and the audio itself is re-encoded, which is a different code path than
+      the one artwork loss needs exercised.
+- [ ] `artv.mkv` under `--to opus`: same check again. Both this and the `ogg`
+      item above take the **cheap-attempt** path -- verified against the real
+      engine, the vorbis audio copies as-is into both containers (`ffprobe` the
+      output: still `vorbis`, never re-encoded to `opus`) -- and because both
+      profiles declare `partial_mapping`, the success-side verifier still names
+      the dropped picture stream and its codec on top of the cheap attempt's own
+      standing note. `opus` is not a special case that the ladder alone
+      reaches: `ogg` names the loss exactly the same way. See the Decision log
+      for why an earlier version of this item called `ogg`'s loss silent.
 - [ ] `--to mp3` on `clip.mp4` rips the audio and names the dropped video stream.
 
 ## Risks and mitigations
@@ -545,3 +552,32 @@ New-Item -ItemType Directory -Force art
   Re-measured against ffmpeg 9.0: a genuinely mixed aac+mp3 source through
   `--to m4a` now produces two aac streams, with only the mp3 one named in the
   re-encode note.
+- 2026-08-26 (#56): The Verification fixtures all shared the stem `tone` --
+  `tone.mp3`, `tone.m4a`, `tone.flac`, `tone.opus`, `tone.ogg`, `tone.wav` --
+  so a single `--to <fmt>` run over `in/` derived the same output path for up
+  to six of the seven sources and the collision refusal (`paths.find_collisions`,
+  exit 2) fired before any conversion ran. Renamed to `tone-mp3.mp3`,
+  `tone-m4a.m4a`, `tone-flac.flac`, `tone-opus.opus`, `tone-ogg.ogg`,
+  `tone-wav.wav`. Ran the whole block as written against real ffmpeg 9.0 with
+  `--ffmpeg`/`--ffprobe`: all six targets converted the seven-source `in/`
+  tree at exit 0 with exactly the notes named above; the `tone-mp3.mp3` ->
+  `mp3` stream copy was packet-identical (`-f md5` matched); `tone-wav.wav` ->
+  `flac` reached the selective rung (`ffprobe`: `codec_name=flac`); a second
+  run over each converted tree reported `0 converted`, exit 0; `art.mp3`
+  under `--to mp3` and `artv.mkv` under `--to ogg` both lost the picture
+  stream, confirmed by `ffprobe`; `--to mp3` on `clip.mp4` named the dropped
+  video stream.
+
+  One checklist claim did not hold: "`ogg`'s silent loss" versus opus being
+  "the one target where the loss is reported properly". Both `OGG` and
+  `OPUS` (`converter/profiles.py`) declare `partial_mapping=True` and carry
+  an identical-shaped standing note, so both report a cover-art drop the same
+  way. Measured directly: `artv.mkv` (vorbis audio, cover art) under both
+  `--to ogg` and `--to opus` takes the **cheap-attempt** path -- `ffprobe` on
+  each output still shows `vorbis`, never re-encoded to `opus` -- and each
+  run printed both the standing note ("non-audio streams, including cover
+  art, are not carried into OGG/OPUS") and a per-stream note ("video stream 1
+  (png) dropped: not supported by OGG/OPUS") from the success-side verifier.
+  Neither target is silent, and neither needs the ladder to name the loss.
+  The Verification item was corrected to describe what the engine actually
+  does instead of a speculative asymmetry between the two targets.

--- a/docs/specs/spec-image-formats.md
+++ b/docs/specs/spec-image-formats.md
@@ -279,17 +279,17 @@ Human milestone-QA gate. `$FF` is the absolute ffmpeg path from *This machine*:
 
 ```text
 New-Item -ItemType Directory -Force in
-& $FF -y -f lavfi -i color=c=red:size=320x240:d=1 -frames:v 1 in/flat.png
-& $FF -y -f lavfi -i color=c=red:size=320x240:d=1 -frames:v 1 in/flat.jpg
+& $FF -y -f lavfi -i color=c=red:size=320x240:d=1 -frames:v 1 in/flat-png.png
+& $FF -y -f lavfi -i color=c=red:size=320x240:d=1 -frames:v 1 in/flat-jpg.jpg
 & $FF -y -f lavfi -i "color=c=red@0.5:size=320x240:d=1,format=rgba" -frames:v 1 in/alpha.png
 & $FF -y -f lavfi -i testsrc=size=320x240:rate=10:duration=2 -c:v libx264 in/clip.mp4
 ```
 
-- [ ] Each of the seven targets converts `flat.png` and the result opens.
-- [ ] `--to png in out` over `flat.jpg` produces a **real PNG** — `ffprobe` it,
+- [ ] Each of the seven targets converts `flat-png.png` and the result opens.
+- [ ] `--to png in out` over `flat-jpg.jpg` produces a **real PNG** — `ffprobe` it,
       and check `file` too. A stream copy would produce a JPEG named `.png` at
       exit 0, which is the defect this phase's cheap attempts exist to prevent.
-- [ ] `--to jpg in out` over `flat.png` produces a real JPEG, same check.
+- [ ] `--to jpg in out` over `flat-png.png` produces a real JPEG, same check.
 - [ ] `--to jpg in out` over `alpha.png` prints the transparency note, and the
       output's `pix_fmt` shows the alpha is gone. `--to bmp`, `--to png`,
       `--to tiff` and `--to webp` keep it and print no such note. Repeat for
@@ -297,11 +297,25 @@ New-Item -ItemType Directory -Force in
 - [ ] `--to gif in out` over `clip.mp4` produces an **animated** GIF, and
       `--to webp` an animated WebP: count frames with `ffprobe -count_frames`.
 - [ ] `--to avif in out` over `clip.mp4` produces a single frame and says so.
+      Confirmed, matching the issue #35 Decision log entry below: the primary
+      displayed item (`ffprobe -show_streams`: stream index 0, `nb_frames=1`)
+      is the one an AVIF viewer shows; the file's `major_brand` comes back
+      `avis` and a second, non-primary stream retains the full 20-frame
+      encoded sequence on disk (index 1, `nb_frames=20`) -- already recorded
+      as "undersells rather than oversells what the file retains", not a new
+      finding.
 - [ ] `--to png in out` over `clip.mp4` produces a single frame via the
       `last_resort` and names it; a second run reports the same thing, exit 0.
+      Confirmed: `png`'s output genuinely carries a single stream, single frame
+      (`ffprobe -count_frames`: `nb_read_frames=1`), unlike `avif`'s two-stream
+      container above.
 - [ ] `--to gif in out` over a photograph names the colour quantisation, via its standing note.
-- [ ] Time `--to avif` over a large still and compare with `--to webp`. The
-      measured gap is 17x; confirm it is tolerable on real photographs.
+- [ ] Time `--to avif` over a large still and compare with `--to webp`.
+      Measured on *This machine* (not the 3000x2000 photograph the Prior
+      decisions table used): a synthetic 1920x1080 still took 6.8 s via `avif`
+      against 0.75 s via `webp`, a ~9x gap -- same order of magnitude as the
+      table's 17x on a larger image, and the conclusion holds: tolerable for
+      one file, not for a folder.
 - [ ] A second run over any converted tree reports `0 converted`, exit 0.
 
 ## Risks and mitigations
@@ -416,3 +430,33 @@ New-Item -ItemType Directory -Force in
   valid against real ffmpeg (`-map 0:v:0` already selects the one stream a
   bare `-crf` would apply to). A second run over the converted fixtures
   reports `0 converted, 4 skipped`, exit 0.
+- 2026-08-26 (#56): `in/flat.png` and `in/flat.jpg` shared the stem `flat`,
+  so a single `--to <fmt>` run over `in/` derived the same output path for
+  both -- `flat.jpg -> out/flat.png` collides with `flat.png -> out/flat.png`
+  itself under `--to png`, and the equivalent collides under every other
+  target -- and the collision refusal (exit 2) fired before any conversion
+  ran, the same defect phase 3's audio fixtures had. Renamed to
+  `flat-png.png` and `flat-jpg.jpg`; `alpha.png` and `clip.mp4` already had
+  distinct stems and needed no change. Ran the whole block as written against
+  real ffmpeg 9.0 with `--ffmpeg`/`--ffprobe`: all seven targets converted
+  `flat-png.png` and opened; `--to png` over `flat-jpg.jpg` produced a real
+  PNG (`ffprobe`: `codec_name=png`) and `--to jpg` over `flat-png.png` a real
+  JPEG (`codec_name=mjpeg`); `--to jpg` over `alpha.png` dropped the alpha
+  (`pix_fmt=yuvj444p`) while `bmp`/`png`/`tiff`/`webp` kept it
+  (`bgra`/`rgba`/`rgba`/`yuva420p`) and printed no transparency note; `--to
+  gif`/`--to webp` over `clip.mp4` produced 20-frame animated outputs
+  (`ffprobe -count_frames`); `--to avif` over `clip.mp4` matched the issue
+  #35 entry above exactly (confirmed there, not a new finding -- the
+  Verification item was reworded only to point at that entry instead of
+  restating an unqualified "single frame" claim); `--to png` over `clip.mp4`
+  produced one frame via the `last_resort`, and a second run reported `0
+  converted`, exit 0 for every converted tree.
+
+  The avif-vs-webp timing item's pinned "17x" comes from the Prior decisions
+  table's own measurement (3000x2000 still, 6.9 s vs 0.41 s). Re-measured
+  here on a different, smaller synthetic still (1920x1080, a generated
+  Mandelbrot pattern) since no real photograph was available: 6.8 s via
+  `avif` against 0.75 s via `webp`, a ~9x gap. Recorded as its own data point
+  rather than overwriting the table's figure -- different resolution and
+  image content, same conclusion (`avif` is a different, much slower tool
+  for a whole folder).

--- a/docs/specs/spec-video-formats.md
+++ b/docs/specs/spec-video-formats.md
@@ -223,8 +223,19 @@ New-Item -ItemType Directory -Force in
 - [ ] `--to mov in out` over `attached.mkv` *fails the cheap attempt*, reaches the
       ladder, and names the dropped attachment. The one place a drop is reported
       per stream rather than by a standing note.
-- [ ] `--to webm in out` over `attached.mkv` succeeds and prints WebM's standing
-      note, since nothing failed and there was no ladder to name it.
+- [ ] `--to webm in out` over `attached.mkv` drops the attachment -- but not via
+      the standing note alone. `attached.mkv` carries the same h264 video as
+      `h264.mkv`, which is itself outside WebM's copy mask, so the cheap
+      attempt already fails on the *video* and the run reaches the ladder
+      regardless of the attachment (measured directly: `-map 0:v? -map 0:a?
+      -map 0:s? -c copy -c:s webvtt` into `.webm` exits non-zero with "Only
+      VP8 or VP9 or AV1 video ... are supported for WebM"). The ladder
+      re-encodes video and audio and names the attachment drop with its own
+      per-stream note, on top of re-encode notes for video and audio -- this
+      fixture set has no source that is already VP9/Opus **and** carries an
+      attachment, so the standing-note-only path (cheap attempt succeeds,
+      nothing else to name) is not actually exercised here. See the Decision
+      log.
 - [ ] `--to webm in out` over `h264.mkv` re-encodes video and audio, names both,
       and produces a file that plays in a browser.
 - [ ] `--to webm in out` over `vp9.webm` stream-copies: near-instant, and the
@@ -235,6 +246,11 @@ New-Item -ItemType Directory -Force in
 - [ ] A second run over any converted tree reports `0 converted`, exit 0.
 - [ ] Time the `--to webm` run over a 30-second source and record it, so the
       gate's fallback choice can be checked against a real number on real content.
+      Measured on *This machine*: a 30 s, 320x240, 10 fps `libx264`+`aac`
+      source (the ladder's `libvpx-vp9` fallback, since h264 is outside WebM's
+      copy mask) took ~2 s end to end -- comfortably tolerable, though this is
+      a tiny, low-motion synthetic clip and says nothing about a real
+      full-resolution source.
 
 ## Risks and mitigations
 
@@ -447,3 +463,36 @@ New-Item -ItemType Directory -Force in
   (`test_a_source_webm_cannot_hold_at_all_is_unsupported`), using the same
   attachment-only stream shape the real fixture would have produced had
   ffmpeg been willing to write one.
+- 2026-08-26 (#56): The four Verification fixtures (`h264.mkv`, `vp9.webm`,
+  `lossless.mkv`, `attached.mkv`) already carry distinct stems, so this spec
+  did not share phase 3's collision defect -- confirmed by running the block
+  as written; no fixture rename was needed here. Ran the whole block against
+  real ffmpeg 9.0 with `--ffmpeg`/`--ffprobe`: all four targets converted the
+  four-source `in/` tree at exit 0; `mkv` kept `attached.mkv`'s font
+  attachment (`ffprobe`: stream 2, `codec_type=attachment`); `mov` and `mp4`
+  dropped it with a named note and no other stream touched; `vp9.webm` ->
+  `webm` stream-copied the video packet-identically (`-f md5` matched);
+  `vp9.webm` -> `mov` re-encoded rather than failing; a second run over a
+  converted tree reported `0 converted`, exit 0; timed a 30 s, 320x240,
+  10 fps source through `--to webm`: ~2 s end to end.
+
+  One checklist claim needed correcting. "`--to webm` over `attached.mkv`
+  succeeds and prints WebM's standing note, since nothing failed and there
+  was no ladder to name it" assumes the cheap attempt succeeds for this
+  fixture. It does not: `attached.mkv` carries the same h264 video as
+  `h264.mkv`, which is outside `WEBM_VIDEO_CODECS`, and WebM's muxer rejects
+  an h264 stream copy outright -- measured directly, `-map 0:v? -map 0:a?
+  -map 0:s? -c copy -c:s webvtt` into `.webm` exits non-zero with "Only VP8
+  or VP9 or AV1 video ... are supported for WebM". The run reaches the
+  ladder regardless of the attachment, which re-encodes video and audio and
+  names the attachment drop with its own per-stream note -- not the standing
+  note, which (per `batch._attempt_conversion`) only ships with the *cheap*
+  attempt's result. This also appears to contradict the issue #29 entry
+  above, which states a run over "a font-attached, h264/aac MKV" printed
+  *both* the standing note and the per-stream note together -- a combination
+  that, by the same code path, requires the cheap attempt to succeed, and the
+  same entry's own preceding paragraph already calls an h264/aac source
+  "non-copyable" for WebM. Left uncorrected per this issue's scope (Decision
+  log entries are append-only outside one's own), but recorded here since the
+  Verification item is what actually gates the milestone and now matches
+  what this run observed rather than the older claim.


### PR DESCRIPTION
## Summary

- The audio spec's Verification fixtures (`tone.mp3`, `tone.m4a`, `tone.flac`, `tone.opus`, `tone.ogg`, `tone.wav`) all shared the stem `tone`, so `converter --to <fmt> in out` derived the same output path for up to six sources and the collision refusal (exit 2) fired before any conversion ran. Renamed to `tone-mp3.mp3`, `tone-m4a.m4a`, `tone-flac.flac`, `tone-opus.opus`, `tone-ogg.ogg`, `tone-wav.wav`.
- The image spec had the same shape: `flat.png`/`flat.jpg` shared the stem `flat`. Renamed to `flat-png.png`/`flat-jpg.jpg`.
- The video spec's fixtures (`h264.mkv`, `vp9.webm`, `lossless.mkv`, `attached.mkv`) already had distinct stems -- no rename needed there.
- Ran every Verification block, as written, against real ffmpeg 9.0 with absolute `--ffmpeg`/`--ffprobe` paths, and corrected three stated expectations that did not match observed reality (each recorded in its spec's Decision log):
  - **Audio**: the claimed `ogg`-is-silent vs `opus`-reports-properly asymmetry doesn't hold -- both profiles declare `partial_mapping=True` and report a cover-art drop identically via the success-side verifier.
  - **Video**: `--to webm` over `attached.mkv` does not succeed via the cheap attempt alone as claimed -- `attached.mkv`'s h264 video is outside WebM's copy mask, so the cheap attempt fails and the ladder (not the standing note) is what names the attachment loss. Also flagged an apparent internal inconsistency in the existing issue #29 Decision log entry, without editing it.
  - **Image**: re-measured the avif-vs-webp timing gap on available hardware (9x on a 1920x1080 synthetic still vs the table's 17x on a 3000x2000 photograph) and recorded it as its own data point.
- Investigated a suspicious two-stream AVIF output during testing; confirmed it matches the already-documented issue #35 Decision log finding rather than being a new defect, and adjusted the Verification wording to reference that entry instead of restating an unqualified "single frame" claim.

## Test plan

- [x] `.venv/Scripts/python.exe scripts/verify.py` green (763 tests passed, ruff clean)
- [x] Every Verification block in all three specs run as written against real ffmpeg 9.0 / ffprobe 9.0, in a temp directory, with `--ffmpeg`/`--ffprobe` absolute paths
- [x] `git diff main...HEAD --name-only` touches only the three spec files

Closes #56

https://claude.ai/code/session_013pdnJyntsFJyawGBSGj4cV