### PR TITLE
docs(readme): warn that --to opus can produce vorbis in a .opus file

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ note    Show.S01E02.mkv: subtitle stream 2 (hdmv_pgs_subtitle) dropped: bitmap s
   embedded cover art — is left out. A straight copy says so even when the
   source had nothing to lose; when the audio itself has to be re-encoded, the
   dropped stream is still named, just without the extra line.
+* **`--to opus` can hand you a `.opus` file that is actually Vorbis.** A
+  Vorbis source (typically a `.ogg`/`.oga` file) is stream-copied into the
+  `.opus` container without transcoding — genuinely lossless, but `.opus` is a
+  codec-defined format (RFC 7845), so strict players may reject the result.
+  This is a deliberate trade: forcing a re-encode instead would cost every
+  already-Opus source a generation loss just to guard against a mislabel that
+  only a Vorbis source can trigger. Point a Vorbis source at `--to ogg`
+  instead for a lossless copy that keeps its real codec.
 * **Windows path length.** Mirroring a deep source tree onto a sub-directory can
   push paths past Windows' 260-character limit; the error message says so when it
   happens. Either pick a shorter output root or

--- a/docs/specs/archive/spec-audio-formats.md
+++ b/docs/specs/archive/spec-audio-formats.md
@@ -619,7 +619,10 @@ New-Item -ItemType Directory -Force art
   `.opus` mislabel as `opus`'s one deliberate trade, but `README.md` never
   said so. Re-measured against ffmpeg 9.0 before writing anything: a
   `libvorbis`-encoded `.ogg` through `--to opus` produced a `.opus` file
-  byte-identical to the source (6913 bytes both sides) whose stream
+  identical in size to the source (6913 bytes both sides, this spec's
+  established "byte-identical in size" convention from line 130 -- a byte
+  compare (`cmp -l`) shows 32 differing bytes, the Ogg muxer's per-page
+  serial number and CRC, unrelated to the audio payload) whose stream
   `ffprobe` still reports as `codec_name=vorbis`. Added a `README.md` bullet
   to "Notes and limitations" stating the mislabel plainly, naming the RFC
   7845 codec-defined-format reason strict players may reject it, and pointing

--- a/docs/specs/archive/spec-audio-formats.md
+++ b/docs/specs/archive/spec-audio-formats.md
@@ -614,3 +614,15 @@ New-Item -ItemType Directory -Force art
 - 2026-08-26: Close-out. The final QA gate ran against real ffmpeg 9.0 on
   Windows 11, verifying all 17 target formats end-to-end with ffprobe.
   Verdict: PASS WITH FINDINGS; the findings are filed as issues #66-#73.
+- 2026-08-27 (#68): The QA gate's finding was a docs gap, not a profile bug:
+  "The opus decision, in full" above had already accepted the Vorbis-into-
+  `.opus` mislabel as `opus`'s one deliberate trade, but `README.md` never
+  said so. Re-measured against ffmpeg 9.0 before writing anything: a
+  `libvorbis`-encoded `.ogg` through `--to opus` produced a `.opus` file
+  byte-identical to the source (6913 bytes both sides) whose stream
+  `ffprobe` still reports as `codec_name=vorbis`. Added a `README.md` bullet
+  to "Notes and limitations" stating the mislabel plainly, naming the RFC
+  7845 codec-defined-format reason strict players may reject it, and pointing
+  a Vorbis source at `--to ogg` instead. No profile, engine or test change --
+  the behaviour itself was already correct and already decided; this closes
+  the gap between that decision and what the user is told.


### PR DESCRIPTION
## Summary
- `--to opus` stream-copies a Vorbis source into a `.opus` container without transcoding — deliberately accepted in `docs/specs/archive/spec-audio-formats.md` ("The opus decision, in full") to avoid a generation loss on every already-Opus file, but README never told the user
- Adds a `README.md` "Notes and limitations" bullet stating the mislabel plainly, naming the RFC 7845 codec-defined-format reason strict players may reject it, and pointing a Vorbis source at `--to ogg` instead
- Adds a decision-log entry to the spec recording the reproduction and the doc change

## Reproduction (ffmpeg 9.0, Windows 11)
```
& $FF -y -f lavfi -i sine=duration=2 -c:a libvorbis vo/vorbsrc-68.ogg
& .venv/Scripts/python.exe -m converter --ffmpeg $FF --ffprobe $FP --to opus vo out-opus -q
& $FP -v error -show_entries "stream=codec_name" -of "default=nw=1:nk=1" out-opus/vorbsrc-68.opus
```
Result: `codec_name=vorbis`, output file byte-identical to the source (6913 bytes both sides) — confirms the stream copy is genuinely lossless and genuinely mislabeled.

This is documentation-only: no change to `converter/profiles.py`, `converter/jobs.py`, or any test — the behaviour was already correct and already decided; this closes the gap between that decision and what the user is told.

## Test plan
- [x] `.venv/Scripts/python.exe scripts/verify.py` green (888 tests)
- [x] Reproduced the mislabel against real ffmpeg 9.0 as shown above

Closes #68