### PR TITLE
test(profiles): cross-profile guard rails for the video-formats phase

### DIFF
--- a/docs/specs/spec-video-formats.md
+++ b/docs/specs/spec-video-formats.md
@@ -454,32 +454,62 @@ New-Item -ItemType Directory -Force in
   each of the three profiles' `last_resort is not None`, so those two
   acceptance bullets needed no new test -- re-implementing them would have
   been a second copy of an existing guard rail, the cost the parent task
-  explicitly warned against. Two bullets did need new work: `mp4` had no
-  whole-`Profile` snapshot test the way `wav` got in phase 3
-  (`test_profile_is_byte_for_byte_unchanged_since_phase_2`), even though three
-  siblings were landing in the same registry around it, so
-  `test_profile_is_byte_for_byte_unchanged_since_before_this_phase` closes
-  that gap the same way; and the README's format list already carried `mkv`,
-  `mov` and `webm` (added when their own issues landed), so that bullet was
-  already satisfied and needed no edit.
+  explicitly warned against. The "`mp4`'s argv and notes are byte-for-byte
+  unchanged" bullet was also already satisfied, by `tests/test_argv.py`'s
+  `TestProfileArgvPinning.test_mp4_copyable_source` /
+  `test_mp4_non_copyable_source` and `TestMp4DegradationNotes` -- all landed
+  in phase 2 (issue #11, `2455d3d`), well before this phase's three siblings.
+  What this PR adds instead, `TestMp4Profile.test_profile_is_byte_for_byte_unchanged_since_before_this_phase`,
+  is a different and additional thing: a snapshot of the whole declared
+  `Profile` object, the way `wav` got in phase 3
+  (`test_profile_is_byte_for_byte_unchanged_since_phase_2`) as its own
+  siblings landed -- not a substitute for the argv/notes pins, a companion to
+  them, covering fields (like each rule's `copy_mask`) that no argv-level test
+  exercises. And the README's format list already carried `mkv`, `mov` and
+  `webm` (added when their own issues landed), so that bullet was already
+  satisfied too and needed no edit.
 
-  Beyond the acceptance list, three genuinely cross-profile rails were added
-  to `TestRegistryStructuralInvariants`/a new `TestRegistryTargetCoherence`
-  class, targeting bug classes the per-profile tests structurally cannot catch
-  because each only ever looks at its own profile: (1) every `StreamRule`
-  whose `stream_limit` is `None` must carry ffmpeg's `{n}` position
-  placeholder in its codec options -- generalising issue #22's real bug
-  (an unindexed `-c:a copy` silently re-encoding an already-accepted stream,
+  Beyond the acceptance list, two genuinely cross-profile rails were added to
+  `TestRegistryStructuralInvariants`, targeting bug classes the per-profile
+  tests structurally cannot catch because each only ever looks at its own
+  profile: (1) every `StreamRule` not capped at one output stream of its type
+  (`stream_limit == 1`) must carry ffmpeg's `{n}` position placeholder in its
+  codec options, and `accept_options` itself must be non-empty rather than
+  merely skipped when falsy -- generalising issue #22's real bug (an
+  unindexed `-c:a copy` silently re-encoding an already-accepted stream,
   because ffmpeg's own unindexed codec options are not positional) to the
-  whole registry rather than the one profile that motivated it; (2) every
+  whole registry rather than the one profile that motivated it; and (2) every
   declared `last_resort` must carry at least one note -- generalising issue
   #34's real bug (the image `last_resort` dropping a stream type with no note
   at all, a direct violation of the constitution's "never report success for
-  a conversion that silently dropped something") the same way; and (3) no two
-  profiles in `PROFILES` may share a `target_suffix`. Mutation-tested outside
-  the repo against copies of `m4a`, `mkv` and `mov`/`mkv` respectively (a
-  stripped placeholder, an emptied `last_resort.notes`, a collided suffix) to
-  confirm each rail actually fails before trusting it to pass on the real,
-  unmutated registry. None of the three found a live bug in a shipped
-  profile -- every shipped profile already satisfies all three -- so this
-  closes a hole in the contract's test coverage, not a live defect.
+  a conversion that silently dropped something") the same way. A third rail,
+  in a new `TestRegistryTargetCoherence` class, asserts no two profiles in
+  `PROFILES` share a `target_suffix`. Mutation-tested outside the repo against
+  copies of `m4a`, `mkv` and `mov` respectively (a stripped placeholder, an
+  emptied `last_resort.notes`, a suffix collided with `mkv`'s) to confirm each
+  rail actually fails before trusting it to pass on the real, unmutated
+  registry. None of the three found a live bug in a shipped profile -- every
+  shipped profile already satisfies all three -- so this closes a hole in the
+  contract's test coverage, not a live defect.
+
+  Review (fresh Agent, this PR) measured that the first draft had two rails
+  that could not do what they claimed: the `mp4` snapshot imported
+  `MP4_VIDEO_CODECS`/`MP4_AUDIO_CODECS`/`TEXT_SUBTITLE_CODECS` and compared
+  them against themselves, so it passed even with a codec deleted from the
+  real constant (`X == X`) -- fixed by spelling the three masks out literally,
+  `wav`'s own precedent. A fourth rail this draft had also added,
+  `test_every_profile_is_reachable_by_its_own_name`, could not catch the
+  duplicate-name collision its class docstring claimed either: `PROFILES` is
+  built as `{profile.name: profile for profile in (...)}`, so a name
+  collision drops the losing profile out of the dict before a test
+  parametrized over `PROFILES.values()` ever sees it -- caught instead by
+  `TestRegistry.test_keys_are_each_profile_s_own_name`'s existing dict-literal
+  equality. Rather than keep a near-tautological rail duplicating that
+  coverage, it was removed and the class docstring corrected to claim only
+  the suffix check it actually performs. The placeholder rail's exemption was
+  also tightened from `stream_limit is not None` to `stream_limit == 1` (the
+  reasoning its own docstring already gave), and its `accept_options` guard
+  changed from skipping an empty tuple to asserting it is non-empty -- an
+  empty `accept_options` on an uncapped rule is exactly the shape `OPUS`'s own
+  audio-rule comment (`converter/profiles.py`) warns would emit a map with no
+  codec option, an undeclared re-encode.

--- a/docs/specs/spec-video-formats.md
+++ b/docs/specs/spec-video-formats.md
@@ -447,3 +447,39 @@ New-Item -ItemType Directory -Force in
   (`test_a_source_webm_cannot_hold_at_all_is_unsupported`), using the same
   attachment-only stream shape the real fixture would have produced had
   ffmpeg been willing to write one.
+- 2026-08-26 (issue #30): Issue #23 (PR #61) had already landed registry-wide
+  structural rails (`TestRegistryStructuralInvariants` in
+  `tests/test_profiles.py`) and this phase's own per-profile tests already
+  pinned `mkv`'s and `mov`'s `0:t?` mapping against `webm`'s absence of it, and
+  each of the three profiles' `last_resort is not None`, so those two
+  acceptance bullets needed no new test -- re-implementing them would have
+  been a second copy of an existing guard rail, the cost the parent task
+  explicitly warned against. Two bullets did need new work: `mp4` had no
+  whole-`Profile` snapshot test the way `wav` got in phase 3
+  (`test_profile_is_byte_for_byte_unchanged_since_phase_2`), even though three
+  siblings were landing in the same registry around it, so
+  `test_profile_is_byte_for_byte_unchanged_since_before_this_phase` closes
+  that gap the same way; and the README's format list already carried `mkv`,
+  `mov` and `webm` (added when their own issues landed), so that bullet was
+  already satisfied and needed no edit.
+
+  Beyond the acceptance list, three genuinely cross-profile rails were added
+  to `TestRegistryStructuralInvariants`/a new `TestRegistryTargetCoherence`
+  class, targeting bug classes the per-profile tests structurally cannot catch
+  because each only ever looks at its own profile: (1) every `StreamRule`
+  whose `stream_limit` is `None` must carry ffmpeg's `{n}` position
+  placeholder in its codec options -- generalising issue #22's real bug
+  (an unindexed `-c:a copy` silently re-encoding an already-accepted stream,
+  because ffmpeg's own unindexed codec options are not positional) to the
+  whole registry rather than the one profile that motivated it; (2) every
+  declared `last_resort` must carry at least one note -- generalising issue
+  #34's real bug (the image `last_resort` dropping a stream type with no note
+  at all, a direct violation of the constitution's "never report success for
+  a conversion that silently dropped something") the same way; and (3) no two
+  profiles in `PROFILES` may share a `target_suffix`. Mutation-tested outside
+  the repo against copies of `m4a`, `mkv` and `mov`/`mkv` respectively (a
+  stripped placeholder, an emptied `last_resort.notes`, a collided suffix) to
+  confirm each rail actually fails before trusting it to pass on the real,
+  unmutated registry. None of the three found a live bug in a shipped
+  profile -- every shipped profile already satisfies all three -- so this
+  closes a hole in the contract's test coverage, not a live defect.

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -19,14 +19,11 @@ from converter.profiles import (
     MOV,
     MP3,
     MP4,
-    MP4_AUDIO_CODECS,
-    MP4_VIDEO_CODECS,
     OGG,
     OPUS,
     PNG,
     PROFILES,
     SOURCE_SUFFIXES,
-    TEXT_SUBTITLE_CODECS,
     TIFF,
     WAV,
     WEBM,
@@ -395,7 +392,12 @@ class TestMp4Profile:
         `TestWavProfile.test_profile_is_byte_for_byte_unchanged_since_phase_2`
         guards `wav` against phase 3's siblings, so a change to any field --
         including one nobody wrote a dedicated assertion for -- fails here
-        rather than shipping silently.
+        rather than shipping silently. The three copy masks are spelled out
+        literally rather than imported (`WAV`'s snapshot precedent), because
+        importing `MP4_VIDEO_CODECS` et al. and comparing them against
+        themselves would make this assertion `X == X` for those three
+        fields -- passing even if a codec were added to or removed from the
+        real constant.
         """
         expected = Profile(
             label="MP4",
@@ -422,7 +424,9 @@ class TestMp4Profile:
             partial_mapping=True,
             rules={
                 "video": StreamRule(
-                    copy_mask=MP4_VIDEO_CODECS,
+                    copy_mask=frozenset(
+                        {"h264", "hevc", "av1", "vp9", "mpeg4", "mpeg2video", "mjpeg"}
+                    ),
                     accept_options=("-c:v:{n}", "copy"),
                     fallback_options=("-c:v:{n}", "libx264", "-crf:v:{n}", "18"),
                     fallback_name="h264",
@@ -430,7 +434,7 @@ class TestMp4Profile:
                     drop_reason=None,
                 ),
                 "audio": StreamRule(
-                    copy_mask=MP4_AUDIO_CODECS,
+                    copy_mask=frozenset({"aac", "mp3", "ac3", "eac3", "alac", "opus", "flac"}),
                     accept_options=("-c:a:{n}", "copy"),
                     fallback_options=("-c:a:{n}", "aac", "-b:a:{n}", "192k"),
                     fallback_name="aac",
@@ -438,7 +442,9 @@ class TestMp4Profile:
                     drop_reason=None,
                 ),
                 "subtitle": StreamRule(
-                    copy_mask=TEXT_SUBTITLE_CODECS,
+                    copy_mask=frozenset(
+                        {"subrip", "srt", "ass", "ssa", "mov_text", "webvtt", "text"}
+                    ),
                     accept_options=("-c:s:{n}", "mov_text"),
                     fallback_options=None,
                     fallback_name=None,
@@ -1559,26 +1565,37 @@ class TestRegistryStructuralInvariants:
         stream of that type, not one per stream in map order (measured against
         ffmpeg 9.0, `M4A`'s and `OPUS`'s audio-rule comments in
         `converter/profiles.py`). That silently re-encodes an already-accepted
-        stream with no note, so a rule that can produce more than one output
-        stream of its type -- `stream_limit is None` -- must carry the `{n}`
-        placeholder `jobs._substitute_position` substitutes per stream
-        position. A
-        rule capped at one stream (`stream_limit == 1`, e.g. `WAV`'s or the
-        image profiles') is exempt: only one index is ever substituted, so the
-        bare form cannot collide.
+        stream with no note, so a rule not capped at one output stream of its
+        type -- `stream_limit == 1`, e.g. `WAV`'s or the image profiles', where
+        only one index is ever substituted and the bare form cannot collide --
+        must carry the `{n}` placeholder `jobs._substitute_position`
+        substitutes per stream position.
+
+        `accept_options` is asserted non-empty rather than skipped when falsy:
+        an empty `accept_options` on an uncapped rule would emit a map with no
+        codec option at all, producing an undeclared re-encode -- exactly what
+        `OPUS`'s own audio-rule comment (`converter/profiles.py`) says was
+        measured and is why `opus`'s cheap attempt does not use `WAV`'s empty
+        form. `fallback_options` stays conditional: it is genuinely optional
+        (`StreamRule.fallback_options: tuple[str, ...] | None`), unlike
+        `accept_options`.
         """
         for rule in profile.rules.values():
-            if rule.stream_limit is not None:
+            if rule.stream_limit == 1:
                 continue
-            if rule.accept_options:
-                assert "{n}" in " ".join(rule.accept_options), (
-                    f"{profile.label}: accept_options {rule.accept_options!r} has no "
-                    "stream_limit but no {n} placeholder"
-                )
+            assert rule.accept_options, (
+                f"{profile.label}: accept_options is empty on a rule with no "
+                "stream_limit==1 cap -- this would emit a map with no codec option, "
+                "producing an undeclared re-encode"
+            )
+            assert "{n}" in " ".join(rule.accept_options), (
+                f"{profile.label}: accept_options {rule.accept_options!r} has no "
+                "stream_limit==1 cap but no {n} placeholder"
+            )
             if rule.fallback_options:
                 assert "{n}" in " ".join(rule.fallback_options), (
                     f"{profile.label}: fallback_options {rule.fallback_options!r} has no "
-                    "stream_limit but no {n} placeholder"
+                    "stream_limit==1 cap but no {n} placeholder"
                 )
 
     def test_a_declared_last_resort_always_carries_a_note(self, profile):
@@ -1602,29 +1619,24 @@ class TestRegistryStructuralInvariants:
 
 
 class TestRegistryTargetCoherence:
-    """Target/suffix/name coherence across the whole registry (issue #30).
+    """Target-suffix coherence across the whole registry (issue #30).
 
     `TestRegistryStructuralInvariants` above already pins that every target
     suffix is a curated source suffix; this class pins the direction that
-    check cannot: that no two profiles claim the *same* suffix or the *same*
-    registry name, which `resolve_target` silently resolves to whichever
-    profile happened to be inserted into ``PROFILES`` last, per ordinary dict
-    behaviour.
+    check cannot: that no two profiles claim the *same* suffix. A duplicate
+    registry *name* is not this class's concern -- `PROFILES` is built as
+    ``{profile.name: profile for profile in (...)}``, so a name collision
+    would silently drop one profile from the dict entirely rather than leave
+    both reachable for a test parametrized over ``PROFILES.values()`` to
+    compare; `TestRegistry.test_keys_are_each_profile_s_own_name`'s full
+    dict-literal equality is what would actually notice a missing profile.
     """
 
     def test_no_two_profiles_share_a_target_suffix(self):
         suffixes = [profile.target_suffix for profile in PROFILES.values()]
+        duplicates = {suffix for suffix in suffixes if suffixes.count(suffix) > 1}
 
-        assert len(suffixes) == len(set(suffixes))
-
-    def test_every_profile_is_reachable_by_its_own_name(self):
-        """`PROFILES` is built from each profile's own `name`
-        (`converter/profiles.py`'s comment on the dict comprehension), but
-        that only guarantees the *key* matches -- not that `resolve_target`,
-        which lower-cases and strips a leading dot before the lookup, still
-        finds the same object back."""
-        for profile in PROFILES.values():
-            assert resolve_target(profile.name) is profile
+        assert not duplicates, f"target_suffix collision(s) in the registry: {sorted(duplicates)}"
 
 
 class TestResolveTarget:

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -19,11 +19,14 @@ from converter.profiles import (
     MOV,
     MP3,
     MP4,
+    MP4_AUDIO_CODECS,
+    MP4_VIDEO_CODECS,
     OGG,
     OPUS,
     PNG,
     PROFILES,
     SOURCE_SUFFIXES,
+    TEXT_SUBTITLE_CODECS,
     TIFF,
     WAV,
     WEBM,
@@ -381,6 +384,95 @@ class TestMp4Profile:
         assert rule.accept_options == ("-c:s:{n}", "mov_text")
         assert rule.fallback_options is None
         assert rule.drop_reason == "bitmap subtitles cannot be stored in MP4"
+
+    def test_profile_is_byte_for_byte_unchanged_since_before_this_phase(self):
+        """Guard rail for issue #30: `mkv`, `mov` and `webm` land in the same
+        registry this phase, and `mp4` is the one profile every one of them
+        could plausibly bump into (it is the source every other cheap-attempt
+        docstring in `converter/profiles.py` contrasts itself against). The
+        field-by-field tests above already pin most of `mp4`'s shape; this
+        compares the *whole* frozen `Profile` at once, the same way
+        `TestWavProfile.test_profile_is_byte_for_byte_unchanged_since_phase_2`
+        guards `wav` against phase 3's siblings, so a change to any field --
+        including one nobody wrote a dedicated assertion for -- fails here
+        rather than shipping silently.
+        """
+        expected = Profile(
+            label="MP4",
+            name="mp4",
+            description="Video: copies compatible streams, re-encodes the rest to h264/aac",
+            target_suffix=".mp4",
+            container_options=("-movflags", "+faststart"),
+            cheap_attempt=Attempt(
+                label="remux",
+                options=(
+                    "-map",
+                    "0:v?",
+                    "-map",
+                    "0:a?",
+                    "-map",
+                    "0:s?",
+                    "-c",
+                    "copy",
+                    "-c:s",
+                    "mov_text",
+                ),
+            ),
+            explicit_streams=False,
+            partial_mapping=True,
+            rules={
+                "video": StreamRule(
+                    copy_mask=MP4_VIDEO_CODECS,
+                    accept_options=("-c:v:{n}", "copy"),
+                    fallback_options=("-c:v:{n}", "libx264", "-crf:v:{n}", "18"),
+                    fallback_name="h264",
+                    stream_limit=None,
+                    drop_reason=None,
+                ),
+                "audio": StreamRule(
+                    copy_mask=MP4_AUDIO_CODECS,
+                    accept_options=("-c:a:{n}", "copy"),
+                    fallback_options=("-c:a:{n}", "aac", "-b:a:{n}", "192k"),
+                    fallback_name="aac",
+                    stream_limit=None,
+                    drop_reason=None,
+                ),
+                "subtitle": StreamRule(
+                    copy_mask=TEXT_SUBTITLE_CODECS,
+                    accept_options=("-c:s:{n}", "mov_text"),
+                    fallback_options=None,
+                    fallback_name=None,
+                    stream_limit=None,
+                    drop_reason="bitmap subtitles cannot be stored in MP4",
+                ),
+            },
+            last_resort=Attempt(
+                label="re-encode",
+                options=(
+                    "-map",
+                    "0:v:0?",
+                    "-map",
+                    "0:a?",
+                    "-c:v",
+                    "libx264",
+                    "-crf",
+                    "18",
+                    "-preset",
+                    "medium",
+                    "-pix_fmt",
+                    "yuv420p",
+                    "-c:a",
+                    "aac",
+                    "-b:a",
+                    "192k",
+                ),
+                notes=(
+                    "re-encoded to h264/aac (lossy); subtitles and extra video streams dropped",
+                    "10-bit or HDR sources are reduced to 8-bit yuv420p for player compatibility",
+                ),
+            ),
+        )
+        assert expected == MP4
 
 
 class TestWavProfile:
@@ -1459,6 +1551,80 @@ class TestRegistryStructuralInvariants:
         `describe_unsupported`), which is not a target format, it is a no-op
         that pretends to be one."""
         assert len(profile.rules) >= 1
+
+    def test_a_rule_with_no_stream_limit_carries_the_position_placeholder(self, profile):
+        """Issue #22's real bug, generalised registry-wide: ffmpeg's unindexed
+        codec options (`-c:a copy`) are not positional -- when several are
+        given for the same stream type, the *last* one wins for every output
+        stream of that type, not one per stream in map order (measured against
+        ffmpeg 9.0, `M4A`'s and `OPUS`'s audio-rule comments in
+        `converter/profiles.py`). That silently re-encodes an already-accepted
+        stream with no note, so a rule that can produce more than one output
+        stream of its type -- `stream_limit is None` -- must carry the `{n}`
+        placeholder `jobs._substitute_position` substitutes per stream
+        position. A
+        rule capped at one stream (`stream_limit == 1`, e.g. `WAV`'s or the
+        image profiles') is exempt: only one index is ever substituted, so the
+        bare form cannot collide.
+        """
+        for rule in profile.rules.values():
+            if rule.stream_limit is not None:
+                continue
+            if rule.accept_options:
+                assert "{n}" in " ".join(rule.accept_options), (
+                    f"{profile.label}: accept_options {rule.accept_options!r} has no "
+                    "stream_limit but no {n} placeholder"
+                )
+            if rule.fallback_options:
+                assert "{n}" in " ".join(rule.fallback_options), (
+                    f"{profile.label}: fallback_options {rule.fallback_options!r} has no "
+                    "stream_limit but no {n} placeholder"
+                )
+
+    def test_a_declared_last_resort_always_carries_a_note(self, profile):
+        """Issue #34's bug class, generalised registry-wide: the image
+        `last_resort` used to drop a stream type it did not explicitly map
+        (audio, alongside `-map 0:v:0`) with no note at all -- a direct
+        violation of the constitution's "Never report success for a
+        conversion that silently dropped something." A `last_resort` exists
+        specifically because the ladder's earlier rungs failed, so by
+        construction it is always more constrained than the cheap attempt; an
+        empty `notes` tuple on one would mean a future profile shipped that
+        same silent drop again. Every shipped `last_resort` names either what
+        it re-encoded or what it structurally could not reach, so this is not
+        a hypothetical -- it is the shape every one of them already has.
+        """
+        if profile.last_resort is None:
+            return
+        assert profile.last_resort.notes, (
+            f"{profile.label}: last_resort declares no note for what it degrades or drops"
+        )
+
+
+class TestRegistryTargetCoherence:
+    """Target/suffix/name coherence across the whole registry (issue #30).
+
+    `TestRegistryStructuralInvariants` above already pins that every target
+    suffix is a curated source suffix; this class pins the direction that
+    check cannot: that no two profiles claim the *same* suffix or the *same*
+    registry name, which `resolve_target` silently resolves to whichever
+    profile happened to be inserted into ``PROFILES`` last, per ordinary dict
+    behaviour.
+    """
+
+    def test_no_two_profiles_share_a_target_suffix(self):
+        suffixes = [profile.target_suffix for profile in PROFILES.values()]
+
+        assert len(suffixes) == len(set(suffixes))
+
+    def test_every_profile_is_reachable_by_its_own_name(self):
+        """`PROFILES` is built from each profile's own `name`
+        (`converter/profiles.py`'s comment on the dict comprehension), but
+        that only guarantees the *key* matches -- not that `resolve_target`,
+        which lower-cases and strips a leading dot before the lookup, still
+        finds the same object back."""
+        for profile in PROFILES.values():
+            assert resolve_target(profile.name) is profile
 
 
 class TestResolveTarget:


### PR DESCRIPTION
Closes #30.

## Already satisfied by #23 / this phase's own PRs -- not re-implemented

- **"A test that mkv's and mov's cheap attempts map `0:t?` and webm's does
  not"** -- already pinned: `TestMkvProfile.test_cheap_attempt_maps_every_stream_type_including_attachments`,
  `TestMovProfile.test_cheap_attempt_maps_every_stream_type_including_attachments`,
  `TestWebmProfile.test_cheap_attempt_maps_no_attachment` (plus the argv-level
  mirrors in `tests/test_argv.py`'s `TestMkvRemux`/`TestMovRemux`/`TestWebmRemux`).
- **"A test that each new profile declares a `last_resort`"** -- already
  pinned per profile (`MKV.last_resort is not None` etc. in each profile's own
  test class).
- **"A test that mp4's argv and notes are byte-for-byte what they were before
  this phase"** -- already satisfied by `tests/test_argv.py`'s
  `TestProfileArgvPinning.test_mp4_copyable_source` /
  `test_mp4_non_copyable_source` and `TestMp4DegradationNotes`, all landed in
  phase 2 (issue #11, `2455d3d`). This PR still adds
  `TestMp4Profile.test_profile_is_byte_for_byte_unchanged_since_before_this_phase`
  as a companion, not a substitute -- a whole-`Profile` snapshot the way `wav`
  got one in phase 3, covering fields (each rule's `copy_mask`) the argv-level
  pins don't exercise.
- **"README format list updated with the three new targets"** -- `mkv`, `mov`
  and `webm` are already in README.md's fenced format block (added when their
  own issues landed), and #23 already added a byte-match test between that
  block and `--list-formats`'s actual output, so this needed no edit.

Ticking these rather than re-implementing them, per the parent task's
instruction that duplicated guard rails are a maintenance cost, not extra
safety.

## Genuinely new

1. **`mp4` whole-`Profile` snapshot** (`TestMp4Profile.test_profile_is_byte_for_byte_unchanged_since_before_this_phase`).
   `wav` got this in phase 3 as three siblings landed around it in the same
   registry (`test_profile_is_byte_for_byte_unchanged_since_phase_2`); `mp4`
   is in the same position this phase (`mkv`/`mov`/`webm` land around it) and
   had no equivalent. The three copy masks are spelled out as literal
   `frozenset`s rather than imported from `converter.profiles` -- see Review
   round 1 below for why that distinction matters.

2. **Registry-wide: every `StreamRule` not capped at one output stream of its
   type (`stream_limit == 1`) carries the `{n}` position placeholder, and its
   `accept_options` is non-empty** (`TestRegistryStructuralInvariants.test_a_rule_with_no_stream_limit_carries_the_position_placeholder`).
   Generalises issue #22's real bug -- an unindexed `-c:a copy` is not
   positional in ffmpeg, so the last one given silently wins for every output
   stream of that type, re-encoding an already-accepted stream with no note --
   from the one profile that surfaced it to the whole registry.

3. **Registry-wide: every declared `last_resort` carries at least one note**
   (`TestRegistryStructuralInvariants.test_a_declared_last_resort_always_carries_a_note`).
   Generalises issue #34's real bug -- the image `last_resort` dropped a
   stream type with no note at all, violating the constitution's "never
   report success for a conversion that silently dropped something" -- to
   every profile's `last_resort`, present and future.

4. **Registry-wide: no two profiles share a `target_suffix`**
   (`TestRegistryTargetCoherence.test_no_two_profiles_share_a_target_suffix`).

## Review round 1 -- two rails were vacuous, now fixed

A fresh reviewer measured two real problems in the first draft, both now
fixed (second commit on this branch):

- The `mp4` snapshot originally imported `MP4_VIDEO_CODECS` /
  `MP4_AUDIO_CODECS` / `TEXT_SUBTITLE_CODECS` and compared them against
  themselves (`X == X`), so it passed even after deleting a codec from the
  real constant. Fixed by spelling all three masks out as literal
  `frozenset`s, `wav`'s own precedent.
- A fourth test, `test_every_profile_is_reachable_by_its_own_name`, and its
  class docstring claimed to catch a duplicate profile *name* across the
  registry -- but `PROFILES` is built as a dict comprehension keyed on
  `name`, so a name collision silently drops the losing profile out of the
  dict before any test iterating `PROFILES.values()` ever sees it; the
  existing `TestRegistry.test_keys_are_each_profile_s_own_name` (a full
  dict-literal equality) is what actually catches that. Removed the
  vacuous test and corrected the class docstring to claim only the
  suffix-uniqueness check it performs.

Also tightened while fixing the above: the placeholder rail's exemption
changed from `stream_limit is not None` to `stream_limit == 1` (matching its
own stated reasoning), and its `accept_options` check changed from skipping
an empty tuple to asserting it is non-empty -- closing the exact hole
`opus`'s own audio-rule comment warns about (an empty `accept_options` would
emit a map with no codec option, an undeclared re-encode).

A second review round re-verified both fixes independently (re-reading the
real constants byte-for-byte, re-running the mutation tests, re-checking
every citation) and approved.

Deviating from issue #30's "diff touches only profiles.py, README.md and
tests/" bullet: this PR also touches `docs/specs/spec-video-formats.md`, the
project's own decision-log convention (`docs/workflow.md`) for recording why
a spec-covered choice was made -- README needed no edit (see above), so
`spec-video-formats.md` is the only addition beyond `tests/`.

## Mutation evidence

Per the parent task's instructions, each new rail was proven to actually
fail on a mutated copy (never the real registry) before trusting it, in
scratch scripts run outside the repo (not committed):

```
=== Baseline: real registry passes all rails ===
PASS

=== Strip the {n} placeholder from M4A's audio accept_options ===
CAUGHT: M4A: accept_options ('-c:a', 'copy') missing {n}

=== Empty OPUS's audio accept_options (stream_limit still None) ===
CAUGHT: OPUS: accept_options empty on an uncapped rule

=== Empty the notes on MKV's last_resort ===
CAUGHT: MKV: last_resort carries no note

=== Make MOV's target_suffix collide with MKV's ===
CAUGHT: target_suffix collision(s) in the registry: ['.mkv']

=== Drop "mjpeg" from MP4's video copy_mask ===
CAUGHT: mutated MP4 (mjpeg dropped) != the literal expected mask
```

**None of the rails found a live bug in a shipped profile** -- every shipped
profile already satisfies all of them. This closes gaps in the contract's
test coverage against a future profile, not a live defect.

## Honesty note on limits

A machine test cannot catch a pinned argv that real ffmpeg itself rejects --
the suite stubs the subprocess boundary throughout, so none of this is a
substitute for the QA gate's real ffmpeg smoke test.

## Verify

```
ruff check .           -- clean
ruff format --check .  -- clean
pytest                 -- 871 passed (was 835 before this PR)
```
