### PR TITLE
fix(spec): replace the removed video/audio sub-commands in the QA block

### DIFF
--- a/docs/specs/archive/spec-profile-registry.md
+++ b/docs/specs/archive/spec-profile-registry.md
@@ -237,12 +237,16 @@ find tag for codec vp8 in stream #0, codec not currently supported in
 container`), so the remux fails and the selective rung has to re-encode the
 video. `attached.mkv` and
 `two-tone.opus` exist to make deltas 1 and 2 observable — the other fixtures
-never reach those branches. The WAV job only accepts `.opus` sources, which is
-why both audio fixtures use that suffix.
+never reach those branches. `tone.opus` and `two-tone.opus` use `.opus` because
+they are the single- and two-audio-stream cases delta 2 needs, not because
+`--to wav` is suffix-restricted: it attempts every source in `in/` and reports
+`unsupported` for `lossless.mkv` and `attached.mkv`, which carry no audio
+stream at all, while `clip.mkv` converts to `.wav` too despite not being
+`.opus`.
 
-- [ ] `converter video in out` converts `clip.mkv` to a playable `.mp4` and
+- [ ] `converter --to mp4 in out` converts `clip.mkv` to a playable `.mp4` and
       reports `converted`, `0 failed`, exit 0.
-- [ ] `converter audio in out` converts `tone.opus` to a playable `.wav`.
+- [ ] `converter --to wav in out` converts `tone.opus` to a playable `.wav`.
 - [ ] `lossless.mkv` still converts, and prints a note naming the stream index,
       `vp8`, and the re-encode to h264.
 - [ ] A second run of each over the same output tree reports `0 converted`,
@@ -466,3 +470,28 @@ why both audio fixtures use that suffix.
 - 2026-08-26: Close-out. The final QA gate ran against real ffmpeg 9.0 on
   Windows 11, verifying all 17 target formats end-to-end with ffprobe.
   Verdict: PASS WITH FINDINGS; the findings are filed as issues #66-#73.
+- 2026-08-27 (issue #70): the human QA gate's `converter video in out` and
+  `converter audio in out` lines are replaced with `converter --to mp4 in out`
+  and `converter --to wav in out` — the `video`/`audio` sub-commands were
+  removed in phase 2 (issue #15) and now exit 2 with a migration message, so
+  the block could not be run as written. Re-run in full against real ffmpeg 9.0
+  on Windows 11 (gyan.dev build) from a bootstrapped worktree, `--ffmpeg` /
+  `--ffprobe` pointed at the absolute paths from *This machine*: `--to mp4`
+  converts all five `in/` fixtures (`5 converted, 0 failed`, exit 0),
+  `lossless.mkv` re-encodes with the note
+  `video stream 0 (vp8) re-encoded to h264`, and `attached.mkv`'s note names
+  the codec (`attachment stream 1 (ttf) dropped: not supported by MP4`,
+  delta 1). `--to wav` converts `clip.mkv`, `tone.opus` and `two-tone.opus`
+  (`3 converted, 0 failed`, `2 unsupported`), with `two-tone.opus` noting
+  `audio stream 1 (opus) dropped: WAV holds 1 audio stream` (delta 2). A second
+  run of each reports `0 converted`, `N skipped`, `0 failed`, exit 0.
+  `ffprobe` on the outputs confirms `clip.mp4` (h264/aac), `lossless.mp4`
+  (h264) and `tone.wav` (pcm_s16le) are genuinely playable. One correction
+  beyond the two command lines: the sentence "the WAV job only accepts `.opus`
+  sources" no longer holds under `--to wav`, which attempts every source in
+  `in/` — `clip.mkv` converts to `.wav` too (it has an AAC audio stream), and
+  `lossless.mkv`/`attached.mkv` are reported `unsupported` for lacking any
+  audio stream rather than being silently skipped by suffix. Reworded to say
+  why the `.opus` fixtures exist (the single- and two-audio-stream cases delta
+  2 needs) without the false suffix-restriction claim. Everything else in the
+  Verification block matched observation and needed no change.


### PR DESCRIPTION
## Summary
- `docs/specs/archive/spec-profile-registry.md`'s human QA gate still instructed `converter video in out` / `converter audio in out`, both removed in phase 2 (issue #15) and now exiting 2 with a migration message — the block could not be run as written.
- Replaced with `converter --to mp4 in out` / `converter --to wav in out`, matching what `spec-target-driven-cli.md` documents.
- Re-ran the entire Verification block against real ffmpeg 9.0 (gyan.dev build) on Windows 11, from a bootstrapped worktree venv, with `--ffmpeg`/`--ffprobe` pointed at the absolute paths, in a temp directory outside the repo.
- Corrected one other stale claim found along the way: the prose said "the WAV job only accepts `.opus` sources" — no longer true under `--to wav`, which attempts every source in `in/` (`clip.mkv` converts too) and reports `unsupported` only for sources with no audio stream at all (`lossless.mkv`, `attached.mkv`).

## Observed QA output
- `--to mp4 in out`: `5 converted, 0 skipped, 0 failed, 0 unsupported (of 5)`, exit 0. `lossless.mkv` note: `video stream 0 (vp8) re-encoded to h264`. `attached.mkv` note (delta 1): `attachment stream 1 (ttf) dropped: not supported by MP4`.
- `--to wav in out`: `3 converted, 0 skipped, 0 failed, 2 unsupported (of 5)`, exit 0. `two-tone.opus` note (delta 2): `audio stream 1 (opus) dropped: WAV holds 1 audio stream`.
- ffprobe confirms `clip.mp4` (h264/aac), `lossless.mp4` (h264) and `tone.wav` (pcm_s16le) are genuinely playable.
- Second run of each: `0 converted`, `N skipped`, `0 failed`, exit 0.
- Full detail recorded in the spec's Decision log (2026-08-27, issue #70).

## Test plan
- [x] `.venv/Scripts/python.exe scripts/verify.py` green (ruff check, ruff format --check, 888 tests passed)
- [x] `git diff main -- converter/cli.py converter/batch.py converter/paths.py` empty (docs-only change)

Closes #70