### PR TITLE
docs(spec): stream disposition and the artwork carry-through (roadmap phase 6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ More target formats can be added — see [Contributing](#contributing).
 Keep ffmpeg reasonably current. It is the component that parses untrusted media
 files, so it is where media-parsing security fixes land.
 
+**ffmpeg 7.1 or newer is worth having, but is not required.** Converting to
+`mp3`, `m4a` or `flac` uses a stream selector that arrived in 7.1 to carry
+embedded cover art across. On an older build — Ubuntu 24.04 ships 6.1.1, Debian
+12 ships 5.1.9 — those three conversions cost one extra ffmpeg call per file and
+then produce the same result, artwork included. Every other target is unaffected.
+
 ## Install
 
 ```sh

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,8 +65,11 @@ The internal import graph is acyclic today and must stay that way:
    takes; see the 2026-08-26 (issue #41) entries in
    `docs/specs/archive/spec-profile-registry.md`'s Decision log.
 2. **Degradation.** The attempt exits non-zero, so *now* `ffmpegtool.probe_streams`
-   describes the file. The engine matches each stream against the profile's copy
-   mask: streams the mask accepts pass through unchanged — as a literal `copy`, or
+   describes the file. Each stream is first resolved to a rule — by its
+   disposition when it is an attached picture and the profile declares a rule for
+   one, otherwise by its type — and the engine then matches it against that
+   rule's copy mask: streams the mask accepts pass through unchanged — as a
+   literal `copy`, or
    as the cheap in-kind transcode the rule declares, which is how a text subtitle
    becomes `mov_text` — streams it does not are re-encoded with the profile's
    fallback encoder, and streams are dropped when the container cannot hold that

--- a/docs/constitution.md
+++ b/docs/constitution.md
@@ -9,7 +9,7 @@
 | Area | Choice | Rationale |
 | ---- | ------ | --------- |
 | Language | Python >= 3.11 | `StrEnum` and modern typing without `from __future__`; 3.11 is the floor CI proves |
-| Media engine | the ffmpeg / ffprobe CLI, called with argv lists | Wrapper libraries are dead or broken; the reasoning is recorded in `converter/ffmpegtool.py` |
+| Media engine | the ffmpeg / ffprobe CLI, called with argv lists. **7.1 is the floor for the fast path**, not for correctness: below it the three targets that carry cover art spend one failed process plus one probe per file and reach the same result through the ladder | Wrapper libraries are dead or broken; the reasoning is recorded in `converter/ffmpegtool.py`. 7.1 is where `-map 0:disp:...` arrived, and older builds are still supported because refusing them would stop the fourteen targets that never use it |
 | Runtime dependencies | `tqdm>=4.66.3`, nothing else | Progress bar only; the floor is the fix for CVE-2024-34062 |
 | Build backend | hatchling | PEP 517, no `setup.py` |
 | Lint and format | ruff, explicit rule set, line length 100 | One tool for both; `select` is explicit so an upgrade cannot silently change the rule set |

--- a/docs/design/degradation-ladder.md
+++ b/docs/design/degradation-ladder.md
@@ -125,6 +125,17 @@ flowchart TD
   number of that type's streams, the same false accept the equality above
   exists to rule out.
 
+  A **third selector kind** joins the blind/index-named split: a *blind selector
+  over a disposition*, `-map 0:disp:attached_pic?`. It reads like an index-named
+  selector because it carries a colon-separated qualifier, but it behaves like a
+  blind one — measured, a single such map carries **every** attached picture a
+  source holds, not one. So it takes the blind branch of both rules above: the
+  type it maps (`attached_pic`) needs a rule, and that rule declares **no**
+  `stream_limit`. Declaring one would have `_structural_drop` report a picture
+  the mapping demonstrably carried — the false *reject* that mirrors the false
+  accept. `tests/test_profiles.py` classifies it by that behaviour, not by the
+  shape of the string.
+
   The two shipped profiles satisfy the equality by construction — MP4's
   selectors match its three rules exactly and it declares no limit, WAV names
   one audio index and limits audio to 1 — and `tests/test_profiles.py` checks

--- a/docs/design/stream-decision.md
+++ b/docs/design/stream-decision.md
@@ -22,6 +22,7 @@ encoder produces (`h264`, `aac`), `DROP_REASON` the reason the rule declares.
 ```mermaid
 flowchart TD
     S["stream i — type t, codec c"]
+    PIC{"is stream i an attached picture,<br/>and does the profile declare an attached_pic rule?"}
     T{"does the profile declare a rule for type t?"}
     ROOM{"is there still room for a t stream?<br/>(the rule's stream limit)"}
     MASK{"is c in the rule's copy mask?"}
@@ -32,7 +33,9 @@ flowchart TD
     D2["drop — note: t stream i (c) dropped: TARGET holds LIMIT t stream<br/>(the noun agrees in number with LIMIT)"]
     D3["drop — note: t stream i (c) dropped: DROP_REASON"]
 
-    S --> T
+    S --> PIC
+    PIC -->|"yes — use that rule"| ROOM
+    PIC -->|"no"| T
     T -->|"no"| D1
     T -->|"yes"| ROOM
     ROOM -->|"no"| D2
@@ -45,6 +48,13 @@ flowchart TD
 
 ## Rules the diagram encodes
 
+- **Disposition is checked before type.** An attached picture is a video stream
+  by `codec_type`, so a profile that can hold artwork but not video would
+  otherwise have to choose between carrying both and dropping both. The rule is
+  resolved by disposition first, falling back to the type — and a profile that
+  declares no `attached_pic` rule is unaffected, since the fallback is what it
+  already did. The engine still counts a carried picture under `video`, because
+  ffmpeg numbers it as a video output stream.
 - **Three outcomes, never a fourth.** A stream is accepted, re-encoded, or
   dropped. Every drop edge names the reason, because a silent drop is exactly
   what the vision forbids.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,7 +26,7 @@ lives.
 Foundation impact, recorded at seeding and authored in that phase's `/plan` spec
 PR — never edited here:
 
-- Phase 6 — Foundation impact: vision — none; constitution — none; architecture — yes: Key flow 2's per-stream match gains a disposition branch, and `docs/design/stream-decision.md` gains the node that distinguishes a picture from a video stream.
+- Phase 6 — Foundation impact: vision — none; constitution — **yes** (corrected at planning: the disposition selector arrived in ffmpeg 7.1, which the tech-stack row now records as the floor for the fast path); architecture — yes: Key flow 2's per-stream match gains a disposition branch, `docs/design/stream-decision.md` gains the node that distinguishes a picture from a video stream, and `docs/design/degradation-ladder.md` gains a third selector kind.
 - Phase 7 — Foundation impact: vision — none; constitution — yes: the notes convention and its test gate assume a note describes what *this* conversion gave up, and an advisory about loss the source already carried is a second kind that has to be defined; architecture — yes: a lossy-codec set is cross-cutting data, and `converter/profiles.py` is currently described as holding one profile per target format.
 
 ## What each phase covers

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,7 +16,7 @@
 | 3 | audio-formats | [spec-audio-formats.md](specs/archive/spec-audio-formats.md) | [#3](https://github.com/bhemsen/converter/milestone/3) |
 | 4 | video-formats | [spec-video-formats.md](specs/archive/spec-video-formats.md) | [#4](https://github.com/bhemsen/converter/milestone/4) |
 | 5 | image-formats | [spec-image-formats.md](specs/archive/spec-image-formats.md) | [#5](https://github.com/bhemsen/converter/milestone/5) |
-| 6 | stream-disposition | — | — |
+| 6 | stream-disposition | [spec-stream-disposition.md](specs/spec-stream-disposition.md) | [#6](https://github.com/bhemsen/converter/milestone/6) |
 | 7 | lossy-source-notes | — | — |
 
 A phase gets a Spec link once `/plan` drafts it, and a Milestone link once the

--- a/docs/specs/spec-stream-disposition.md
+++ b/docs/specs/spec-stream-disposition.md
@@ -1,0 +1,252 @@
+# Spec: stream-disposition (roadmap phase 6)
+
+> Created: 2026-08-26
+
+Teach the engine to tell a cover picture from a real video stream, so the audio
+targets whose muxers accept one can carry album art through instead of dropping
+it — and retire the standing notes that a partial-mapping verification has since
+made redundant. This spec carries no lifecycle state — acceptance is the spec
+merged on the default branch with a milestone and issues, and all progress lives
+in the GitHub issues and milestone. A completed spec is moved to
+`docs/specs/archive/`.
+
+**Depends on milestone #3 (audio-formats), which is complete.** It revisits the
+`mp3`, `m4a` and `flac` profiles phase 3 created.
+
+## Why this phase changed shape since it was seeded
+
+`docs/roadmap.md` seeded this phase as "the engine cannot name what it dropped".
+That half is already solved: issue #18's fix (`fix(batch): verify a structurally
+partial cheap attempt on success`) narrowed the constitution's probe rule and
+added `jobs.verify_success`, so a profile that declares `partial_mapping=True`
+is probed once on success and names each unmapped stream per stream.
+
+Two consequences this phase must deal with, both measured against the merged
+code:
+
+1. **The remaining half is *carrying* artwork, not reporting it.** The engine has
+   the stream list on the happy path now; what it lacks is the fact that
+   distinguishes a cover picture from a video.
+2. **The phase-3 standing notes are now redundant, and this phase makes them
+   false.** Measured on `PROFILES["mp3"]` with an MP3-plus-cover-art source, the
+   run prints both `non-audio streams, including cover art, are not carried into
+   MP3` (the standing note, on every file) and `video stream 1 (png) dropped: not
+   supported by MP3` (the verifier, accurate). The phase-3 gate chose the
+   standing note *because* per-stream naming was impossible on the happy path —
+   that premise is gone, and once artwork is carried the note is not merely noisy
+   but wrong.
+
+## Outcome
+
+- [ ] `Stream` carries whether a stream is an attached picture, and
+      `probe_streams` fills it — in the same single ffprobe call it already makes.
+- [ ] `mp3`, `m4a` and `flac` carry an embedded cover picture through a
+      conversion instead of dropping it, for the targets the gate approves.
+- [ ] A **real** video stream is still dropped and still named — the whole point
+      of the discriminator is that artwork and video stop being the same thing.
+- [ ] The standing notes on the six audio profiles are gone, and nothing they
+      said is lost: every claim they made is now made per stream by
+      `jobs.verify_success`, or is no longer true.
+- [ ] No conversion loses a stream without a word, and no note claims a loss that
+      did not happen.
+- [ ] `ffprobe` still runs at most once per file.
+
+## Scope
+
+### In scope
+
+- `converter/ffmpegtool.py`: an `attached_pic` field on `Stream`, and the
+  `stream_disposition=attached_pic` clause in `probe_streams`' existing query.
+- `converter/jobs.py`: resolving a stream to its rule by disposition as well as
+  type, so an attached picture can have its own rule.
+- `converter/profiles.py`: an `attached_pic` rule on the audio profiles the gate
+  approves, their cheap attempts mapping video, and the removal of the standing
+  notes this phase makes redundant or false.
+- The tests for all of it, including the per-target carry-through.
+
+### Out of scope
+
+- Video and image targets. `mkv` already carries attachments by `codec_type`,
+  and an image target's whole content is the picture — neither needs a
+  disposition.
+- Any other ffprobe disposition (`default`, `forced`, `comment`). Only
+  `attached_pic` has a decision resting on it; adding the rest would be
+  generality with no caller.
+- **Writing** a disposition. This phase carries an existing picture through; it
+  never marks a stream as artwork that was not already marked.
+- Extracting cover art to a separate file, or embedding art from one.
+- The `wav` and `mp4` standing-note holes phases 3 and 4 left open — those are
+  about a stream type never being mapped at all, which no disposition changes.
+
+## Constraints
+
+- `ffprobe` runs at most once per file, and never on the happy path of an
+  exhaustive cheap attempt (`docs/constitution.md`, as narrowed by #18).
+- Value types are frozen dataclasses; every parameter and return annotated.
+- A target format is data, not code: the per-target decision about artwork is a
+  profile entry, not a branch in the engine.
+- Never report success for a conversion that silently dropped something.
+- The test suite keeps passing with no ffmpeg installed.
+
+## Prior art
+
+- [Cover art and stream disposition (Phase 6)](../prior-art.md#cover-art-and-stream-disposition-phase-6)
+  — the concern seeded for this phase. beets' `convert` plugin is the **stance**
+  to adopt: artwork is a first-class, default-on concern of a conversion pipeline
+  (`embed: yes`), not an incidental stream. Its **mechanism** is the AVOID — it
+  embeds through a tag library, which here would be a second runtime dependency.
+  The ffprobe entry is the reuse, and its AVOID is the trap this phase exists to
+  close: inferring artwork from the codec name, since `mjpeg` and `png` are the
+  codecs of both a cover picture and a real video.
+
+## Design
+
+No new design artifact, but `docs/design/stream-decision.md` gains a node: the
+question "is this stream an attached picture?" sits before the type lookup. That
+edit is authored in this spec's own PR, since the diagram is a foundation-level
+contract and the change is one node.
+
+## Human prerequisites
+
+- none.
+
+## Prior decisions
+
+### The measured facts these decisions rest on
+
+Measured against ffmpeg 9.0 during planning; the review is asked to falsify.
+
+| Fact | Consequence |
+|---|---|
+| One ffprobe query returns the disposition alongside the fields `probe_streams` already asks for: `-show_entries stream=index,codec_type,codec_name:stream_disposition=attached_pic` yields `0,mp3,audio,0` and `1,png,video,1` | No second probe, no new round-trip. The cost is one clause |
+| **Artwork survives a mapped copy** into `mp3`, `m4a` and `flac`, disposition intact (`1,png,video,1` out) — with a source whose audio codec the target accepts | The carry-through works; the discriminator is what is missing |
+| **A real video behaves differently per target.** `m4a` rejects a real mjpeg (`Could not find tag for codec mjpeg`). `flac` accepts it at exit 0 and discards it. `mp3` rejects h264 (`No mimetype is known for stream 1, cannot write an attached picture`) but **writes a real mjpeg as a single-frame attached picture at exit 0** | The hazard of mapping video blindly is confined to `mp3` with an mjpeg or png *video* source. `m4a` fails into the ladder; `flac`'s discard is named by the verifier |
+| `jobs._structural_drop` reaches its verdict from `profile.rules.get(stream.codec_type)` and the stream limit alone, never from the codec | A rule resolved by disposition slots into the same helper, so the success-side verifier keeps working unchanged |
+| Every one of the 17 profiles declares `partial_mapping=True` | Every conversion is already probed on success. This phase adds no probe to any run that did not have one |
+
+### Decisions
+
+| Decision | Rationale | Date |
+|---|---|---|
+| `Stream` gains one boolean field, `attached_pic`, not a general disposition set | Only this disposition has a decision resting on it. A `frozenset[str]` of every disposition would be generality with no caller, and the constitution's value-type rule favours the narrow, named fact | 2026-08-26 |
+| An attached picture is resolved to a **`"attached_pic"` key in `profile.rules`**, falling back to `stream.codec_type` when the profile declares none — exactly how phase 4 added the `attachment` rule, and no new `StreamRule` field | Keeps the per-target decision in the profile where the constitution puts it, and keeps `_structural_drop` and `verify_success` working by construction, since both resolve a rule and neither cares how the key was chosen | 2026-08-26 |
+| A profile with **no** `attached_pic` rule keeps today's behaviour exactly: the picture falls through to the `video` lookup, finds no rule, and is dropped with the existing note | This phase must not change a target nobody asked it to change. `ogg`, `opus` and `wav` reject a picture outright (measured in phase 3) and gain nothing from a rule | 2026-08-26 |
+| The `attached_pic` rule copies unconditionally — an accept-anything mask, like `mkv`'s attachment rule | ffprobe reports the picture's codec (`png`, `mjpeg`) but the decision is the disposition, not the codec. Enumerating codec names would repeat the phase-4 mistake the attachment rule already corrected | 2026-08-26 |
+| **The standing notes are removed from all six audio profiles**, not just the three that gain artwork | Measured: the verifier already names every stream those notes describe, per stream and accurately. Keeping them would print a blanket note on every file for a benefit that no longer exists — and for `mp3`, `m4a` and `flac` the note becomes false the moment artwork is carried. Their removal is a behaviour change and is listed in Verification | 2026-08-26 |
+| `docs/design/stream-decision.md` gains one node — "is this stream an attached picture?" ahead of the type lookup — authored in this PR | The diagram is where the per-stream branch is settled; leaving it stale would be the drift `docs/design.md` warns about. One node, and the rest of the diagram is unchanged | 2026-08-26 |
+| No profile's `partial_mapping` changes | All 17 already declare it true, so the success-side verification this phase depends on is already running everywhere | 2026-08-26 |
+| OPEN — which of `mp3`, `m4a`, `flac` map video in their cheap attempt, given the measured per-target hazard | resolved at the spec-acceptance gate; see the note below | — |
+
+### The one open decision, in full
+
+Carrying artwork requires the cheap attempt to map video (`-map 0:a? -map 0:v?
+-c copy`); the cheap attempt is blind, so it cannot filter on disposition. The
+measured consequence differs per target:
+
+- **`m4a` — no cost.** A real video is rejected by the muxer, so such a source
+  fails into the ladder, where the disposition *is* known and the video is
+  dropped with a proper note. Pure win.
+- **`flac` — no cost.** A real video is silently discarded by the muxer, and the
+  success-side verifier names it (`video stream N (mjpeg) dropped: not supported
+  by FLAC`) because the stream is not an attached picture and so does not match
+  the new rule. Pure win.
+- **`mp3` — a real cost.** h264 is rejected, so the common video case is safe.
+  But a source whose video stream is **mjpeg or png** is written as a
+  single-frame attached picture at exit 0. The user asked to rip audio from an
+  MJPEG video and gets an MP3 with a stray cover image, while the verifier
+  reports the video stream as *dropped* — approximately true (only one frame
+  survived, as art) but not exactly what happened.
+
+Today, with no video mapped, that mp3 case is clean: the video is not mapped, and
+the verifier names it accurately. So the gate is trading `mp3` artwork against
+`mp3` accuracy on an unusual source. Three answers:
+
+1. **All three map video.** `mp3` gets artwork like the others; an MJPEG-video
+   source produces a stray cover and a note that is close but not exact.
+   Simplest to explain: "the three targets whose muxers hold a picture, hold it".
+2. **`m4a` and `flac` map video; `mp3` does not.** Follows the measurements
+   exactly — the two targets that pay nothing gain artwork, and the one that
+   pays keeps today's accuracy. The cost is that the commonest music format is
+   the one that loses its artwork, which is the reverse of what a user expects.
+3. **All three map video, and `mp3` declares an `attached_pic` rule whose drop
+   note for a non-picture video says what actually happens** — reduced to a
+   single frame rather than dropped. Answer 1 plus one honest note, at the cost
+   of a note whose wording is specific to one target's muxer quirk.
+
+## Tracking
+
+- Milestone: stream-disposition (created at the spec-acceptance gate)
+- Issues: created from this spec once it is merged (one per implementable step)
+
+## Verification
+
+Machine checks:
+
+- [ ] Verify passes (ruff check, ruff format --check, pytest) on the merge commit.
+- [ ] A test that `probe_streams` fills `attached_pic` from a stubbed ffprobe
+      payload, true for a picture stream and false for a plain video.
+- [ ] A test that the probe still makes exactly **one** ffprobe call per file,
+      and that its `-show_entries` argument is pinned verbatim — the clause is
+      easy to break and the failure would be silent.
+- [ ] A test that a stream with `attached_pic` resolves to the `attached_pic`
+      rule when the profile declares one, and to the `video` rule when it does
+      not.
+- [ ] A test that a profile with no `attached_pic` rule behaves byte-for-byte as
+      it does today, for both argv and notes — `ogg`, `opus` and `wav` are the
+      guard.
+- [ ] Per target that gains artwork, a test pinning the cheap attempt's argv and
+      one asserting a picture stream is accepted while a non-picture video stream
+      of the same codec is dropped with a note.
+- [ ] A test that **no** audio profile carries a standing note any more, and a
+      test per removed note that the verifier still names the same loss per
+      stream — the removal must lose no statement.
+- [ ] `jobs.verify_success` and `jobs.describe_unsupported` keep their current
+      behaviour for every profile that gains no rule.
+
+Human milestone-QA gate. `$FF` is the absolute ffmpeg path from *This machine*:
+
+```text
+New-Item -ItemType Directory -Force in
+& $FF -y -f lavfi -i color=c=blue:size=200x200:d=1 -frames:v 1 cover.png
+& $FF -y -f lavfi -i sine=duration=2 -c:a libmp3lame in/plain.mp3
+& $FF -y -i in/plain.mp3 -i cover.png -map 0:a -map 1:v -c copy -disposition:v:0 attached_pic in/art.mp3
+& $FF -y -f lavfi -i sine=duration=2 -c:a aac in/s.m4a
+& $FF -y -i in/s.m4a -i cover.png -map 0:a -map 1:v -c copy -disposition:v:0 attached_pic in/art.m4a
+& $FF -y -f lavfi -i sine=duration=2 -c:a flac in/s.flac
+& $FF -y -i in/s.flac -i cover.png -map 0:a -map 1:v -c copy -disposition:v:0 attached_pic in/art.flac
+& $FF -y -f lavfi -i testsrc=size=160x120:rate=10:duration=2 -f lavfi -i sine=duration=2 -c:v mjpeg -c:a libmp3lame in/mjpegvid.mkv
+```
+
+- [ ] For each target the gate approves: converting its `art.*` fixture keeps the
+      picture — `ffprobe` the output and confirm the stream is present **and**
+      still carries `attached_pic=1`.
+- [ ] `in/plain.mp3` (no artwork) converts and prints **no** note at all. This is
+      what the standing-note removal buys, and it is the change a user notices
+      first.
+- [ ] `in/mjpegvid.mkv` under `--to mp3` behaves exactly as the gate's decision
+      says, and whatever it prints matches what `ffprobe` finds in the output.
+- [ ] `--to ogg` and `--to wav` over `in/art.mp3` behave exactly as they do on
+      the previous commit — the targets that gain no rule must be untouched.
+- [ ] A second run over any converted tree reports `0 converted`, exit 0.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Removing the standing notes loses a statement the verifier does not make | A test per removed note asserts the verifier still names that loss per stream; the QA gate checks the no-artwork case prints nothing |
+| The new rule changes a target nobody asked to change | A profile with no `attached_pic` rule is pinned byte-for-byte against today, with `ogg`, `opus` and `wav` as the guard |
+| The `-show_entries` clause is broken later and the field silently reads false | Its argv is pinned verbatim by a test, because a wrong clause fails silently rather than loudly |
+| Mapping video reintroduces the phase-3 hazard | Measured per target, and the one target that actually pays is the gate's decision rather than an assumption |
+| A second probe creeps in | The one-call test, plus every profile already declaring `partial_mapping=True`, so no run gains a probe it did not have |
+
+## Decision log
+
+- 2026-08-26: The phase was re-scoped before drafting. Its seeded framing —
+  "the engine cannot name what it dropped" — was overtaken by issue #18's fix,
+  which narrowed the constitution's probe rule and added a success-side verifier.
+  What remains is carrying artwork, plus retiring the phase-3 standing notes that
+  the verifier made redundant and that carrying artwork would make false.
+- 2026-08-26: Measured that the hazard of mapping video is confined to `mp3` with
+  an mjpeg or png video source — `m4a` rejects a real video and `flac` discards
+  it where the verifier names it. That measurement is what turned a blanket
+  question into a per-target one, and it is the phase's open decision.

--- a/docs/specs/spec-stream-disposition.md
+++ b/docs/specs/spec-stream-disposition.md
@@ -171,9 +171,9 @@ this one is rebuilt from what survived plus what the review found.
 | **The cheap-attempt standing notes are removed from the five audio profiles that carry one** — `mp3`, `flac`, `m4a`, `ogg`, `opus`. `wav` carries none | Measured: the verifier already names every stream those notes describe, per stream and accurately, so the blanket line is duplication. For `mp3`, `m4a` and `flac` it also becomes false the moment artwork is carried. `ogg` and `opus` gain no artwork, so their removal rests on the duplication argument alone | 2026-08-26 |
 | `last_resort` notes are **retained** on every profile | That rung maps `-map 0:a:0` explicitly and is never verified (`docs/design/degradation-ladder.md`: only the cheap attempt's notes are added to), so its note is the only place that information exists. Removing it would lose a statement | 2026-08-26 |
 | The first draft's open decision -- which targets map video, given a per-target hazard -- was **dissolved** by the disposition specifier rather than resolved | Recorded so the gate is not asked a question the measurement removed | 2026-08-26 |
-| OPEN -- what happens below ffmpeg 7.1 | resolved at the spec-acceptance gate; see the note below | -- |
+| **ffmpeg 7.1 is the floor for the fast path, not for correctness.** Older builds stay supported: below 7.1 the cheap attempt of `mp3`, `m4a` and `flac` fails per file and the ladder reaches the same result, artwork included | Resolved at the gate on 2026-08-27. The failure below the floor is a performance cost on three of seventeen targets, not a correctness one, and refusing at startup would stop the fourteen that never touch the specifier on the LTS distributions most Linux users run -- the opposite of the vision's "whatever ffmpeg can read". The wasted rung stays silent, which the ladder already guarantees: only the winning rung's notes are reported | 2026-08-27 |
 
-### The one open decision, in full
+### The ffmpeg-floor decision, in full (resolved at the gate)
 
 The disposition specifier arrived in **ffmpeg 7.1**. The project states no ffmpeg
 floor today -- `docs/constitution.md`'s tech-stack row names the CLI without a
@@ -194,6 +194,9 @@ and join this PR's Scope, and `docs/roadmap.md`'s recorded verdict for this phas
 authored **on this branch after the gate decides and before the merge** -- a
 recorded foundation impact belongs to the plan PR (`docs/workflow.md`), not to an
 implementation issue.
+
+**Resolved at the gate on 2026-08-27: option 1.** `docs/constitution.md` and
+`README.md` carry the floor as of this commit.
 
 1. **Supported with degradation.** Record `ffmpeg >= 7.1` as the floor *for the
    fast path*, and state the cost below it plainly. Nothing breaks anywhere, and
@@ -233,10 +236,9 @@ Machine checks:
       same codec** is dropped with a note — the distinction the whole phase is for.
 - [ ] A test that `verify_success` does **not** report a carried picture as
       dropped, for each of the three targets.
-- [ ] Whichever floor option the gate picks produces a checkable artifact: under
-      option 1, the floor stated in `docs/constitution.md` and `README.md` and
-      nothing else; under option 2, a startup check with an actionable message
-      and a test driving it against a stubbed version banner.
+- [ ] The floor is stated in `docs/constitution.md` and `README.md`, and nowhere
+      enforced: no startup check, no version parsing. A test asserting the three
+      cheap attempts are unconditional -- the degradation must stay automatic.
 - [ ] A test that `ogg`, `opus` and `wav` are byte-for-byte unchanged in argv,
       and unchanged in notes apart from the removed standing note.
 - [ ] A test that no audio profile carries a **`cheap_attempt`** standing note,
@@ -322,3 +324,9 @@ New-Item -ItemType Directory -Force in
   outright: with no codec option covering the picture ffmpeg re-encodes it to the
   ipod muxer's default h264, which ipod then rejects. The cheap attempts are
   pinned in full rather than described as "gaining a map".
+- 2026-08-27: Gate chose supported-with-degradation. The floor is recorded in the
+  constitution and the README and enforced nowhere — below 7.1 the ladder does
+  the work at one wasted process per file, which is a performance cost on three
+  of seventeen targets rather than a correctness one. This also corrects
+  `docs/roadmap.md`'s seeded "constitution — none" verdict for this phase, which
+  the version floor made false.

--- a/docs/specs/spec-stream-disposition.md
+++ b/docs/specs/spec-stream-disposition.md
@@ -211,7 +211,7 @@ implementation issue.
 
 ## Tracking
 
-- Milestone: stream-disposition (created at the spec-acceptance gate)
+- Milestone: [stream-disposition](https://github.com/bhemsen/converter/milestone/6) (#6)
 - Issues: created from this spec once it is merged (one per implementable step)
 
 ## Verification

--- a/docs/specs/spec-stream-disposition.md
+++ b/docs/specs/spec-stream-disposition.md
@@ -61,10 +61,13 @@ The fix is not to sort it out afterwards but never to map it: ffmpeg has a
 - `converter/profiles.py`: an `attached_pic` rule on `mp3`, `m4a` and `flac`,
   their cheap attempts gaining `-map 0:disp:attached_pic?`, and the removal of
   the five cheap-attempt standing notes.
-- `tests/test_profiles.py`: `MAP_LETTERS` / `mapped_types` learn the disposition
-  selector, so the mapped-types-equals-rules invariant keeps holding.
-- **`docs/design/stream-decision.md` and `docs/architecture.md` Key flow 2**,
-  amended in this PR — the foundation impact `docs/roadmap.md` recorded for this
+- `tests/test_profiles.py`: `MAP_LETTERS` and `mapped_types` learn the disposition
+  selector and classify it as **blind**, and `named_index_counts` skips it -- three
+  shipped invariants, of which one currently fails against the new shape.
+- `docs/constitution.md` and `README.md`: the ffmpeg version floor, per the gate's
+  decision, and `docs/roadmap.md`'s "constitution -- none" verdict corrected.
+- **`docs/design/stream-decision.md`, `docs/design/degradation-ladder.md` and
+  `docs/architecture.md` Key flow 2**, amended in this PR — the foundation impact `docs/roadmap.md` recorded for this
   phase, which `docs/workflow.md` binds to be authored here.
 - The tests for all of it.
 
@@ -121,6 +124,9 @@ Both foundation edits are authored in this PR, not deferred:
   lookup.
 - `docs/architecture.md` Key flow 2 gains the same clause, since it restates the
   per-stream match in prose.
+- `docs/design/degradation-ladder.md` gains the third selector kind -- a blind
+  selector over a disposition -- because its `stream_limit` reasoning is built on
+  a two-way blind-versus-index-named split that no longer covers every case.
 
 ## Human prerequisites
 
@@ -142,22 +148,60 @@ this one is rebuilt from what survived plus what the review found.
 | **Artwork survives a mapped copy** into `mp3`, `m4a` and `flac` with disposition intact, for **png and mjpeg** — the two artwork codecs that matter | The carry-through works once the mapping is precise |
 | One ffprobe query returns the disposition alongside the existing fields, but under `-of json` it is **nested**: `{"index":1,"codec_name":"png","codec_type":"video","disposition":{"attached_pic":1}}` | No second probe, but the parser change is a nested lookup plus a default for a stream reporting no `disposition` object — not "one clause" |
 | `ogg`, `opus` and `wav` reject a picture outright even with an accepted audio codec (`Unsupported codec id in stream 1`; `wav muxer does not support any stream of type video`) | Those three gain no rule and no mapping, and stay unchanged |
-| `tests/test_profiles.py` binds `set(profile.rules)` to `mapped_types(profile)`, whose `MAP_LETTERS` covers `v/a/s/t/d` only | The invariant is not an obstacle here — it is the reason the design works. See the rules-key decision |
+| **The disposition specifier arrived in ffmpeg 7.1** ("stream specifiers in fftools can now match by stream disposition", `Changelog` under `version 7.1:`, absent from every earlier heading). Ubuntu 24.04 LTS ships 6.1.1 and Debian 12 ships 5.1.9 -- both below it | A new runtime floor the project does not currently state anywhere. `README.md` tells Linux users `sudo apt install ffmpeg`, which lands under the floor on both |
+| **Below 7.1 the `?` does not save the invocation.** An unknown disposition specifier makes ffmpeg refuse the option and abort: `Invalid disposition specifier` / `Failed to set value ... for option 'map'` / `Error opening output files`, exit 127 | The cheap attempt fails for *every* file on the three targets, not just artwork-bearing ones. It degrades rather than breaks -- the selective rung maps by index and needs no specifier -- at one failed ffmpeg process plus one probe per file |
+| **One `-map 0:disp:attached_pic?` carries *every* picture, not one.** Measured on a two-picture source into all three targets: `1,png,video,1` and `2,mjpeg,video,1` both arrive | The selector is **blind**, not index-named. Declaring `stream_limit=1` on the rule would make `verify_success` report the second picture as dropped while ffmpeg carried it |
+| A source with **no** artwork exits 0 on all three targets under the same cheap attempt, carrying audio only | The trailing `?` is load-bearing and works; the majority case is unaffected |
+| `tests/test_profiles.py` binds `set(profile.rules)` to `mapped_types(profile)` **and** binds a stream limit to `named_index_counts`, which reads `0:disp:attached_pic?` as index-named | Two of the three invariants hold as-is; the third fails and must be taught the new selector kind. See the rules-key decision |
 
 ### Decisions
 
 | Decision | Rationale | Date |
 |---|---|---|
-| The cheap attempt of `mp3`, `m4a` and `flac` gains **`-map 0:disp:attached_pic?`**, never `-map 0:v?` | Measured: it maps pictures and nothing else, on all three targets, including the h264 cases that break a blind map. The `?` keeps a source without artwork exiting 0 | 2026-08-26 |
+| The cheap attempt of `mp3`, `m4a` and `flac` becomes exactly `flags("-map 0:a? -map 0:disp:attached_pic? -c copy")` -- **`-c:a copy` becomes `-c copy`**, which is a second argv change beyond adding the map | Measured: the specifier maps pictures and nothing else on all three targets, including the h264 cases that break a blind map, and the `?` keeps a source without artwork exiting 0. But with `-c:a copy` retained, no codec option covers the picture, so ffmpeg re-encodes it with the muxer's default video encoder -- h264 for ipod, which ipod then rejects, failing every artwork-bearing `--to m4a` at rung 1. `mp3` and `flac` exit 0 and silently re-encode the picture. With `-c copy` all three copy it | 2026-08-26 |
 | `Stream` gains one boolean field, `attached_pic`, not a general disposition set | Only this disposition has a decision resting on it. The field is needed even though ffmpeg does the mapping: the success-side verifier must not report a *carried* picture as dropped, and the selective rung maps by index and so has no specifier to lean on | 2026-08-26 |
-| An attached picture resolves to an **`"attached_pic"` key in `profile.rules`**, falling back to `stream.codec_type` when the profile declares none | It lines up with the mapping rather than fighting it: the cheap attempt now maps attached pictures as their own thing, so a rule for them is exactly what the mapped-types-equals-rules invariant demands. `MAP_LETTERS` / `mapped_types` learn `disp:attached_pic -> "attached_pic"`, which is a one-entry extension, not an exemption | 2026-08-26 |
+| An attached picture resolves to an **`"attached_pic"` key in `profile.rules`**, falling back to `stream.codec_type` when the profile declares none | It lines up with the mapping rather than fighting it: the cheap attempt now maps attached pictures as their own thing, so a rule for them is exactly what the mapped-types-equals-rules invariant demands. Two of the three shipped invariants then hold unchanged. The third does not: `named_index_counts` reads `0:disp:attached_pic?` as index-named and would demand `stream_limit=1` -- and measured, one such map carries *every* picture, so that limit would make `verify_success` report a carried picture as dropped. `named_index_counts` must skip the `disp:` form and `mapped_types` must classify it as **blind** | 2026-08-26 |
+| The `attached_pic` rule declares **no** `stream_limit` | Measured: a two-picture source arrives whole on all three targets. A limit of 1 would be a false statement about ffmpeg's behaviour and would produce a drop note for a stream that was carried -- the mirror this spec's Constraints forbid | 2026-08-26 |
+| `docs/design/degradation-ladder.md`'s blind-versus-index-named dichotomy gains a **third selector kind**: a blind selector over a disposition. Authored in this PR | That file's whole `stream_limit` reasoning is built on the two-way split, so leaving it out would make the shipped invariant and the design contract disagree | 2026-08-26 |
+| The engine needs **no change for counting**: `_decide_stream` already writes `counts[stream.codec_type]`, and a picture's `codec_type` is `video` | Verified against the real engine: a two-picture m4a selective rung emits `-c:v:0 copy -c:v:1 copy` and both pictures arrive with `attached_pic=1`. The do-nothing option is also the correct one | 2026-08-26 |
 | A profile with **no** `attached_pic` rule keeps today's behaviour exactly: the picture falls through to the `video` lookup, finds no rule, and is dropped with the existing note | This phase must not change a target nobody asked it to change. `ogg`, `opus` and `wav` are the guard | 2026-08-26 |
 | The `attached_pic` rule copies unconditionally — accept-anything mask, `accept_options=flags("-c:v copy")` for `mp3` and `flac`, `flags("-c:v:{n} copy")` for `m4a` | The decision is the disposition, not the codec, so enumerating codec names would repeat the phase-4 mistake the attachment rule corrected. The `{n}` split follows the existing per-profile convention: `mp3` and `flac` are stream-limited to one, `m4a` is not | 2026-08-26 |
 | The engine counts a carried picture under **`"video"`**, not `"attached_pic"` | ffmpeg counts an attached picture as a video output stream, so `{n}` must stay in step with ffmpeg's own numbering. Irrelevant for the three audio targets, which declare no `video` rule, and a latent bug for any later profile with both | 2026-08-26 |
 | `describe_unsupported` stays keyed on `codec_type` deliberately, and is pinned by a test | Its question is "does this source carry any stream type the profile could use", which a disposition does not change. Measured: a standalone `.png` reports `attached_pic=0`, so it stays a genuine `unsupported` | 2026-08-26 |
 | **The cheap-attempt standing notes are removed from the five audio profiles that carry one** — `mp3`, `flac`, `m4a`, `ogg`, `opus`. `wav` carries none | Measured: the verifier already names every stream those notes describe, per stream and accurately, so the blanket line is duplication. For `mp3`, `m4a` and `flac` it also becomes false the moment artwork is carried. `ogg` and `opus` gain no artwork, so their removal rests on the duplication argument alone | 2026-08-26 |
 | `last_resort` notes are **retained** on every profile | That rung maps `-map 0:a:0` explicitly and is never verified (`docs/design/degradation-ladder.md`: only the cheap attempt's notes are added to), so its note is the only place that information exists. Removing it would lose a statement | 2026-08-26 |
-| Genuinely open decisions: **none**. The first draft's open decision — which targets map video, given a per-target hazard — was dissolved by the disposition specifier rather than resolved | Recorded so the gate is a deliberate "the measurement removed the question", not an omission | 2026-08-26 |
+| The first draft's open decision -- which targets map video, given a per-target hazard -- was **dissolved** by the disposition specifier rather than resolved | Recorded so the gate is not asked a question the measurement removed | 2026-08-26 |
+| OPEN -- what happens below ffmpeg 7.1 | resolved at the spec-acceptance gate; see the note below | -- |
+
+### The one open decision, in full
+
+The disposition specifier arrived in **ffmpeg 7.1**. The project states no ffmpeg
+floor today -- `docs/constitution.md`'s tech-stack row names the CLI without a
+version, and `README.md` says only "keep ffmpeg reasonably current" while telling
+Linux users `sudo apt install ffmpeg`, which lands on 6.1.1 under Ubuntu 24.04 LTS
+and 5.1.9 under Debian 12.
+
+Measured, below the floor the trailing `?` does not help: ffmpeg refuses the
+option and aborts the invocation. So on such a build the cheap attempt of `mp3`,
+`m4a` and `flac` fails for **every** file. It degrades rather than breaks -- the
+selective rung maps by index, needs no specifier, and carries the artwork just the
+same -- but at one failed ffmpeg process plus one ffprobe per file, and every
+conversion then reports through the failure-side path.
+
+Whichever the gate picks, `docs/constitution.md` and `README.md` gain the floor
+and join this PR's Scope, and `docs/roadmap.md`'s recorded verdict for this phase
+("constitution -- none") becomes false and is corrected here.
+
+1. **Supported with degradation.** Record `ffmpeg >= 7.1` as the floor *for the
+   fast path*, and state the cost below it plainly. Nothing breaks anywhere, and
+   a user on Debian 12 still gets their artwork -- just one wasted process per
+   file on three of the seventeen targets.
+2. **Refused up front.** `resolve_tools` already fails fast for a missing binary
+   and `ffmpegtool.version()` already exists, so a floor could be enforced at
+   startup with an actionable message. But it would refuse *every* target,
+   including the fourteen that never use the specifier, on the LTS distribution
+   most Linux users are running. That is a large blast radius for a feature three
+   targets use.
 
 ## Tracking
 
@@ -191,8 +235,12 @@ Machine checks:
 - [ ] A test that no audio profile carries a **`cheap_attempt`** standing note,
       and a test per removed note that the verifier still names the same loss per
       stream. `last_resort.notes` are asserted unchanged.
-- [ ] The `mapped_types` invariant in `tests/test_profiles.py` holds for all 17
-      profiles with the disposition selector recognised.
+- [ ] All three `tests/test_profiles.py` invariants hold for all 17 profiles with
+      the disposition selector recognised -- including the stream-limit one, which
+      fails against the new shape until `named_index_counts` skips the `disp:`
+      form.
+- [ ] A test that a **two-picture** source is carried whole and reported as no
+      loss -- the case that decides the rule declares no `stream_limit`.
 
 Human milestone-QA gate. `$FF` is the absolute ffmpeg path from *This machine*.
 Every fixture has a **distinct stem**, so a single `--to <fmt> in out` run does
@@ -230,7 +278,7 @@ New-Item -ItemType Directory -Force in
 
 | Risk | Mitigation |
 |---|---|
-| The disposition specifier is unavailable on an older ffmpeg than this machine's 9.0, and the cheap attempt fails for everyone on it | The review is asked to establish the version floor. If it is above what the project can assume, the fallback is to carry artwork only on the selective rung, which needs no specifier — a smaller win, not a broken one |
+| A user below ffmpeg 7.1 pays a failed process plus a probe per file on three targets | Established: the floor is 7.1, the failure is a full abort rather than a skipped map, and the degradation is automatic rather than a fallback anyone implements. The gate decides whether that is supported or refused, and the floor is recorded in the constitution and the README either way |
 | A real video is passed through or truncated into an audio target | The specifier maps only pictures, pinned per target by argv tests and by a QA check on both an h264 and an mjpeg video source |
 | Removing the standing notes loses a statement | A test per removed note asserts the verifier still names that loss per stream; `last_resort` notes are explicitly retained and asserted unchanged |
 | The `-show_entries` clause or the nested JSON read breaks and the field silently reads false | Both pinned: the argv verbatim, and the parse against a payload with and without a `disposition` object |
@@ -253,3 +301,17 @@ New-Item -ItemType Directory -Force in
 - 2026-08-26: The override of `docs/prior-art.md`'s and `docs/roadmap.md`'s
   "the note narrows rather than disappears" is named in Prior art, with the
   evidence neither had: the verifier makes every statement those notes make.
+- 2026-08-26: Review round 2 established the version floor this spec could not
+  settle from one machine: the disposition specifier arrived in ffmpeg 7.1, and
+  the LTS distributions most Linux users run ship below it. Promoted to the
+  phase's one open decision, since it adds a runtime requirement the project has
+  never stated and makes `docs/roadmap.md`'s "constitution — none" verdict false.
+- 2026-08-26: Review round 2 also measured that one `-map 0:disp:attached_pic?`
+  carries every picture, not one — so the rule declares no `stream_limit`, and
+  `degradation-ladder.md`'s two-way selector split gains a third kind. Taking the
+  failing invariant at face value and declaring `stream_limit=1` would have
+  produced a drop note for a stream ffmpeg carried.
+- 2026-08-26: And that adding only the map, keeping `-c:a copy`, breaks `m4a`
+  outright: with no codec option covering the picture ffmpeg re-encodes it to the
+  ipod muxer's default h264, which ipod then rejects. The cheap attempts are
+  pinned in full rather than described as "gaining a map".

--- a/docs/specs/spec-stream-disposition.md
+++ b/docs/specs/spec-stream-disposition.md
@@ -2,90 +2,97 @@
 
 > Created: 2026-08-26
 
-Teach the engine to tell a cover picture from a real video stream, so the audio
-targets whose muxers accept one can carry album art through instead of dropping
-it — and retire the standing notes that a partial-mapping verification has since
-made redundant. This spec carries no lifecycle state — acceptance is the spec
-merged on the default branch with a milestone and issues, and all progress lives
-in the GitHub issues and milestone. A completed spec is moved to
-`docs/specs/archive/`.
+Carry an embedded cover picture through the audio conversions whose muxers hold
+one, by mapping **only** attached pictures rather than video in general — and
+retire the standing notes that a partial-mapping verification has since made
+redundant. This spec carries no lifecycle state — acceptance is the spec merged
+on the default branch with a milestone and issues, and all progress lives in the
+GitHub issues and milestone. A completed spec is moved to `docs/specs/archive/`.
 
 **Depends on milestone #3 (audio-formats), which is complete.** It revisits the
 `mp3`, `m4a` and `flac` profiles phase 3 created.
 
-## Why this phase changed shape since it was seeded
+## Why this phase changed shape twice before it was drafted
 
 `docs/roadmap.md` seeded this phase as "the engine cannot name what it dropped".
-That half is already solved: issue #18's fix (`fix(batch): verify a structurally
-partial cheap attempt on success`) narrowed the constitution's probe rule and
-added `jobs.verify_success`, so a profile that declares `partial_mapping=True`
-is probed once on success and names each unmapped stream per stream.
+That half was already solved by issue #18's fix (`1183a09`), which narrowed the
+constitution's probe rule and added `jobs.verify_success`: a profile declaring
+`partial_mapping=True` is probed once on success and names each unmapped stream,
+per stream. So the remaining work is *carrying* artwork, not reporting it.
 
-Two consequences this phase must deal with, both measured against the merged
-code:
+The first draft then proposed mapping video blindly (`-map 0:v?`) and using the
+disposition to sort it out afterwards. The review falsified that: **the ipod
+muxer accepts h264**, so `--to m4a` over an ordinary video would have shipped the
+whole video renamed `.m4a` at exit 0 *and* printed a drop that never happened.
+Measured, `-map 0:a? -map 0:v? -c copy` on an h264+aac source yields
+`0,aac,audio,88` and `1,h264,video,20`.
 
-1. **The remaining half is *carrying* artwork, not reporting it.** The engine has
-   the stream list on the happy path now; what it lacks is the fact that
-   distinguishes a cover picture from a video.
-2. **The phase-3 standing notes are now redundant, and this phase makes them
-   false.** Measured on `PROFILES["mp3"]` with an MP3-plus-cover-art source, the
-   run prints both `non-audio streams, including cover art, are not carried into
-   MP3` (the standing note, on every file) and `video stream 1 (png) dropped: not
-   supported by MP3` (the verifier, accurate). The phase-3 gate chose the
-   standing note *because* per-stream naming was impossible on the happy path —
-   that premise is gone, and once artwork is carried the note is not merely noisy
-   but wrong.
+The fix is not to sort it out afterwards but never to map it: ffmpeg has a
+**disposition stream specifier**, and it does exactly what this phase needs.
 
 ## Outcome
 
-- [ ] `Stream` carries whether a stream is an attached picture, and
-      `probe_streams` fills it — in the same single ffprobe call it already makes.
 - [ ] `mp3`, `m4a` and `flac` carry an embedded cover picture through a
-      conversion instead of dropping it, for the targets the gate approves.
-- [ ] A **real** video stream is still dropped and still named — the whole point
-      of the discriminator is that artwork and video stop being the same thing.
-- [ ] The standing notes on the six audio profiles are gone, and nothing they
-      said is lost: every claim they made is now made per stream by
-      `jobs.verify_success`, or is no longer true.
-- [ ] No conversion loses a stream without a word, and no note claims a loss that
-      did not happen.
+      conversion instead of dropping it.
+- [ ] A real video stream is **never mapped** into an audio target — not
+      dropped-after-mapping, not truncated, not passed through. Measured on
+      h264 into `m4a`, the case the first draft got wrong.
+- [ ] `Stream` carries whether a stream is an attached picture, and
+      `probe_streams` fills it from the same single ffprobe call it already makes.
+- [ ] A carried picture is **not** reported as dropped, and a real video stream
+      still is.
+- [ ] The five audio profiles' cheap-attempt standing notes are gone, and nothing
+      they said is lost: every claim is made per stream by `jobs.verify_success`,
+      or is no longer true. `last_resort` notes are untouched.
+- [ ] `ogg`, `opus` and `wav` are byte-for-byte unchanged in argv, and unchanged
+      in notes except for the standing note this phase removes from `ogg` and
+      `opus`.
 - [ ] `ffprobe` still runs at most once per file.
 
 ## Scope
 
 ### In scope
 
-- `converter/ffmpegtool.py`: an `attached_pic` field on `Stream`, and the
-  `stream_disposition=attached_pic` clause in `probe_streams`' existing query.
+- `converter/ffmpegtool.py`: an `attached_pic` field on `Stream`, the
+  `stream_disposition=attached_pic` clause in `probe_streams`' existing query,
+  and the nested-JSON read that goes with it.
 - `converter/jobs.py`: resolving a stream to its rule by disposition as well as
-  type, so an attached picture can have its own rule.
-- `converter/profiles.py`: an `attached_pic` rule on the audio profiles the gate
-  approves, their cheap attempts mapping video, and the removal of the standing
-  notes this phase makes redundant or false.
-- The tests for all of it, including the per-target carry-through.
+  type, so an attached picture has its own rule.
+- `converter/profiles.py`: an `attached_pic` rule on `mp3`, `m4a` and `flac`,
+  their cheap attempts gaining `-map 0:disp:attached_pic?`, and the removal of
+  the five cheap-attempt standing notes.
+- `tests/test_profiles.py`: `MAP_LETTERS` / `mapped_types` learn the disposition
+  selector, so the mapped-types-equals-rules invariant keeps holding.
+- **`docs/design/stream-decision.md` and `docs/architecture.md` Key flow 2**,
+  amended in this PR — the foundation impact `docs/roadmap.md` recorded for this
+  phase, which `docs/workflow.md` binds to be authored here.
+- The tests for all of it.
 
 ### Out of scope
 
-- Video and image targets. `mkv` already carries attachments by `codec_type`,
-  and an image target's whole content is the picture — neither needs a
-  disposition.
-- Any other ffprobe disposition (`default`, `forced`, `comment`). Only
-  `attached_pic` has a decision resting on it; adding the rest would be
-  generality with no caller.
+- Video and image targets. `mkv` carries attachments by `codec_type`, and an
+  image target's whole content is the picture.
+- Any other disposition (`default`, `forced`, `comment`). Only `attached_pic` has
+  a decision resting on it.
 - **Writing** a disposition. This phase carries an existing picture through; it
   never marks a stream as artwork that was not already marked.
-- Extracting cover art to a separate file, or embedding art from one.
+- Extracting cover art to a file, or embedding art from one.
+- `ogg`, `opus` and `wav` gaining artwork — measured, all three reject a picture
+  outright even with an accepted audio codec.
 - The `wav` and `mp4` standing-note holes phases 3 and 4 left open — those are
-  about a stream type never being mapped at all, which no disposition changes.
+  about a stream type never being mapped at all.
+- `last_resort` notes. They stay: that rung maps `-map 0:a:0` explicitly and is
+  never verified (`docs/design/degradation-ladder.md`), so its note is the only
+  place that information exists.
 
 ## Constraints
 
 - `ffprobe` runs at most once per file, and never on the happy path of an
   exhaustive cheap attempt (`docs/constitution.md`, as narrowed by #18).
 - Value types are frozen dataclasses; every parameter and return annotated.
-- A target format is data, not code: the per-target decision about artwork is a
-  profile entry, not a branch in the engine.
-- Never report success for a conversion that silently dropped something.
+- A target format is data, not code.
+- Never report success for a conversion that silently dropped something — and,
+  its mirror, never announce a drop that did not happen.
 - The test suite keeps passing with no ffmpeg installed.
 
 ## Prior art
@@ -94,17 +101,26 @@ code:
   — the concern seeded for this phase. beets' `convert` plugin is the **stance**
   to adopt: artwork is a first-class, default-on concern of a conversion pipeline
   (`embed: yes`), not an incidental stream. Its **mechanism** is the AVOID — it
-  embeds through a tag library, which here would be a second runtime dependency.
-  The ffprobe entry is the reuse, and its AVOID is the trap this phase exists to
-  close: inferring artwork from the codec name, since `mjpeg` and `png` are the
-  codecs of both a cover picture and a real video.
+  embeds through a tag library, a second runtime dependency here. The ffprobe
+  entry's AVOID is what this phase closes: never infer artwork from the codec
+  name, since `mjpeg` and `png` are the codecs of both a cover picture and a real
+  video.
+- That concern's own AVOID says the standing note "**narrows** rather than
+  disappears", and `docs/roadmap.md`'s phase-6 row says the same. **This spec
+  overrides both**, on evidence neither had: the verifier added by #18 already
+  makes every statement those notes make, per stream and accurately, so a
+  narrowed note would still be a blanket line duplicating an exact one. The
+  override is named here rather than left as a silent divergence.
 
 ## Design
 
-No new design artifact, but `docs/design/stream-decision.md` gains a node: the
-question "is this stream an attached picture?" sits before the type lookup. That
-edit is authored in this spec's own PR, since the diagram is a foundation-level
-contract and the change is one node.
+Both foundation edits are authored in this PR, not deferred:
+
+- `docs/design/stream-decision.md` gains one node — "is this stream an attached
+  picture, and does the profile declare a rule for one?" — ahead of the type
+  lookup.
+- `docs/architecture.md` Key flow 2 gains the same clause, since it restates the
+  per-stream match in prose.
 
 ## Human prerequisites
 
@@ -114,64 +130,34 @@ contract and the change is one node.
 
 ### The measured facts these decisions rest on
 
-Measured against ffmpeg 9.0 during planning; the review is asked to falsify.
+Measured against ffmpeg 9.0; the first draft's table was falsified by review and
+this one is rebuilt from what survived plus what the review found.
 
 | Fact | Consequence |
 |---|---|
-| One ffprobe query returns the disposition alongside the fields `probe_streams` already asks for: `-show_entries stream=index,codec_type,codec_name:stream_disposition=attached_pic` yields `0,mp3,audio,0` and `1,png,video,1` | No second probe, no new round-trip. The cost is one clause |
-| **Artwork survives a mapped copy** into `mp3`, `m4a` and `flac`, disposition intact (`1,png,video,1` out) — with a source whose audio codec the target accepts | The carry-through works; the discriminator is what is missing |
-| **A real video behaves differently per target.** `m4a` rejects a real mjpeg (`Could not find tag for codec mjpeg`). `flac` accepts it at exit 0 and discards it. `mp3` rejects h264 (`No mimetype is known for stream 1, cannot write an attached picture`) but **writes a real mjpeg as a single-frame attached picture at exit 0** | The hazard of mapping video blindly is confined to `mp3` with an mjpeg or png *video* source. `m4a` fails into the ladder; `flac`'s discard is named by the verifier |
-| `jobs._structural_drop` reaches its verdict from `profile.rules.get(stream.codec_type)` and the stream limit alone, never from the codec | A rule resolved by disposition slots into the same helper, so the success-side verifier keeps working unchanged |
-| Every one of the 17 profiles declares `partial_mapping=True` | Every conversion is already probed on success. This phase adds no probe to any run that did not have one |
+| **ffmpeg has a disposition stream specifier.** `-map 0:disp:attached_pic?` maps embedded pictures and nothing else. Measured: an MP3-with-art source yields `0,mp3,audio,0` + `1,png,video,1`; an **h264** video source yields audio only; an h264+aac source into `m4a` yields audio only | This is the phase's mechanism. The cheap attempt never sees a real video stream, so none of the pass-through hazards below can arise |
+| **The ipod muxer accepts h264.** `-map 0:a? -map 0:v? -c copy` on h264+aac into `.m4a` exits 0 and writes `1,h264,video,20` — a whole video renamed `.m4a`, with `verify_success` printing a drop that did not happen | Why the first draft's blind `-map 0:v?` is rejected outright. The same defect `converter/profiles.py`'s OGG comment already records |
+| `mp3` writes a real **mjpeg** video as exactly one packet with `attached_pic=1` (source had 20), and rejects **h264** (`No mimetype is known for stream 1`) | The other half of the same hazard: blind mapping is unsafe per target in different ways |
+| `flac` accepts a real mjpeg at exit 0 and discards it entirely | The third variant. Three targets, three different wrong answers — hence: map neither, map only pictures |
+| **Artwork survives a mapped copy** into `mp3`, `m4a` and `flac` with disposition intact, for **png and mjpeg** — the two artwork codecs that matter | The carry-through works once the mapping is precise |
+| One ffprobe query returns the disposition alongside the existing fields, but under `-of json` it is **nested**: `{"index":1,"codec_name":"png","codec_type":"video","disposition":{"attached_pic":1}}` | No second probe, but the parser change is a nested lookup plus a default for a stream reporting no `disposition` object — not "one clause" |
+| `ogg`, `opus` and `wav` reject a picture outright even with an accepted audio codec (`Unsupported codec id in stream 1`; `wav muxer does not support any stream of type video`) | Those three gain no rule and no mapping, and stay unchanged |
+| `tests/test_profiles.py` binds `set(profile.rules)` to `mapped_types(profile)`, whose `MAP_LETTERS` covers `v/a/s/t/d` only | The invariant is not an obstacle here — it is the reason the design works. See the rules-key decision |
 
 ### Decisions
 
 | Decision | Rationale | Date |
 |---|---|---|
-| `Stream` gains one boolean field, `attached_pic`, not a general disposition set | Only this disposition has a decision resting on it. A `frozenset[str]` of every disposition would be generality with no caller, and the constitution's value-type rule favours the narrow, named fact | 2026-08-26 |
-| An attached picture is resolved to a **`"attached_pic"` key in `profile.rules`**, falling back to `stream.codec_type` when the profile declares none — exactly how phase 4 added the `attachment` rule, and no new `StreamRule` field | Keeps the per-target decision in the profile where the constitution puts it, and keeps `_structural_drop` and `verify_success` working by construction, since both resolve a rule and neither cares how the key was chosen | 2026-08-26 |
-| A profile with **no** `attached_pic` rule keeps today's behaviour exactly: the picture falls through to the `video` lookup, finds no rule, and is dropped with the existing note | This phase must not change a target nobody asked it to change. `ogg`, `opus` and `wav` reject a picture outright (measured in phase 3) and gain nothing from a rule | 2026-08-26 |
-| The `attached_pic` rule copies unconditionally — an accept-anything mask, like `mkv`'s attachment rule | ffprobe reports the picture's codec (`png`, `mjpeg`) but the decision is the disposition, not the codec. Enumerating codec names would repeat the phase-4 mistake the attachment rule already corrected | 2026-08-26 |
-| **The standing notes are removed from all six audio profiles**, not just the three that gain artwork | Measured: the verifier already names every stream those notes describe, per stream and accurately. Keeping them would print a blanket note on every file for a benefit that no longer exists — and for `mp3`, `m4a` and `flac` the note becomes false the moment artwork is carried. Their removal is a behaviour change and is listed in Verification | 2026-08-26 |
-| `docs/design/stream-decision.md` gains one node — "is this stream an attached picture?" ahead of the type lookup — authored in this PR | The diagram is where the per-stream branch is settled; leaving it stale would be the drift `docs/design.md` warns about. One node, and the rest of the diagram is unchanged | 2026-08-26 |
-| No profile's `partial_mapping` changes | All 17 already declare it true, so the success-side verification this phase depends on is already running everywhere | 2026-08-26 |
-| OPEN — which of `mp3`, `m4a`, `flac` map video in their cheap attempt, given the measured per-target hazard | resolved at the spec-acceptance gate; see the note below | — |
-
-### The one open decision, in full
-
-Carrying artwork requires the cheap attempt to map video (`-map 0:a? -map 0:v?
--c copy`); the cheap attempt is blind, so it cannot filter on disposition. The
-measured consequence differs per target:
-
-- **`m4a` — no cost.** A real video is rejected by the muxer, so such a source
-  fails into the ladder, where the disposition *is* known and the video is
-  dropped with a proper note. Pure win.
-- **`flac` — no cost.** A real video is silently discarded by the muxer, and the
-  success-side verifier names it (`video stream N (mjpeg) dropped: not supported
-  by FLAC`) because the stream is not an attached picture and so does not match
-  the new rule. Pure win.
-- **`mp3` — a real cost.** h264 is rejected, so the common video case is safe.
-  But a source whose video stream is **mjpeg or png** is written as a
-  single-frame attached picture at exit 0. The user asked to rip audio from an
-  MJPEG video and gets an MP3 with a stray cover image, while the verifier
-  reports the video stream as *dropped* — approximately true (only one frame
-  survived, as art) but not exactly what happened.
-
-Today, with no video mapped, that mp3 case is clean: the video is not mapped, and
-the verifier names it accurately. So the gate is trading `mp3` artwork against
-`mp3` accuracy on an unusual source. Three answers:
-
-1. **All three map video.** `mp3` gets artwork like the others; an MJPEG-video
-   source produces a stray cover and a note that is close but not exact.
-   Simplest to explain: "the three targets whose muxers hold a picture, hold it".
-2. **`m4a` and `flac` map video; `mp3` does not.** Follows the measurements
-   exactly — the two targets that pay nothing gain artwork, and the one that
-   pays keeps today's accuracy. The cost is that the commonest music format is
-   the one that loses its artwork, which is the reverse of what a user expects.
-3. **All three map video, and `mp3` declares an `attached_pic` rule whose drop
-   note for a non-picture video says what actually happens** — reduced to a
-   single frame rather than dropped. Answer 1 plus one honest note, at the cost
-   of a note whose wording is specific to one target's muxer quirk.
+| The cheap attempt of `mp3`, `m4a` and `flac` gains **`-map 0:disp:attached_pic?`**, never `-map 0:v?` | Measured: it maps pictures and nothing else, on all three targets, including the h264 cases that break a blind map. The `?` keeps a source without artwork exiting 0 | 2026-08-26 |
+| `Stream` gains one boolean field, `attached_pic`, not a general disposition set | Only this disposition has a decision resting on it. The field is needed even though ffmpeg does the mapping: the success-side verifier must not report a *carried* picture as dropped, and the selective rung maps by index and so has no specifier to lean on | 2026-08-26 |
+| An attached picture resolves to an **`"attached_pic"` key in `profile.rules`**, falling back to `stream.codec_type` when the profile declares none | It lines up with the mapping rather than fighting it: the cheap attempt now maps attached pictures as their own thing, so a rule for them is exactly what the mapped-types-equals-rules invariant demands. `MAP_LETTERS` / `mapped_types` learn `disp:attached_pic -> "attached_pic"`, which is a one-entry extension, not an exemption | 2026-08-26 |
+| A profile with **no** `attached_pic` rule keeps today's behaviour exactly: the picture falls through to the `video` lookup, finds no rule, and is dropped with the existing note | This phase must not change a target nobody asked it to change. `ogg`, `opus` and `wav` are the guard | 2026-08-26 |
+| The `attached_pic` rule copies unconditionally — accept-anything mask, `accept_options=flags("-c:v copy")` for `mp3` and `flac`, `flags("-c:v:{n} copy")` for `m4a` | The decision is the disposition, not the codec, so enumerating codec names would repeat the phase-4 mistake the attachment rule corrected. The `{n}` split follows the existing per-profile convention: `mp3` and `flac` are stream-limited to one, `m4a` is not | 2026-08-26 |
+| The engine counts a carried picture under **`"video"`**, not `"attached_pic"` | ffmpeg counts an attached picture as a video output stream, so `{n}` must stay in step with ffmpeg's own numbering. Irrelevant for the three audio targets, which declare no `video` rule, and a latent bug for any later profile with both | 2026-08-26 |
+| `describe_unsupported` stays keyed on `codec_type` deliberately, and is pinned by a test | Its question is "does this source carry any stream type the profile could use", which a disposition does not change. Measured: a standalone `.png` reports `attached_pic=0`, so it stays a genuine `unsupported` | 2026-08-26 |
+| **The cheap-attempt standing notes are removed from the five audio profiles that carry one** — `mp3`, `flac`, `m4a`, `ogg`, `opus`. `wav` carries none | Measured: the verifier already names every stream those notes describe, per stream and accurately, so the blanket line is duplication. For `mp3`, `m4a` and `flac` it also becomes false the moment artwork is carried. `ogg` and `opus` gain no artwork, so their removal rests on the duplication argument alone | 2026-08-26 |
+| `last_resort` notes are **retained** on every profile | That rung maps `-map 0:a:0` explicitly and is never verified (`docs/design/degradation-ladder.md`: only the cheap attempt's notes are added to), so its note is the only place that information exists. Removing it would lose a statement | 2026-08-26 |
+| Genuinely open decisions: **none**. The first draft's open decision — which targets map video, given a per-target hazard — was dissolved by the disposition specifier rather than resolved | Recorded so the gate is a deliberate "the measurement removed the question", not an omission | 2026-08-26 |
 
 ## Tracking
 
@@ -184,69 +170,86 @@ Machine checks:
 
 - [ ] Verify passes (ruff check, ruff format --check, pytest) on the merge commit.
 - [ ] A test that `probe_streams` fills `attached_pic` from a stubbed ffprobe
-      payload, true for a picture stream and false for a plain video.
+      **JSON** payload with the nested `disposition` object, true for a picture,
+      false for a plain video, and false for a stream carrying no `disposition`
+      object at all.
 - [ ] A test that the probe still makes exactly **one** ffprobe call per file,
-      and that its `-show_entries` argument is pinned verbatim — the clause is
-      easy to break and the failure would be silent.
+      with its `-show_entries` argument pinned verbatim — a wrong clause fails
+      silently rather than loudly.
 - [ ] A test that a stream with `attached_pic` resolves to the `attached_pic`
       rule when the profile declares one, and to the `video` rule when it does
       not.
-- [ ] A test that a profile with no `attached_pic` rule behaves byte-for-byte as
-      it does today, for both argv and notes — `ogg`, `opus` and `wav` are the
-      guard.
-- [ ] Per target that gains artwork, a test pinning the cheap attempt's argv and
-      one asserting a picture stream is accepted while a non-picture video stream
-      of the same codec is dropped with a note.
-- [ ] A test that **no** audio profile carries a standing note any more, and a
-      test per removed note that the verifier still names the same loss per
-      stream — the removal must lose no statement.
-- [ ] `jobs.verify_success` and `jobs.describe_unsupported` keep their current
-      behaviour for every profile that gains no rule.
+- [ ] A test that `describe_unsupported` is unchanged for every profile,
+      including the three that gain a rule.
+- [ ] Per target that gains artwork: the cheap attempt's argv pinned, and a test
+      that a picture stream is accepted while a **non-picture video stream of the
+      same codec** is dropped with a note — the distinction the whole phase is for.
+- [ ] A test that `verify_success` does **not** report a carried picture as
+      dropped, for each of the three targets.
+- [ ] A test that `ogg`, `opus` and `wav` are byte-for-byte unchanged in argv,
+      and unchanged in notes apart from the removed standing note.
+- [ ] A test that no audio profile carries a **`cheap_attempt`** standing note,
+      and a test per removed note that the verifier still names the same loss per
+      stream. `last_resort.notes` are asserted unchanged.
+- [ ] The `mapped_types` invariant in `tests/test_profiles.py` holds for all 17
+      profiles with the disposition selector recognised.
 
-Human milestone-QA gate. `$FF` is the absolute ffmpeg path from *This machine*:
+Human milestone-QA gate. `$FF` is the absolute ffmpeg path from *This machine*.
+Every fixture has a **distinct stem**, so a single `--to <fmt> in out` run does
+not collide (`docs/specs/spec-image-formats.md` and commit `a6b1342` record why):
 
 ```text
 New-Item -ItemType Directory -Force in
 & $FF -y -f lavfi -i color=c=blue:size=200x200:d=1 -frames:v 1 cover.png
-& $FF -y -f lavfi -i sine=duration=2 -c:a libmp3lame in/plain.mp3
-& $FF -y -i in/plain.mp3 -i cover.png -map 0:a -map 1:v -c copy -disposition:v:0 attached_pic in/art.mp3
-& $FF -y -f lavfi -i sine=duration=2 -c:a aac in/s.m4a
-& $FF -y -i in/s.m4a -i cover.png -map 0:a -map 1:v -c copy -disposition:v:0 attached_pic in/art.m4a
-& $FF -y -f lavfi -i sine=duration=2 -c:a flac in/s.flac
-& $FF -y -i in/s.flac -i cover.png -map 0:a -map 1:v -c copy -disposition:v:0 attached_pic in/art.flac
-& $FF -y -f lavfi -i testsrc=size=160x120:rate=10:duration=2 -f lavfi -i sine=duration=2 -c:v mjpeg -c:a libmp3lame in/mjpegvid.mkv
+& $FF -y -f lavfi -i sine=duration=2 -c:a libmp3lame in/tone-mp3.mp3
+& $FF -y -i in/tone-mp3.mp3 -i cover.png -map 0:a -map 1:v -c copy -disposition:v:0 attached_pic in/art-mp3.mp3
+& $FF -y -f lavfi -i sine=duration=2 -c:a aac in/tone-m4a.m4a
+& $FF -y -i in/tone-m4a.m4a -i cover.png -map 0:a -map 1:v -c copy -disposition:v:0 attached_pic in/art-m4a.m4a
+& $FF -y -f lavfi -i sine=duration=2 -c:a flac in/tone-flac.flac
+& $FF -y -i in/tone-flac.flac -i cover.png -map 0:a -map 1:v -c copy -disposition:v:0 attached_pic in/art-flac.flac
+& $FF -y -f lavfi -i testsrc=size=160x120:rate=10:duration=2 -f lavfi -i sine=duration=2 -c:v libx264 -c:a aac in/vid-h264.mkv
+& $FF -y -f lavfi -i testsrc=size=160x120:rate=10:duration=2 -f lavfi -i sine=duration=2 -c:v mjpeg -c:a libmp3lame in/vid-mjpeg.mkv
 ```
 
-- [ ] For each target the gate approves: converting its `art.*` fixture keeps the
-      picture — `ffprobe` the output and confirm the stream is present **and**
-      still carries `attached_pic=1`.
-- [ ] `in/plain.mp3` (no artwork) converts and prints **no** note at all. This is
-      what the standing-note removal buys, and it is the change a user notices
-      first.
-- [ ] `in/mjpegvid.mkv` under `--to mp3` behaves exactly as the gate's decision
-      says, and whatever it prints matches what `ffprobe` finds in the output.
-- [ ] `--to ogg` and `--to wav` over `in/art.mp3` behave exactly as they do on
-      the previous commit — the targets that gain no rule must be untouched.
+- [ ] `--to mp3 in out`, `--to m4a in out` and `--to flac in out`: each `art-*`
+      fixture keeps its picture — `ffprobe` the output and confirm the stream is
+      present **and** still carries `attached_pic=1`.
+- [ ] **The selective-rung case**, which is the motivating one: `art-flac.flac`
+      under `--to mp3` needs an audio re-encode, so the cheap attempt fails and
+      the ladder runs. The picture must still arrive with `attached_pic=1`.
+- [ ] `vid-h264.mkv` and `vid-mjpeg.mkv` under `--to m4a` and `--to mp3`: the
+      output holds **audio only**, and the run names the dropped video stream.
+      This is the regression the first draft would have shipped.
+- [ ] `tone-mp3.mp3` (no artwork) converts and prints **no** note at all. This is
+      what the standing-note removal buys, and the change a user notices first.
+- [ ] `--to ogg` and `--to wav` over `art-mp3.mp3` behave exactly as on the
+      previous commit apart from the removed standing note.
 - [ ] A second run over any converted tree reports `0 converted`, exit 0.
 
 ## Risks and mitigations
 
 | Risk | Mitigation |
 |---|---|
-| Removing the standing notes loses a statement the verifier does not make | A test per removed note asserts the verifier still names that loss per stream; the QA gate checks the no-artwork case prints nothing |
-| The new rule changes a target nobody asked to change | A profile with no `attached_pic` rule is pinned byte-for-byte against today, with `ogg`, `opus` and `wav` as the guard |
-| The `-show_entries` clause is broken later and the field silently reads false | Its argv is pinned verbatim by a test, because a wrong clause fails silently rather than loudly |
-| Mapping video reintroduces the phase-3 hazard | Measured per target, and the one target that actually pays is the gate's decision rather than an assumption |
-| A second probe creeps in | The one-call test, plus every profile already declaring `partial_mapping=True`, so no run gains a probe it did not have |
+| The disposition specifier is unavailable on an older ffmpeg than this machine's 9.0, and the cheap attempt fails for everyone on it | The review is asked to establish the version floor. If it is above what the project can assume, the fallback is to carry artwork only on the selective rung, which needs no specifier — a smaller win, not a broken one |
+| A real video is passed through or truncated into an audio target | The specifier maps only pictures, pinned per target by argv tests and by a QA check on both an h264 and an mjpeg video source |
+| Removing the standing notes loses a statement | A test per removed note asserts the verifier still names that loss per stream; `last_resort` notes are explicitly retained and asserted unchanged |
+| The `-show_entries` clause or the nested JSON read breaks and the field silently reads false | Both pinned: the argv verbatim, and the parse against a payload with and without a `disposition` object |
+| A target that gains no rule changes behaviour | `ogg`, `opus` and `wav` pinned byte-for-byte on argv, and on notes minus the removed standing note |
 
 ## Decision log
 
-- 2026-08-26: The phase was re-scoped before drafting. Its seeded framing —
-  "the engine cannot name what it dropped" — was overtaken by issue #18's fix,
-  which narrowed the constitution's probe rule and added a success-side verifier.
-  What remains is carrying artwork, plus retiring the phase-3 standing notes that
-  the verifier made redundant and that carrying artwork would make false.
-- 2026-08-26: Measured that the hazard of mapping video is confined to `mp3` with
-  an mjpeg or png video source — `m4a` rejects a real video and `flac` discards
-  it where the verifier names it. That measurement is what turned a blanket
-  question into a per-target one, and it is the phase's open decision.
+- 2026-08-26: Re-scoped before drafting. The seeded framing — "the engine cannot
+  name what it dropped" — was overtaken by issue #18's fix, which added a
+  success-side verifier. What remains is carrying artwork, plus retiring the
+  phase-3 standing notes the verifier made redundant.
+- 2026-08-26: The first draft proposed mapping video blindly and sorting it out
+  with the disposition afterwards. Review falsified it on the measurement that
+  mattered most: the ipod muxer accepts h264, so `--to m4a` would have shipped a
+  whole video renamed `.m4a` at exit 0 with a false drop note. The first draft
+  had measured only mjpeg.
+- 2026-08-26: Replaced by `-map 0:disp:attached_pic?`, measured to map pictures
+  and nothing else on all three targets. That dissolved the phase's open decision
+  rather than answering it — there is no longer a per-target trade to make.
+- 2026-08-26: The override of `docs/prior-art.md`'s and `docs/roadmap.md`'s
+  "the note narrows rather than disappears" is named in Prior art, with the
+  evidence neither had: the verifier makes every statement those notes make.

--- a/docs/specs/spec-stream-disposition.md
+++ b/docs/specs/spec-stream-disposition.md
@@ -117,7 +117,7 @@ The fix is not to sort it out afterwards but never to map it: ffmpeg has a
 
 ## Design
 
-Both foundation edits are authored in this PR, not deferred:
+Three foundation edits are authored in this PR, not deferred:
 
 - `docs/design/stream-decision.md` gains one node — "is this stream an attached
   picture, and does the profile declare a rule for one?" — ahead of the type
@@ -165,7 +165,7 @@ this one is rebuilt from what survived plus what the review found.
 | `docs/design/degradation-ladder.md`'s blind-versus-index-named dichotomy gains a **third selector kind**: a blind selector over a disposition. Authored in this PR | That file's whole `stream_limit` reasoning is built on the two-way split, so leaving it out would make the shipped invariant and the design contract disagree | 2026-08-26 |
 | The engine needs **no change for counting**: `_decide_stream` already writes `counts[stream.codec_type]`, and a picture's `codec_type` is `video` | Verified against the real engine: a two-picture m4a selective rung emits `-c:v:0 copy -c:v:1 copy` and both pictures arrive with `attached_pic=1`. The do-nothing option is also the correct one | 2026-08-26 |
 | A profile with **no** `attached_pic` rule keeps today's behaviour exactly: the picture falls through to the `video` lookup, finds no rule, and is dropped with the existing note | This phase must not change a target nobody asked it to change. `ogg`, `opus` and `wav` are the guard | 2026-08-26 |
-| The `attached_pic` rule copies unconditionally — accept-anything mask, `accept_options=flags("-c:v copy")` for `mp3` and `flac`, `flags("-c:v:{n} copy")` for `m4a` | The decision is the disposition, not the codec, so enumerating codec names would repeat the phase-4 mistake the attachment rule corrected. The `{n}` split follows the existing per-profile convention: `mp3` and `flac` are stream-limited to one, `m4a` is not | 2026-08-26 |
+| The `attached_pic` rule copies unconditionally — accept-anything mask, `accept_options=flags("-c:v:{n} copy")` on all three | The decision is the disposition, not the codec, so enumerating codec names would repeat the phase-4 mistake the attachment rule corrected. The placeholder form is used uniformly because the rule declares no `stream_limit` -- `StreamRule`'s bare-specifier convention is keyed on a limit of 1, which belongs to these profiles' *audio* rule, not this one | 2026-08-26 |
 | The engine counts a carried picture under **`"video"`**, not `"attached_pic"` | ffmpeg counts an attached picture as a video output stream, so `{n}` must stay in step with ffmpeg's own numbering. Irrelevant for the three audio targets, which declare no `video` rule, and a latent bug for any later profile with both | 2026-08-26 |
 | `describe_unsupported` stays keyed on `codec_type` deliberately, and is pinned by a test | Its question is "does this source carry any stream type the profile could use", which a disposition does not change. Measured: a standalone `.png` reports `attached_pic=0`, so it stays a genuine `unsupported` | 2026-08-26 |
 | **The cheap-attempt standing notes are removed from the five audio profiles that carry one** — `mp3`, `flac`, `m4a`, `ogg`, `opus`. `wav` carries none | Measured: the verifier already names every stream those notes describe, per stream and accurately, so the blanket line is duplication. For `mp3`, `m4a` and `flac` it also becomes false the moment artwork is carried. `ogg` and `opus` gain no artwork, so their removal rests on the duplication argument alone | 2026-08-26 |
@@ -190,7 +190,10 @@ conversion then reports through the failure-side path.
 
 Whichever the gate picks, `docs/constitution.md` and `README.md` gain the floor
 and join this PR's Scope, and `docs/roadmap.md`'s recorded verdict for this phase
-("constitution -- none") becomes false and is corrected here.
+("constitution -- none") becomes false and is corrected here. Those three edits are
+authored **on this branch after the gate decides and before the merge** -- a
+recorded foundation impact belongs to the plan PR (`docs/workflow.md`), not to an
+implementation issue.
 
 1. **Supported with degradation.** Record `ffmpeg >= 7.1` as the floor *for the
    fast path*, and state the cost below it plainly. Nothing breaks anywhere, and
@@ -230,6 +233,10 @@ Machine checks:
       same codec** is dropped with a note — the distinction the whole phase is for.
 - [ ] A test that `verify_success` does **not** report a carried picture as
       dropped, for each of the three targets.
+- [ ] Whichever floor option the gate picks produces a checkable artifact: under
+      option 1, the floor stated in `docs/constitution.md` and `README.md` and
+      nothing else; under option 2, a startup check with an actionable message
+      and a test driving it against a stubbed version banner.
 - [ ] A test that `ogg`, `opus` and `wav` are byte-for-byte unchanged in argv,
       and unchanged in notes apart from the removed standing note.
 - [ ] A test that no audio profile carries a **`cheap_attempt`** standing note,


### PR DESCRIPTION
Roadmap phase 6. **Re-scoped before drafting**, because the ground moved: the phase was seeded as "the engine cannot name what it dropped", but issue #18's fix narrowed the constitution's probe rule and added `jobs.verify_success`, so that half is already solved.

Two consequences, both measured against the merged code:

- The remaining half is **carrying** artwork, not reporting it.
- The phase-3 standing notes are now **redundant**, and this phase makes them **false**. Measured: an MP3 with cover art currently prints both the blanket note and the verifier's accurate per-stream note. The phase-3 gate chose the blanket note *because* per-stream naming was impossible on the happy path — that premise is gone.

The open decision is per target, from measurement: `m4a` rejects a real video (fails into the ladder), `flac` discards it (the verifier names it), but `mp3` writes a real **mjpeg** as a single-frame cover at exit 0. So mapping video costs nothing for two targets and costs accuracy for the third.
