### PR TITLE
docs: close out phases 1-5 (profile-registry through image-formats)

### DIFF
--- a/converter/batch.py
+++ b/converter/batch.py
@@ -44,7 +44,7 @@ class Outcome(enum.StrEnum):
     FAILED = "failed"
     #: The source carries no stream of any type the target profile has a rule
     #: for at all -- distinct from FAILED, which still sets the exit code
-    #: (docs/specs/spec-target-driven-cli.md). Its discriminator is decided by
+    #: (docs/specs/archive/spec-target-driven-cli.md). Its discriminator is decided by
     #: the engine (converter.jobs.describe_unsupported), never here.
     UNSUPPORTED = "unsupported"
 
@@ -259,7 +259,7 @@ class Summary:
 
     @property
     def exit_code(self) -> int:
-        # `unsupported` never sets the exit code (docs/specs/spec-target-driven-cli.md):
+        # `unsupported` never sets the exit code (docs/specs/archive/spec-target-driven-cli.md):
         # a source the target cannot produce at all is reported honestly, not
         # treated as a run failure -- that is the whole point of the outcome.
         return 1 if self.failed else 0

--- a/converter/cli.py
+++ b/converter/cli.py
@@ -7,7 +7,7 @@ coexist in one: argparse's sub-parser action is itself a positional, so a
 top-level positional ``INPUT`` swallows the command name.  :func:`dispatch`
 therefore routes the raw argument list *before* anything is parsed, which is
 also what makes ``--list-formats`` reachable next to a required ``--to``
-(``docs/specs/spec-target-driven-cli.md``).
+(``docs/specs/archive/spec-target-driven-cli.md``).
 
 The interactive prompt of the old ``prepare*`` scripts is kept, but it only
 assembles an argument list and hands it to :func:`dispatch` -- so the
@@ -379,7 +379,7 @@ def mirror_command(args: argparse.Namespace) -> int:
 def dispatch(raw: Sequence[str]) -> int:
     """Route *raw* to the command that owns it, before any parsing happens.
 
-    The order is the one ``docs/specs/spec-target-driven-cli.md`` fixes: a
+    The order is the one ``docs/specs/archive/spec-target-driven-cli.md`` fixes: a
     leading mirror token, then a leading legacy token, then the list flag
     anywhere, then the convert parser.  Both the prompt's output and a typed
     argument list come through here, which is what keeps them one code path.

--- a/converter/jobs.py
+++ b/converter/jobs.py
@@ -10,7 +10,7 @@ profile's rules itself -- the boundary ``docs/architecture.md`` draws between
 See ``docs/design/degradation-ladder.md`` for the order of attempts this module
 builds, ``docs/design/stream-decision.md`` for how one stream's fate is decided
 inside the engine-built rung, and
-``docs/specs/spec-target-driven-cli.md`` for the ``unsupported`` discriminator
+``docs/specs/archive/spec-target-driven-cli.md`` for the ``unsupported`` discriminator
 :func:`describe_unsupported` implements.
 """
 
@@ -187,7 +187,7 @@ def describe_unsupported(profile: Profile, streams: Sequence[Stream]) -> tuple[s
 
     ``None`` means the source carries at least one stream type *profile* has a
     rule for -- that stream may still be dropped for shape or codec reasons, but
-    that is a genuine ``failed``, not this (``docs/specs/spec-target-driven-cli.md``).
+    that is a genuine ``failed``, not this (``docs/specs/archive/spec-target-driven-cli.md``).
     ``None`` also for an *empty* stream list: that is the fingerprint of a probe
     that could not find anything to work with -- typically a corrupt or
     truncated source -- not positive evidence that the format holds nothing the

--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -195,7 +195,7 @@ class _AcceptAnyCodec(frozenset):
     """A copy mask that is empty by every ordinary measure yet accepts anything.
 
     ``len()`` is 0 and iterating it yields nothing -- the "empty-meaning" shape
-    ``docs/specs/spec-video-formats.md`` asks for -- but membership testing
+    ``docs/specs/archive/spec-video-formats.md`` asks for -- but membership testing
     always succeeds, so :func:`converter.jobs._decide_stream`'s
     ``stream.codec_name in rule.copy_mask`` check reads it as "always accept"
     without the engine (a leaf-adjacent module MKV's profile must not import
@@ -498,7 +498,7 @@ MP3 = Profile(
     container_options=(),
     # Blind by type, not by index: the mp3 muxer -- not this mapping --
     # enforces "at most one audio stream" (measured against ffmpeg 9.0,
-    # docs/specs/spec-audio-formats.md), so a second stream fails the cheap
+    # docs/specs/archive/spec-audio-formats.md), so a second stream fails the cheap
     # attempt outright rather than needing an index-based selector to keep it
     # out; that is what lets stream_limit=1 coexist with a blind "-map 0:a?"
     # below, the muxer-enforced exemption docs/design/degradation-ladder.md
@@ -588,7 +588,7 @@ M4A = Profile(
     # ".m4a" auto-selects the "ipod" muxer, whose accept set is narrower than a
     # standard MP4's -- it rejects mp3, opus and flac stream copies -- so the
     # mask below is curated by hand rather than reused from MP4_AUDIO_CODECS
-    # (docs/specs/spec-audio-formats.md).
+    # (docs/specs/archive/spec-audio-formats.md).
     cheap_attempt=Attempt(
         label="remux",
         options=flags("-map 0:a? -c:a copy"),
@@ -645,7 +645,7 @@ OGG = Profile(
     rules={
         "audio": StreamRule(
             # The ogg muxer accepts vorbis, opus and flac as-is; it rejects
-            # mp3 and aac (docs/specs/spec-audio-formats.md).
+            # mp3 and aac (docs/specs/archive/spec-audio-formats.md).
             copy_mask=frozenset({"vorbis", "opus", "flac"}),
             # No stream_limit: the ogg muxer holds several audio streams. The
             # position placeholder is required for the same reason m4a's
@@ -713,7 +713,7 @@ OPUS = Profile(
     ),
 )
 
-#: Phase 5 (`docs/specs/spec-image-formats.md`): the image2 muxer -- the one
+#: Phase 5 (`docs/specs/archive/spec-image-formats.md`): the image2 muxer -- the one
 #: behind PNG, JPEG, TIFF and BMP -- accepts *any* video codec under
 #: ``-c copy``, so a stream copy would ship a mislabelled file (measured:
 #: ``flat.jpg -c copy out.png`` exits 0 and writes a JPEG named ``.png``).
@@ -864,7 +864,7 @@ BMP = Profile(
     ),
 )
 
-#: Phase 5 (`docs/specs/spec-image-formats.md`): the animated-capable trio.
+#: Phase 5 (`docs/specs/archive/spec-image-formats.md`): the animated-capable trio.
 #: ``gif`` and ``webp`` write every frame of a multi-frame source -- an
 #: animation, not a still -- so unlike the image2 four above, neither carries a
 #: frame limit anywhere. ``avif``'s muxer silently keeps only one frame no

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,7 +63,7 @@ The internal import graph is acyclic today and must stay that way:
    entirely, but no shipped or currently specced profile is one — the
    probe-on-success branch is presently the only path a successful conversion
    takes; see the 2026-08-26 (issue #41) entries in
-   `docs/specs/spec-profile-registry.md`'s Decision log.
+   `docs/specs/archive/spec-profile-registry.md`'s Decision log.
 2. **Degradation.** The attempt exits non-zero, so *now* `ffmpegtool.probe_streams`
    describes the file. The engine matches each stream against the profile's copy
    mask: streams the mask accepts pass through unchanged — as a literal `copy`, or
@@ -91,7 +91,7 @@ The internal import graph is acyclic today and must stay that way:
    outcome, and the partially written output is removed the same way a
    `failed` one is -- but the outcome does not set the exit code, so a re-run
    over a mixed tree reports the same thing rather than failing forever
-   (`docs/specs/spec-target-driven-cli.md`).
+   (`docs/specs/archive/spec-target-driven-cli.md`).
 
 ## Where new code goes
 

--- a/docs/design/degradation-ladder.md
+++ b/docs/design/degradation-ladder.md
@@ -80,7 +80,7 @@ flowchart TD
   attachment outright, so `mov` maps `0:t?` deliberately to make an
   attachment-bearing source fail the cheap attempt and land on the failure side
   instead — `attachment` is exempted from both sides, not carried on either
-  (`docs/specs/spec-video-formats.md`, issue #39). A new profile that cannot
+  (`docs/specs/archive/spec-video-formats.md`, issue #39). A new profile that cannot
   satisfy the equality, modulo that one exemption, is the bug — not the
   verification.
 
@@ -111,7 +111,7 @@ flowchart TD
   mapping does not enforce would normally have the verification report
   surplus streams the output does contain. The one exception mirrors the
   force-failure exemption above rather than adding a new mechanism: `mp3` and
-  `flac` (`docs/specs/spec-audio-formats.md`) both map audio blindly yet
+  `flac` (`docs/specs/archive/spec-audio-formats.md`) both map audio blindly yet
   declare `stream_limit=1`, because their muxers reject a second audio stream
   outright — measured, both exit non-zero — so a source that would trip the
   limit never reaches the success side at all; it fails the cheap attempt and

--- a/docs/prior-art.md
+++ b/docs/prior-art.md
@@ -202,7 +202,7 @@ evidenced, not assumed — see the image-conversion concern.
     art yields `0,mp3,audio,0` and `1,png,video,1`; a plain h264 file yields
     `0,h264,video,0`. So the cost is one extra `-show_entries` clause, one field
     on `Stream`, and one branch in the engine — materially cheaper than the
-    "engine change" framing `docs/specs/spec-audio-formats.md` recorded when the
+    "engine change" framing `docs/specs/archive/spec-audio-formats.md` recorded when the
     idea was first deferred.
   - AVOID: inferring artwork from the codec name. `mjpeg` and `png` are the codecs
     of both a cover picture and a real video stream, which is exactly why `m4a`
@@ -217,7 +217,7 @@ evidenced, not assumed — see the image-conversion concern.
 - Date: 2026-08-26
 - Notes:
   - ADOPT: the deferral is already documented with its cost, in
-    `docs/specs/spec-audio-formats.md`'s "Two roadmap candidates this phase
+    `docs/specs/archive/spec-audio-formats.md`'s "Two roadmap candidates this phase
     deliberately does not take". This phase cashes it in rather than rediscovering
     it.
   - AVOID: re-opening the phase-3 gate decision. Audio profiles currently drop

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,11 +11,11 @@
 
 | Phase | Name | Spec | Milestone |
 |---|---|---|---|
-| 1 | profile-registry | [spec-profile-registry.md](specs/spec-profile-registry.md) | [#1](https://github.com/bhemsen/converter/milestone/1) |
-| 2 | target-driven-cli | [spec-target-driven-cli.md](specs/spec-target-driven-cli.md) | [#2](https://github.com/bhemsen/converter/milestone/2) |
-| 3 | audio-formats | [spec-audio-formats.md](specs/spec-audio-formats.md) | [#3](https://github.com/bhemsen/converter/milestone/3) |
-| 4 | video-formats | [spec-video-formats.md](specs/spec-video-formats.md) | [#4](https://github.com/bhemsen/converter/milestone/4) |
-| 5 | image-formats | [spec-image-formats.md](specs/spec-image-formats.md) | [#5](https://github.com/bhemsen/converter/milestone/5) |
+| 1 | profile-registry | [spec-profile-registry.md](specs/archive/spec-profile-registry.md) | [#1](https://github.com/bhemsen/converter/milestone/1) |
+| 2 | target-driven-cli | [spec-target-driven-cli.md](specs/archive/spec-target-driven-cli.md) | [#2](https://github.com/bhemsen/converter/milestone/2) |
+| 3 | audio-formats | [spec-audio-formats.md](specs/archive/spec-audio-formats.md) | [#3](https://github.com/bhemsen/converter/milestone/3) |
+| 4 | video-formats | [spec-video-formats.md](specs/archive/spec-video-formats.md) | [#4](https://github.com/bhemsen/converter/milestone/4) |
+| 5 | image-formats | [spec-image-formats.md](specs/archive/spec-image-formats.md) | [#5](https://github.com/bhemsen/converter/milestone/5) |
 | 6 | stream-disposition | — | — |
 | 7 | lossy-source-notes | — | — |
 
@@ -73,7 +73,7 @@ can run as parallel orchestrators. That independence is recorded as the
 Phases 6 and 7 both follow phase 3: each revisits audio profiles that phase 3
 creates, and neither is worth planning before those exist. They are independent
 of each other and of phases 4 and 5. Both were deferred out of phase 3 by name,
-with their costs recorded in `docs/specs/spec-audio-formats.md` rather than left
+with their costs recorded in `docs/specs/archive/spec-audio-formats.md` rather than left
 to be rediscovered — and phase 6's cost turned out to be smaller than that
 deferral assumed.
 

--- a/docs/specs/archive/spec-audio-formats.md
+++ b/docs/specs/archive/spec-audio-formats.md
@@ -87,13 +87,13 @@ merged.** Everything this phase builds on — the `PROFILES` registry, `name` an
 
 ## Prior art
 
-- [Python wrapper structure around the ffmpeg CLI (Phase 3, Phase 4)](../prior-art.md#python-wrapper-structure-around-the-ffmpeg-cli-phase-3-phase-4)
+- [Python wrapper structure around the ffmpeg CLI (Phase 3, Phase 4)](../../prior-art.md#python-wrapper-structure-around-the-ffmpeg-cli-phase-3-phase-4)
   — the concern tagged for this phase. Its ADOPT is confirmation rather than code:
   `ffmpeg-normalize`'s split into per-stream-type handling plus a command builder
   is the shape this codebase already has. Its AVOID is the live one — never scrape
   ffmpeg's stderr to decide a second pass; a profile that "needs" stderr to choose
   an encoder is a profile modelled wrong.
-- [Container/codec capability modelling (Phase 1)](../prior-art.md#containercodec-capability-modelling-phase-1)
+- [Container/codec capability modelling (Phase 1)](../../prior-art.md#containercodec-capability-modelling-phase-1)
   — still governing: HandBrake's copy-mask plus encoder-fallback vocabulary is what
   each new profile is written in, and the ffmpeg-CLI entry is why every mask below
   is curated by hand rather than discovered from `ffmpeg -codecs`.

--- a/docs/specs/archive/spec-audio-formats.md
+++ b/docs/specs/archive/spec-audio-formats.md
@@ -610,3 +610,7 @@ New-Item -ItemType Directory -Force art
   Neither target is silent, and neither needs the ladder to name the loss.
   The Verification item was corrected to describe what the engine actually
   does instead of a speculative asymmetry between the two targets.
+
+- 2026-08-26: Close-out. The final QA gate ran against real ffmpeg 9.0 on
+  Windows 11, verifying all 17 target formats end-to-end with ffprobe.
+  Verdict: PASS WITH FINDINGS; the findings are filed as issues #66-#73.

--- a/docs/specs/archive/spec-image-formats.md
+++ b/docs/specs/archive/spec-image-formats.md
@@ -500,3 +500,7 @@ New-Item -ItemType Directory -Force in
   pinned argv is accepted by real ffmpeg -- the test suite stubs the
   subprocess boundary by constitution -- so that evidence remains whatever
   issues #34 and #35 already measured against ffmpeg 9.0, recorded above.
+
+- 2026-08-26: Close-out. The final QA gate ran against real ffmpeg 9.0 on
+  Windows 11, verifying all 17 target formats end-to-end with ffprobe.
+  Verdict: PASS WITH FINDINGS; the findings are filed as issues #66-#73.

--- a/docs/specs/archive/spec-image-formats.md
+++ b/docs/specs/archive/spec-image-formats.md
@@ -86,11 +86,11 @@ Everything below follows from that table.
 
 ## Prior art
 
-- [Image conversion through ffmpeg (Phase 5)](../prior-art.md#image-conversion-through-ffmpeg-phase-5)
+- [Image conversion through ffmpeg (Phase 5)](../../prior-art.md#image-conversion-through-ffmpeg-phase-5)
   — the concern tagged for this phase. Its ADOPT is confirmed by measurement: all
   seven formats have working ffmpeg muxers, so images need no second backend. Its
   AVOID is why EXIF/ICC preservation is a non-goal rather than a bug.
-- [Container/codec capability modelling (Phase 1)](../prior-art.md#containercodec-capability-modelling-phase-1)
+- [Container/codec capability modelling (Phase 1)](../../prior-art.md#containercodec-capability-modelling-phase-1)
   — the copy-mask vocabulary, and the rule that the mask is curated by hand.
 
 ## Design

--- a/docs/specs/archive/spec-profile-registry.md
+++ b/docs/specs/archive/spec-profile-registry.md
@@ -93,13 +93,13 @@ and milestone. A completed spec is moved to `docs/specs/archive/`.
 
 ## Prior art
 
-- [Container/codec capability modelling (Phase 1)](../prior-art.md#containercodec-capability-modelling-phase-1)
+- [Container/codec capability modelling (Phase 1)](../../prior-art.md#containercodec-capability-modelling-phase-1)
   — the whole concern feeds this phase. HandBrake's `AudioCopyMask` plus
   `AudioEncoderFallback` is the vocabulary the profile value type adopts; the
   ffmpeg-CLI entry is why the copy mask is curated by hand instead of discovered;
   this codebase's own entry is why trial-and-fallback survives the refactor while
   its per-pair ladders do not.
-- [Python wrapper structure around the ffmpeg CLI (Phase 3, Phase 4)](../prior-art.md#python-wrapper-structure-around-the-ffmpeg-cli-phase-3-phase-4)
+- [Python wrapper structure around the ffmpeg CLI (Phase 3, Phase 4)](../../prior-art.md#python-wrapper-structure-around-the-ffmpeg-cli-phase-3-phase-4)
   — secondary: `ffmpeg-normalize`'s split into stream types, a command builder and
   dedicated exceptions independently matches the layering this phase keeps, and
   its AVOID note (never scrape ffmpeg's stderr to drive a second pass) is exactly

--- a/docs/specs/archive/spec-profile-registry.md
+++ b/docs/specs/archive/spec-profile-registry.md
@@ -462,3 +462,7 @@ why both audio fixtures use that suffix.
   conversion because every conversion is, structurally, at risk of one. A phase
   not yet on the roadmap could still introduce an exhaustive profile; nothing
   here forecloses that.
+
+- 2026-08-26: Close-out. The final QA gate ran against real ffmpeg 9.0 on
+  Windows 11, verifying all 17 target formats end-to-end with ffprobe.
+  Verdict: PASS WITH FINDINGS; the findings are filed as issues #66-#73.

--- a/docs/specs/archive/spec-target-driven-cli.md
+++ b/docs/specs/archive/spec-target-driven-cli.md
@@ -327,7 +327,7 @@ reusing the fixtures the phase-1 gate synthesises:
   reports that cost honestly. Recorded as revisitable if the cost bites.
 - 2026-08-26 (#12): `SOURCE_SUFFIXES` seeded with exactly `.mkv`, `.mp4`, `.opus`,
   `.wav` — the old `video`/`audio` sub-commands' suffixes plus each shipped
-  profile's own target suffix. `docs/specs/spec-video-formats.md` (phase 4, not
+  profile's own target suffix. `docs/specs/archive/spec-video-formats.md` (phase 4, not
   yet merged) attributes `.mp4` to phase 3 instead, but this phase's own
   Verification list requires a source with the target's suffix to be a
   candidate ("a source with the target's suffix but a different output root
@@ -483,3 +483,7 @@ reusing the fixtures the phase-1 gate synthesises:
   `tests/test_cli.py::test_the_legacy_message_names_no_format` pins). Reworded
   to say the old sub-command "prints a pointer to `--to` and `--list-formats`"
   instead of claiming it repeats the README's own `mp4`/`wav` examples.
+
+- 2026-08-26: Close-out. The final QA gate ran against real ffmpeg 9.0 on
+  Windows 11, verifying all 17 target formats end-to-end with ffprobe.
+  Verdict: PASS WITH FINDINGS; the findings are filed as issues #66-#73.

--- a/docs/specs/archive/spec-target-driven-cli.md
+++ b/docs/specs/archive/spec-target-driven-cli.md
@@ -102,7 +102,7 @@ milestone. A completed spec is moved to `docs/specs/archive/`.
 
 ## Prior art
 
-- [Format-driven converter CLI (Phase 2)](../prior-art.md#format-driven-converter-cli-phase-2)
+- [Format-driven converter CLI (Phase 2)](../../prior-art.md#format-driven-converter-cli-phase-2)
   — the concern that feeds this phase. pandoc's readers-plus-writers is the direct
   precedent for `--to` over per-pair sub-commands: N+M implementations instead of
   N*M, with the ffprobe stream list as the reader and the target profile as the

--- a/docs/specs/archive/spec-video-formats.md
+++ b/docs/specs/archive/spec-video-formats.md
@@ -369,7 +369,7 @@ New-Item -ItemType Directory -Force in
   (`codec_name` reported as `unknown`, measured) round-trips through
   `-map 0:t? -c copy` and through the selective rung's `-c:t:0 copy` alike.
   `jobs.py` needed no change, keeping the PR's diff to `converter/profiles.py`,
-  `README.md`, `docs/specs/spec-video-formats.md` and `tests/`.
+  `README.md`, `docs/specs/archive/spec-video-formats.md` and `tests/`.
 
   `mkv`'s cheap attempt maps `video`, `audio`, `subtitle` and `attachment`, and
   the profile declares exactly those four rules, so it satisfies
@@ -406,7 +406,7 @@ New-Item -ItemType Directory -Force in
   existing "no rule for this type" branch, so the per-stream drop note falls
   out of the engine that shipped for `mp4`'s attachment case rather than
   needing new logic, keeping the PR's diff to `converter/profiles.py`,
-  `README.md`, `docs/specs/spec-video-formats.md` and `tests/`.
+  `README.md`, `docs/specs/archive/spec-video-formats.md` and `tests/`.
 
 - 2026-08-26 (issue #29): Added the `webm` `Profile`, the last of this phase's
   three. Re-measured every muxer fact against real ffmpeg 9.0 while
@@ -562,3 +562,7 @@ New-Item -ItemType Directory -Force in
   log entries are append-only outside one's own), but recorded here since the
   Verification item is what actually gates the milestone and now matches
   what this run observed rather than the older claim.
+
+- 2026-08-26: Close-out. The final QA gate ran against real ffmpeg 9.0 on
+  Windows 11, verifying all 17 target formats end-to-end with ffprobe.
+  Verdict: PASS WITH FINDINGS; the findings are filed as issues #66-#73.

--- a/docs/specs/archive/spec-video-formats.md
+++ b/docs/specs/archive/spec-video-formats.md
@@ -86,12 +86,12 @@ orchestrators (`docs/workflow.md`).
 
 ## Prior art
 
-- [Container/codec capability modelling (Phase 1)](../prior-art.md#containercodec-capability-modelling-phase-1)
+- [Container/codec capability modelling (Phase 1)](../../prior-art.md#containercodec-capability-modelling-phase-1)
   — HandBrake's copy-mask plus encoder-fallback vocabulary, and the ffmpeg-CLI
   entry's AVOID: the mask is curated by hand, because `ffmpeg -codecs` lists what a
   build contains and never what a muxer will accept. Every mask below was measured
   instead of derived.
-- [Python wrapper structure around the ffmpeg CLI (Phase 3, Phase 4)](../prior-art.md#python-wrapper-structure-around-the-ffmpeg-cli-phase-3-phase-4)
+- [Python wrapper structure around the ffmpeg CLI (Phase 3, Phase 4)](../../prior-art.md#python-wrapper-structure-around-the-ffmpeg-cli-phase-3-phase-4)
   — tagged for this phase too. Its AVOID: never parse values out of ffmpeg's stderr
   to drive a second pass. Relevant here because WebM's rejection message names the
   codecs it wants, which is exactly the tempting string to scrape; the copy mask

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -161,7 +161,7 @@ class TestWavJob:
 
 
 class TestMp3Job:
-    """Issue #21, `docs/specs/spec-audio-formats.md`: mp3's cheap attempt maps
+    """Issue #21, `docs/specs/archive/spec-audio-formats.md`: mp3's cheap attempt maps
     audio *blindly*, unlike WAV's index-explicit one, so unlike WAV a fully
     compatible single-stream source still gets a selective rung -- the same
     shape MP4 has (`TestMp4Retries.test_selective_copies_compatible_streams`)."""
@@ -233,7 +233,7 @@ class TestMp3Job:
 
 
 class TestFlacJob:
-    """Issue #21, `docs/specs/spec-audio-formats.md`: same blind-mapping shape
+    """Issue #21, `docs/specs/archive/spec-audio-formats.md`: same blind-mapping shape
     as `MP3`, but flac's fallback carries no `fallback_name`, so a re-encode
     into flac itself is never reported as a loss."""
 
@@ -300,7 +300,7 @@ class TestFlacJob:
 
 
 class TestM4aJob:
-    """Issue #22, `docs/specs/spec-audio-formats.md`: same blind-mapping shape
+    """Issue #22, `docs/specs/archive/spec-audio-formats.md`: same blind-mapping shape
     as `MP3`/`FLAC`, but `m4a` declares no `stream_limit` -- the ipod muxer
     holds several audio streams, so every one the source has is carried."""
 
@@ -395,7 +395,7 @@ class TestM4aJob:
 
 
 class TestOggJob:
-    """Issue #22, `docs/specs/spec-audio-formats.md`: same shape as `M4A`,
+    """Issue #22, `docs/specs/archive/spec-audio-formats.md`: same shape as `M4A`,
     with a wider copy mask and no stream limit either -- the ogg muxer holds
     several audio streams too."""
 
@@ -417,7 +417,7 @@ class TestOggJob:
         assert attempts[0].notes == ()
 
     def test_non_matching_audio_reencodes_with_a_note(self):
-        """The ogg muxer rejects mp3 and aac (docs/specs/spec-audio-formats.md)."""
+        """The ogg muxer rejects mp3 and aac (docs/specs/archive/spec-audio-formats.md)."""
         streams = [Stream(0, "audio", "aac")]
 
         selective = jobs.retries(OGG, streams)[0]
@@ -486,7 +486,7 @@ class TestOggJob:
 
 
 class TestOpusJob:
-    """Issue #22, `docs/specs/spec-audio-formats.md`: `opus` copies on the
+    """Issue #22, `docs/specs/archive/spec-audio-formats.md`: `opus` copies on the
     happy path even though its own muxer also accepts a Vorbis stream (Prior
     decisions) -- the mask below governs only the failure-side selective rung,
     where a Vorbis stream is re-encoded rather than copied."""
@@ -1236,7 +1236,7 @@ class TestWebmDegradationNotes:
 
 class TestProfileArgvPinning:
     """Verification: the full argv each profile builds, pinned byte-for-byte
-    (docs/specs/spec-profile-registry.md)."""
+    (docs/specs/archive/spec-profile-registry.md)."""
 
     def test_mp4_copyable_source(self):
         streams = [Stream(0, "video", "h264"), Stream(1, "audio", "aac")]
@@ -2539,7 +2539,7 @@ class TestAnimatedProfileArgvPinning:
 
 class TestUnsupportedDiscriminator:
     """`jobs.describe_unsupported`: "no rule matches any present stream"
-    (docs/specs/spec-target-driven-cli.md), derived from the probe alone."""
+    (docs/specs/archive/spec-target-driven-cli.md), derived from the probe alone."""
 
     def test_a_type_with_no_rule_at_all_is_unsupported(self):
         notes = jobs.describe_unsupported(WAV, [Stream(0, "video", "h264")])

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -139,7 +139,7 @@ class TestConvertOne:
         in the milestone's QA gate) must climb to the selective rung's re-encode
         rather than exhaust the whole ladder into `Outcome.FAILED` -- verified
         against the real engine during the audio-formats spec's review
-        (docs/specs/spec-audio-formats.md's Decision log, 2026-08-25 entry: "a
+        (docs/specs/archive/spec-audio-formats.md's Decision log, 2026-08-25 entry: "a
         PCM stream yields `selective` then `re-encode`"). `mp3`/`flac`'s
         `last_resort` exists to rescue a *different* case -- a mask hit whose
         copy the muxer then refuses -- so a PCM source landing there instead of
@@ -343,7 +343,7 @@ class TestPartialCheapAttemptVerification:
 
 
 class TestUnsupportedOutcome:
-    """The `unsupported` outcome (docs/specs/spec-target-driven-cli.md): a
+    """The `unsupported` outcome (docs/specs/archive/spec-target-driven-cli.md): a
     source that carries no stream of any type the target profile has a rule
     for at all, distinct from a stream a rule drops or fails to re-encode.
     """
@@ -438,7 +438,7 @@ class TestUnsupportedOutcome:
         """A probe that succeeds but reports zero streams is what a corrupt or
         truncated source looks like -- not evidence the format holds nothing
         usable -- so it must not be quietly relabelled `unsupported` with no
-        notes and no error text (docs/specs/spec-target-driven-cli.md)."""
+        notes and no error text (docs/specs/archive/spec-target-driven-cli.md)."""
         task = self._video_only_task(tmp_path)
         task.dst.parent.mkdir(parents=True)
         fake_ffmpeg.exit_codes = [1]

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -106,7 +106,7 @@ FORCED_FAILURE_TYPES: dict[str, frozenset[str]] = {
 #: are the profiles issue #40's narrowing was written for -- both map audio
 #: blindly (`-map 0:a?`) yet declare `stream_limit=1`, because their own
 #: muxers reject a second audio stream outright (measured against ffmpeg 9.0,
-#: `docs/specs/spec-audio-formats.md`): a source that would trip the limit
+#: `docs/specs/archive/spec-audio-formats.md`): a source that would trip the limit
 #: never reaches the success side at all; it fails the cheap attempt and lands
 #: on the failure side, where the declared limit drives the selective rung's
 #: own note instead.
@@ -201,7 +201,7 @@ def named_index_counts(profile: Profile) -> dict[str, int]:
 
 #: Exactly `SHIPPED`: both exemptions are now proven by shipped profiles rather
 #: than a stand-in -- `MP3` and `FLAC` prove the muxer-enforced `stream_limit`
-#: exemption (`docs/specs/spec-audio-formats.md`, which retired `MP3_SHAPED`),
+#: exemption (`docs/specs/archive/spec-audio-formats.md`, which retired `MP3_SHAPED`),
 #: and `MOV` now proves the force-failure exemption the same way, retiring
 #: `MOV_SHAPED`.
 INVARIANT_CASES = SHIPPED
@@ -533,7 +533,7 @@ class TestWavProfile:
         above already pin most of this; this test compares the *whole* frozen
         `Profile` at once, so a change to any field -- including one nobody
         wrote a dedicated assertion for -- fails here. Notably: the gate
-        (`docs/specs/spec-audio-formats.md`) deliberately did NOT extend the
+        (`docs/specs/archive/spec-audio-formats.md`) deliberately did NOT extend the
         five siblings' standing non-audio note to `wav`, to keep this exact
         promise; a well-intentioned "consistency" edit adding one would trip
         this test immediately.
@@ -655,7 +655,7 @@ class TestMkvProfile:
 
 class TestMovProfile:
     """Pins the shape Acceptance fixes for `mov` (issue #28,
-    `docs/specs/spec-video-formats.md`)."""
+    `docs/specs/archive/spec-video-formats.md`)."""
 
     def test_label_and_suffix(self):
         assert MOV.label == "MOV"
@@ -739,7 +739,7 @@ class TestMovProfile:
 
 class TestWebmProfile:
     """Pins the shape Acceptance fixes for `webm` (issue #29,
-    `docs/specs/spec-video-formats.md`)."""
+    `docs/specs/archive/spec-video-formats.md`)."""
 
     def test_label_and_suffix(self):
         assert WEBM.label == "WebM"
@@ -867,7 +867,7 @@ class TestWebmProfile:
 
 class TestMp3Profile:
     """Pins the shape Acceptance fixes for `mp3` (issue #21,
-    `docs/specs/spec-audio-formats.md`)."""
+    `docs/specs/archive/spec-audio-formats.md`)."""
 
     def test_label_and_suffix(self):
         assert MP3.label == "MP3"
@@ -915,7 +915,7 @@ class TestMp3Profile:
 
 class TestFlacProfile:
     """Pins the shape Acceptance fixes for `flac` (issue #21,
-    `docs/specs/spec-audio-formats.md`)."""
+    `docs/specs/archive/spec-audio-formats.md`)."""
 
     def test_label_and_suffix(self):
         assert FLAC.label == "FLAC"
@@ -966,7 +966,7 @@ class TestFlacProfile:
 
 class TestM4aProfile:
     """Pins the shape Acceptance fixes for `m4a` (issue #22,
-    `docs/specs/spec-audio-formats.md`)."""
+    `docs/specs/archive/spec-audio-formats.md`)."""
 
     def test_label_and_suffix(self):
         assert M4A.label == "M4A"
@@ -997,7 +997,7 @@ class TestM4aProfile:
     def test_audio_rule_mask_and_fallback(self):
         """The mask is `{aac, alac}`, not `MP4_AUDIO_CODECS`: `.m4a` selects
         the narrower `ipod` muxer, which rejects mp3, opus and flac stream
-        copies (docs/specs/spec-audio-formats.md)."""
+        copies (docs/specs/archive/spec-audio-formats.md)."""
         rule = M4A.rules["audio"]
 
         assert rule.copy_mask == frozenset({"aac", "alac"})
@@ -1028,7 +1028,7 @@ class TestM4aProfile:
 
 class TestOggProfile:
     """Pins the shape Acceptance fixes for `ogg` (issue #22,
-    `docs/specs/spec-audio-formats.md`)."""
+    `docs/specs/archive/spec-audio-formats.md`)."""
 
     def test_label_and_suffix(self):
         assert OGG.label == "OGG"
@@ -1043,7 +1043,7 @@ class TestOggProfile:
 
     def test_cheap_attempt_maps_audio_blindly(self):
         """ "-c copy", not "-c:a copy": the spec pins this exact spelling
-        (docs/specs/spec-audio-formats.md's fixed-profiles table)."""
+        (docs/specs/archive/spec-audio-formats.md's fixed-profiles table)."""
         assert OGG.explicit_streams is False
         assert OGG.cheap_attempt.options == ("-map", "0:a?", "-c", "copy")
 
@@ -1083,7 +1083,7 @@ class TestOggProfile:
 
 class TestOpusProfile:
     """Pins the shape Acceptance fixes for `opus` (issue #22,
-    `docs/specs/spec-audio-formats.md`)."""
+    `docs/specs/archive/spec-audio-formats.md`)."""
 
     def test_label_and_suffix(self):
         assert OPUS.label == "OPUS"
@@ -1123,7 +1123,7 @@ class TestOpusProfile:
 
     def test_audio_rule_declares_no_stream_limit(self):
         """The opus muxer holds several audio streams, by copy and by
-        encode (docs/specs/spec-audio-formats.md)."""
+        encode (docs/specs/archive/spec-audio-formats.md)."""
         assert OPUS.rules["audio"].stream_limit is None
 
     def test_audio_rule_carries_the_position_placeholder(self):


### PR DESCRIPTION
## Summary

Milestone close-out for the five full-spec phases that make up the converter's initial format coverage:

| # | Milestone | Spec |
|---|---|---|
| 1 | profile-registry | `docs/specs/archive/spec-profile-registry.md` |
| 2 | target-driven-cli | `docs/specs/archive/spec-target-driven-cli.md` |
| 3 | audio-formats | `docs/specs/archive/spec-audio-formats.md` |
| 4 | video-formats | `docs/specs/archive/spec-video-formats.md` |
| 5 | image-formats | `docs/specs/archive/spec-image-formats.md` |

All issues in all five milestones are closed. The final QA gate ran against real ffmpeg 9.0 on Windows 11, verifying all 17 target formats end-to-end with ffprobe: **PASS WITH FINDINGS**, with the findings filed as issues #66-#73 (not blockers for this close-out).

- Archives the five specs to `docs/specs/archive/`, per the close-out convention in `docs/workflow.md`.
- Repoints every reference to the old spec paths across `docs/`, `converter/` and `tests/` (comment/docstring cross-references, not behavior).
- Updates the `docs/roadmap.md` phase table's Spec links to the archive location (phase 6/7 rows untouched).
- Records the QA outcome as a dated Decision-log entry in each of the five archived specs.

This PR does not close an issue — it is milestone close-out, and `docs:` is exempt from the spec-trace rule. The five milestones are closed via the GitHub API after this merges; issues #66-#73 get their `Spec:` line corrected in a follow-up step.

## Test plan

- [x] `.venv/Scripts/python.exe scripts/verify.py` green (lint, format, 888 tests)
- [x] Every rewritten link/path reference verified to resolve to a file that exists on disk
- [x] CI (7-job Linux+Windows matrix) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pdnJyntsFJyawGBSGj4cV