### PR TITLE
fix(cli): mirror --mirror-to onto the typed input path, not its resolved one

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,20 @@ option list (`converter mirror --help` for the mirror sub-command's own).
 | `-q`, `--quiet` | hide the progress bar |
 | `--ffmpeg`, `--ffprobe` | use a specific executable instead of searching `PATH` |
 
+> **`--mirror-to` and `subst`/junction/symlinked inputs.** `--mirror-to` re-roots
+> `INPUT_DIR` onto `ROOT` using the path you typed, not the physical path it
+> resolves to. So `subst Q: D:\Rips` followed by
+> `converter --to mp4 -r Q:\ --mirror-to E:` writes to `E:\...` mirroring what is
+> under `Q:\`, **not** `E:\D\Rips\...` or some other re-rooting of the physical
+> drive `Q:` happens to point at. The same holds for a directory junction or an
+> NTFS symlink standing in for `INPUT_DIR`. This only changes the *shape* of the
+> mirrored tree; the safety checks below are unaffected — a self-write or an
+> `--overwrite` hazard is still caught by resolving both the input and the
+> derived output path to their physical location before comparing, however
+> `INPUT_DIR` was typed, so mirroring a virtual drive back onto the real
+> location it points at is still refused (self-write) or reported (skip)
+> exactly as if no `subst`/junction/symlink were involved.
+
 ### Examples
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -107,17 +107,20 @@ option list (`converter mirror --help` for the mirror sub-command's own).
 
 > **`--mirror-to` and `subst`/junction/symlinked inputs.** `--mirror-to` re-roots
 > `INPUT_DIR` onto `ROOT` using the path you typed, not the physical path it
-> resolves to. So `subst Q: D:\Rips` followed by
-> `converter --to mp4 -r Q:\ --mirror-to E:` writes to `E:\...` mirroring what is
-> under `Q:\`, **not** `E:\D\Rips\...` or some other re-rooting of the physical
-> drive `Q:` happens to point at. The same holds for a directory junction or an
-> NTFS symlink standing in for `INPUT_DIR`. This only changes the *shape* of the
-> mirrored tree; the safety checks below are unaffected — a self-write or an
-> `--overwrite` hazard is still caught by resolving both the input and the
-> derived output path to their physical location before comparing, however
-> `INPUT_DIR` was typed, so mirroring a virtual drive back onto the real
-> location it points at is still refused (self-write) or reported (skip)
-> exactly as if no `subst`/junction/symlink were involved.
+> resolves to. So `subst Q: <fixtures>` followed by
+> `converter --to mp4 -r Q:\ --mirror-to R:` writes to `R:\Season1\...`, mirroring
+> the shallow tree under `Q:\` — **not** `R:\Users\...\<physical path>\Season1\...`,
+> the whole physical path `Q:` happens to resolve to. The same holds for a
+> directory junction, an NTFS symlink standing in for `INPUT_DIR`, or a relative
+> `INPUT_DIR` (mirrored from the path as given, not resolved against the current
+> working directory first). This only changes the *shape* of the mirrored tree,
+> never its safety: a self-write (`INPUT_DIR` and `--mirror-to` resolving to the
+> same file) is still reported as a skipped file at exit 0, and an `--overwrite`
+> hazard that would destroy one of the run's own inputs is still refused at
+> exit 2 — both checks resolve the input and the derived output path to their
+> physical location at comparison time, so mirroring a virtual drive back onto
+> the real directory behind it is still caught exactly as if no
+> `subst`/junction/symlink were involved.
 
 ### Examples
 

--- a/converter/cli.py
+++ b/converter/cli.py
@@ -178,11 +178,25 @@ def list_formats_command() -> int:
 
 
 def _resolve_output_root(args: argparse.Namespace) -> Path:
+    """Derive OUTPUT from ``--mirror-to``, or return the OUTPUT the user gave.
+
+    ``--mirror-to`` re-roots the path *as typed*, not ``args.input_dir.resolve()``
+    -- a `subst`/junction/symlinked INPUT would otherwise mirror onto the
+    physical path it resolves to, nesting the whole physical prefix into the
+    output tree instead of the shallow tree the user asked for (issue #72).
+    This is safe: the self-write and overwrite-hazard guards
+    (``paths.is_self_write``, ``paths.find_overwrite_hazards``) resolve both
+    the source and the derived output path themselves, independently, at
+    comparison time -- so a mirrored output that physically lands back on an
+    input is still caught no matter how the output root was built. Only
+    ``README.md``'s documented shape of the mirrored tree depends on this
+    choice, not the safety of the guards.
+    """
     if args.output_dir is not None and args.mirror_to is not None:
         raise UsageError("give either OUTPUT or --mirror-to, not both")
     if args.mirror_to is not None:
         try:
-            return paths.mirror_to_drive(args.input_dir.resolve(), args.mirror_to)
+            return paths.mirror_to_drive(args.input_dir, args.mirror_to)
         except ValueError as exc:
             raise UsageError(str(exc)) from exc
     if args.output_dir is not None:
@@ -358,14 +372,19 @@ def convert_command(args: argparse.Namespace) -> int:
 
 
 def mirror_command(args: argparse.Namespace) -> int:
-    """Print, and optionally create, the mirrored directory tree."""
+    """Print, and optionally create, the mirrored directory tree.
+
+    Re-roots each directory *as typed*, matching ``_resolve_output_root``: this
+    command exists to preview what ``--mirror-to`` will do, so resolving here
+    and not there would make the preview lie about the tree that gets built.
+    """
     try:
         directories = paths.list_directories(args.input_root, recursive=args.recursive)
     except NotADirectoryError as exc:
         raise UsageError(str(exc)) from exc
     for directory in directories:
         try:
-            target = paths.mirror_to_drive(directory.resolve(), args.output_root)
+            target = paths.mirror_to_drive(directory, args.output_root)
         except ValueError as exc:
             raise UsageError(str(exc)) from exc
         print(f"{directory} -> {target}")

--- a/converter/paths.py
+++ b/converter/paths.py
@@ -24,10 +24,10 @@ def _resolved_key(path: str | os.PathLike[str]) -> str:
     """Return a case-folded string of *path*, resolved, for identity comparisons.
 
     Resolving first -- rather than comparing the paths as given -- is what
-    catches a ``--mirror-to`` self-write or hazard: the output root is derived
-    from a resolved input path while discovery returns paths built from the
-    root as typed, so two paths that name the same file can look different
-    until both sides are resolved.
+    catches a ``--mirror-to`` self-write or hazard when a `subst`/junction/
+    symlinked INPUT and the ``--mirror-to`` target can each be spelled through
+    the alias or through the real path behind it: two paths that name the same
+    file can look completely different strings until both sides are resolved.
     """
     return os.path.normcase(os.fspath(Path(path).resolve()))
 
@@ -210,9 +210,10 @@ def is_self_write(src: str | os.PathLike[str], dst: str | os.PathLike[str]) -> b
 
     Both paths are resolved before comparison, then compared case-folded --
     unlike ``find_collisions``, which case-folds the paths as given. The
-    difference is load-bearing under ``--mirror-to``: the output root is
-    derived from a resolved input path while discovery returns paths built
-    from the root as typed, so comparing as given would miss the self-write.
+    difference is load-bearing under ``--mirror-to``: a `subst`/junction/
+    symlinked INPUT and the ``--mirror-to`` target can each be named through
+    the alias or through the real path behind it, so comparing as given would
+    miss a self-write where the two spellings resolve to the same file.
     Per ``docs/design/source-selection.md``'s SELF node, a true self-write is
     reported as a counted skip, never silently dropped, and never refuses the
     run by itself.

--- a/docs/design/source-selection.md
+++ b/docs/design/source-selection.md
@@ -61,8 +61,9 @@ flowchart TD
   the output root is a **strict descendant** of the input root, because that is
   the only shape where the walk can reach its own output. Both roots are resolved
   before the descendancy test, for the same reason the two guards below resolve:
-  `--mirror-to` derives the output root from a resolved input path while the input
-  root is whatever was typed, so comparing as given would test the wrong pair. An output root that is
+  a `subst`/junction/symlinked input root and a `--mirror-to`-derived output root
+  can each be spelled through the alias or through the real path behind it, so
+  comparing as given would test the wrong pair. An output root that is
   a *sibling*, on another drive, or an *ancestor* of the input root is already
   outside the walked tree: `--to mp4 -r D:\Media\Season1 D:\Media` writes one
   level up, run 2 walks only `Season1` and never sees it. Testing "lies under the
@@ -73,9 +74,10 @@ flowchart TD
   only when its derived output path *is* its input path. Both sides are resolved
   before they are compared, and then compared case-folded — unlike
   `paths.find_collisions`, which case-folds the paths **as given**. The difference
-  is load-bearing: `--mirror-to` derives the output root from a resolved input
-  path while discovery returns paths built from the root as typed, so comparing as
-  given would miss the self-write. The guard resolves the output path the same way
+  is load-bearing: a `subst`/junction/symlinked INPUT and the `--mirror-to` target
+  can each be spelled through the alias or through the real path behind it, so
+  comparing as given would miss a self-write where the two spellings resolve to
+  the same file. The guard resolves the output path the same way
   the write will see it; note that a bare-drive `OUTPUT` (`converter --to mp4 IN
   E:`) is drive-relative by construction, so it resolves against the current
   directory on `E:` — `--mirror-to E:` is the spelling that normalises it, which is
@@ -116,7 +118,9 @@ flowchart TD
     overwritten by `a.mkv`. Reading "selected" as "reached `TASK`" would build a
     guard that never fires for the case it exists for. Like `SELF`, it compares an
     output path against an input path, so it **resolves both sides** before
-    comparing; comparing as given would miss the hazard under `--mirror-to`.
+    comparing; comparing as given would miss the hazard when a
+    `subst`/junction/symlinked INPUT and the `--mirror-to` target name the same
+    physical file under different spellings.
 - **Skipped is a reported outcome; not-a-candidate is not.** An already-converted
   file is counted, because `0 converted, 12 skipped` is the idempotent-re-run
   evidence the vision promises. A `.txt`, or a file inside the output tree, is not,

--- a/docs/specs/archive/spec-target-driven-cli.md
+++ b/docs/specs/archive/spec-target-driven-cli.md
@@ -487,3 +487,24 @@ reusing the fixtures the phase-1 gate synthesises:
 - 2026-08-26: Close-out. The final QA gate ran against real ffmpeg 9.0 on
   Windows 11, verifying all 17 target formats end-to-end with ffprobe.
   Verdict: PASS WITH FINDINGS; the findings are filed as issues #66-#73.
+- 2026-08-27 (#72): `_resolve_output_root`'s `--mirror-to` branch now re-roots
+  `args.input_dir` as typed, not `.resolve()`d -- the QA gate's finding that a
+  `subst`/junction/symlinked INPUT mirrored onto the physical path it resolves
+  to, nesting the whole physical prefix into the output tree instead of the
+  shallow tree the user asked for. `mirror_command` (the `converter mirror`
+  preview sub-command) changed the same way, since it exists to preview what
+  `--mirror-to` will do and a divergent derivation would make the preview lie.
+  The two concerns the issue asked to separate turn out to already be
+  separate: `paths.is_self_write` and `paths.find_overwrite_hazards` resolve
+  *both* the source and the derived output path themselves, independently, at
+  comparison time (`paths._resolved_key`) -- so which path
+  `_resolve_output_root` starts from cannot change what those guards catch,
+  only the shape of the tree that gets built. Proved rather than assumed: a
+  real `subst Q: <fixtures>; subst R: <dest>` reproduction confirmed both the
+  fixed tree shape and the unchanged guards (self-write, `--overwrite` hazard,
+  collision, in-place idempotence all still fire/hold exactly as before), and
+  `tests/test_cli.py` gained two tests -- one proving `_resolve_output_root`
+  now uses the typed root (and fails against the old `.resolve()` call when
+  reverted), one proving the self-write guard still fires once that root is
+  no longer pre-resolved. `README.md`'s Options section documents the chosen
+  behaviour for `subst`/junction/symlinked inputs.

--- a/docs/specs/archive/spec-target-driven-cli.md
+++ b/docs/specs/archive/spec-target-driven-cli.md
@@ -508,3 +508,44 @@ reusing the fixtures the phase-1 gate synthesises:
   reverted), one proving the self-write guard still fires once that root is
   no longer pre-resolved. `README.md`'s Options section documents the chosen
   behaviour for `subst`/junction/symlinked inputs.
+- 2026-08-27 (#72, review round 1): The self-write regression test above
+  proved to be a false positive under mutation -- an independent review
+  replaced `paths._resolved_key`'s resolve call with a plain string compare
+  and the whole `tests/test_cli.py` suite still passed, because
+  `self_mirroring_root` (drive-only) plus `sub/..` puts the same lexical `..`
+  segment on *both* the derived source and the derived output, so the two
+  sides matched textually before resolution was ever needed. Replaced with
+  `test_the_self_write_guard_still_fires_across_a_virtual_drive_boundary`,
+  which fakes a `subst`-like alias with `Path.resolve` (redirecting an entire
+  subtree, not one path, and computing the "physical" location with
+  `paths.mirror_to_drive` itself rather than a hand-picked path) and a
+  `--mirror-to` target that names the alias's real location directly by a
+  *different* spelling -- confirmed to fail under the same mutation, and to
+  pass again once reverted. The same review found `mirror_command`'s
+  typed-vs-resolved change had no test at all; added
+  `TestMirrorCommand::test_uses_the_typed_root_not_the_resolved_one`, first
+  written with a substring assertion that also proved not to fail when
+  `directory.resolve()` was restored (both candidate targets share a drive
+  letter and a `physical` path segment), then corrected to assert the exact
+  expected line. The review also found `docs/design/source-selection.md`
+  (the OWN, SELF and HAZ nodes) and three `converter/paths.py` docstrings
+  (`_resolved_key`, `is_self_write`, plus the now-adjacent test docstrings in
+  `tests/test_cli.py` and `tests/test_paths.py`) still gave resolving's *why*
+  as "the output root is derived from a resolved input path" -- true before
+  this issue, false after it. Corrected throughout to the reason that
+  actually holds post-fix: a `subst`/junction/symlinked INPUT and a
+  `--mirror-to` target can each be spelled through the alias or through the
+  real path behind it, and only resolving both sides catches the two
+  spellings naming the same file. Also corrected in `README.md`: the
+  `--mirror-to`-onto-a-plain-drive counter-example named a path
+  (`E:\D\Rips\...`) `mirror_to_drive` cannot produce (it strips a drive
+  letter, never turns one into a directory component); the note attached
+  "refused" to a self-write when the design (SELF -> SKIP, HAZ -> REFUSE) and
+  the observed behaviour both make a self-write the *reported skip* and only
+  the `--overwrite` hazard the refusal; "the safety checks below" pointed at
+  a section that does not exist; and a relative `INPUT_DIR`'s own blast-radius
+  change (mirrored from the path as given, not resolved against the cwd
+  first) went unmentioned. No functional line changed in `converter/cli.py`
+  or `converter/paths.py` in this round -- the reviewer's verdict was that
+  the fix itself does not weaken the guards, only that the tests proving it
+  and the docs explaining it needed to be right.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -281,6 +281,31 @@ class TestOutputRootResolution:
 
         assert cli._resolve_output_root(args) == Path("some/out")
 
+    def test_mirror_to_uses_the_typed_root_not_the_resolved_one(self, tmp_path, monkeypatch):
+        """Issue #72: a `subst`/junction/symlinked INPUT must shape the mirrored
+        tree from the path the user typed, not the physical path it resolves
+        to -- otherwise the whole physical prefix gets nested into the output
+        tree instead of the shallow tree the user asked for. Faked here (no
+        real subst/junction needed) by making `Path.resolve` answer for the
+        input root the way a virtual drive would."""
+        typed_root = tmp_path / "Q"
+        typed_root.mkdir()
+        physical_root = tmp_path / "physical" / "mirsrc"
+        real_resolve = Path.resolve
+        monkeypatch.setattr(
+            Path,
+            "resolve",
+            lambda self, *a, **kw: (
+                physical_root if self == typed_root else real_resolve(self, *a, **kw)
+            ),
+        )
+        args = parse(convert_argv(str(typed_root), "--mirror-to", "E:"))
+
+        result = cli._resolve_output_root(args)
+
+        assert result == cli.paths.mirror_to_drive(typed_root, "E:")
+        assert result != cli.paths.mirror_to_drive(physical_root, "E:")
+
 
 class TestConvertCommand:
     def test_missing_input_directory_is_a_usage_error(self, tmp_path, capsys):
@@ -523,6 +548,27 @@ class TestSourceSelection:
 
         assert code == 2
         assert "would be overwritten" in capsys.readouterr().err
+
+    def test_the_self_write_guard_still_fires_once_the_typed_root_is_resolved(
+        self, tmp_path, capsys, stub_ffmpeg
+    ):
+        """Issue #72 stops `_resolve_output_root` from resolving INPUT before
+        deriving the mirror root -- this proves that does not reopen the hole
+        `_resolved_key` exists to close. `sub/..` stands in for a second drive
+        the same way `tests/test_paths.py::TestIsSelfWrite.test_resolves_before_
+        comparing` does: the guard must still catch the self-write once it
+        resolves both sides itself, at comparison time, regardless of how the
+        (now unresolved) output root was built."""
+        (tmp_path / "sub").mkdir()
+        typed_root = tmp_path / "sub" / ".." / "in"
+        make_source(typed_root, f"a{VIDEO_SUFFIX}")
+
+        code = main(
+            convert_argv(str(typed_root), "--mirror-to", self_mirroring_root(typed_root), "-q")
+        )
+
+        assert code == 0
+        assert "this file itself" in capsys.readouterr().out
 
     def test_a_nested_output_root_converges(self, tmp_path, capsys, stub_ffmpeg):
         """Without the output-tree exclusion this grows one `converted` level per

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -485,9 +485,10 @@ class TestSourceSelection:
         assert "this file itself" in out
 
     def test_the_self_write_guard_fires_under_mirror_to(self, tmp_path, capsys, stub_ffmpeg):
-        """--mirror-to derives the output root from a *resolved* input path while
-        discovery returns paths built from the root as typed, so a guard that
-        compared them as given would miss this."""
+        """Mirroring INPUT straight back onto its own drive reconstructs the
+        identical path, so the guard must catch it exactly as an in-place
+        self-write would -- `self_mirroring_root` only needs one real
+        directory to show this, no second drive required."""
         inside = tmp_path / "in"
         make_source(inside, f"a{VIDEO_SUFFIX}")
 
@@ -549,23 +550,37 @@ class TestSourceSelection:
         assert code == 2
         assert "would be overwritten" in capsys.readouterr().err
 
-    def test_the_self_write_guard_still_fires_once_the_typed_root_is_resolved(
-        self, tmp_path, capsys, stub_ffmpeg
+    def test_the_self_write_guard_still_fires_across_a_virtual_drive_boundary(
+        self, tmp_path, capsys, stub_ffmpeg, monkeypatch
     ):
-        """Issue #72 stops `_resolve_output_root` from resolving INPUT before
-        deriving the mirror root -- this proves that does not reopen the hole
-        `_resolved_key` exists to close. `sub/..` stands in for a second drive
-        the same way `tests/test_paths.py::TestIsSelfWrite.test_resolves_before_
-        comparing` does: the guard must still catch the self-write once it
-        resolves both sides itself, at comparison time, regardless of how the
-        (now unresolved) output root was built."""
-        (tmp_path / "sub").mkdir()
-        typed_root = tmp_path / "sub" / ".." / "in"
+        """The case resolution is still needed for after issue #72: INPUT is
+        typed through a virtual drive (`subst`/junction/symlink), and
+        --mirror-to names the *real* directory that virtual drive backs onto,
+        by its physical spelling -- a different string from what was typed,
+        but the same file. `_resolve_output_root` no longer resolves INPUT
+        itself, so this only stays caught because `paths.is_self_write`
+        resolves both sides independently, at comparison time. Faked without a
+        real subst/junction: `Path.resolve` is patched so everything under
+        `typed_root` answers as if it physically lived under `physical_root`,
+        the same relationship `subst Q: <physical_root>` would establish for
+        real -- and `physical_root` is computed with the very function under
+        test, so it is exactly the output root the CLI will derive."""
+        typed_root = tmp_path / "Q"
         make_source(typed_root, f"a{VIDEO_SUFFIX}")
+        mirror_to = str(tmp_path / "physical")
+        physical_root = cli.paths.mirror_to_drive(typed_root, mirror_to)
+        real_resolve = Path.resolve
 
-        code = main(
-            convert_argv(str(typed_root), "--mirror-to", self_mirroring_root(typed_root), "-q")
-        )
+        def fake_resolve(self, *a, **kw):
+            try:
+                rel = self.relative_to(typed_root)
+            except ValueError:
+                return real_resolve(self, *a, **kw)
+            return real_resolve(physical_root / rel, *a, **kw)
+
+        monkeypatch.setattr(Path, "resolve", fake_resolve)
+
+        code = main(convert_argv(str(typed_root), "--mirror-to", mirror_to, "-q"))
 
         assert code == 0
         assert "this file itself" in capsys.readouterr().out
@@ -705,6 +720,32 @@ class TestMirrorCommand:
 
         assert code == 2
         assert "does not exist" in capsys.readouterr().err
+
+    def test_uses_the_typed_root_not_the_resolved_one(self, tmp_path, monkeypatch, capsys):
+        """This preview exists to show what --mirror-to will actually build
+        (issue #72), so it must not resolve INPUT_ROOT before re-rooting it
+        either -- faked the same way `TestOutputRootResolution` fakes a
+        virtual drive, without needing a real subst/junction. Asserted against
+        the exact typed-root mapping rather than a substring check: both
+        candidate targets share a drive letter and a `physical` segment name,
+        so a weaker check would not actually fail if `.resolve()` came back."""
+        typed_root = tmp_path / "Q"
+        typed_root.mkdir()
+        physical_root = tmp_path / "physical" / "mirsrc"
+        real_resolve = Path.resolve
+        monkeypatch.setattr(
+            Path,
+            "resolve",
+            lambda self, *a, **kw: (
+                physical_root if self == typed_root else real_resolve(self, *a, **kw)
+            ),
+        )
+
+        main([cli.MIRROR_COMMAND, str(typed_root), "E:"])
+        out = capsys.readouterr().out
+
+        assert f"{typed_root} -> {cli.paths.mirror_to_drive(typed_root, 'E:')}" in out
+        assert str(cli.paths.mirror_to_drive(physical_root, "E:")) not in out
 
 
 class TestInteractivePrompt:

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -343,9 +343,10 @@ class TestIsSelfWrite:
         assert is_self_write(tmp_path / "a.mp4", tmp_path / "b.mp4") is False
 
     def test_resolves_before_comparing(self, tmp_path):
-        """A ``..`` segment must not hide a self-write -- the --mirror-to case,
-        where discovery returns the root as typed but the output root is
-        derived from a resolved input path, so comparing as given would miss it."""
+        """A ``..`` segment must not hide a self-write -- ``--mirror-to`` can be
+        pointed at the same file two different ways (a `subst`/junction/
+        symlinked INPUT, or the real path behind it), so comparing as given
+        would miss it."""
         touch(tmp_path / "a.mp4")
         typed_src = tmp_path / "sub" / ".." / "a.mp4"
 
@@ -426,8 +427,10 @@ class TestFindOverwriteHazards:
         assert find_overwrite_hazards(pairs) == []
 
     def test_resolves_before_comparing(self, tmp_path):
-        """The --mirror-to shape: the victim's source path is typed with a
-        ``..`` segment, so only a resolved comparison catches the hazard."""
+        """A `subst`/junction/symlinked INPUT can name the same file as
+        ``--mirror-to``'s target under a different spelling: the victim's
+        source path is typed with a ``..`` segment standing in for that, so
+        only a resolved comparison catches the hazard."""
         victim_typed = tmp_path / "sub" / ".." / "a.mp4"
         pairs = [
             (victim_typed, tmp_path / "a.mp4"),
@@ -507,10 +510,11 @@ class TestSourceSelectionScenarios:
         assert [(v.name, w.name) for v, w in hazards] == [("a.mp4", "a.mkv")]
 
     def test_mirror_to_self_write_is_still_caught(self, tmp_path):
-        """Under --mirror-to the output root is derived from a *resolved*
-        input path while discovery returns paths built from the root as
-        typed -- simulated here with a `..` segment standing in for a second
-        drive, since comparing as given would miss this self-write."""
+        """A `subst`/junction/symlinked INPUT can be named through the alias
+        or through the real path behind it, and so can --mirror-to's target --
+        simulated here with a `..` segment standing in for the alias, since
+        comparing as given would miss this self-write once the two spellings
+        diverge textually."""
         real_input = tmp_path / "Media"
         touch(real_input / "a.mp4")
         typed_input = tmp_path / "Media" / "x" / ".."
@@ -521,7 +525,7 @@ class TestSourceSelectionScenarios:
         assert is_self_write(src, dst) is True
 
     def test_mirror_to_overwrite_hazard_is_still_caught(self, tmp_path):
-        """The same typed-vs-resolved mismatch, now for the hazard guard:
+        """The same alias-vs-real-path mismatch, now for the hazard guard:
         the one-directory test above cannot tell "compares as given" and
         "compares resolved" apart, this one can."""
         real_input = tmp_path / "Media"


### PR DESCRIPTION
## Summary
- `--mirror-to` derived its output root from `args.input_dir.resolve()`, so a `subst`/junction/symlinked INPUT mirrored onto the *physical* path it resolves to, nesting the whole physical prefix into the output tree instead of the shallow tree the user typed.
- `_resolve_output_root` (and `mirror_command`, the `converter mirror` preview sub-command, kept consistent with it) now re-root INPUT as typed instead.
- This is safe: `paths.is_self_write` and `paths.find_overwrite_hazards` resolve both the source and the derived output path themselves, independently, at comparison time (`paths._resolved_key`) — so which path the output root started from cannot change what those guards catch, only the shape of the tree that gets built.

## Verification
- A real `subst Q: <fixtures>; subst R: <dest>` reproduction (Windows) confirmed:
  - Before: `Q:\Season1\ep1.mkv -> R:\Users\...\mirbug\fixtures\Season1\ep1.mp4` (surprising).
  - After: `Q:\Season1\ep1.mkv -> R:\Season1\ep1.mp4` (matches what the user typed), and `converter mirror` previews the same shape.
  - The self-write guard still fires when `Q:\` is mirrored directly onto the real physical directory it substs to (`note    ep1.mp4: the output path is this file itself; nothing to convert`), file contents unchanged.
  - `--overwrite` still refuses (exit 2) the same subst self-write hazard.
  - Ordinary in-place self-write (no subst), and a plain output-path collision, both still behave exactly as before.
- `tests/test_cli.py` gained two tests: one pinning that `_resolve_output_root` uses the typed root (fails against the reverted `.resolve()` call), one proving the self-write guard still fires once that root is no longer pre-resolved.
- `README.md` documents the chosen behaviour for `subst`/junction/symlinked inputs.
- Decision log entry added to `docs/specs/archive/spec-target-driven-cli.md`.

## Test plan
- [x] `.venv\Scripts\python.exe scripts\verify.py` — 890 tests, lint and format clean.
- [x] Manual `subst` reproduction, before and after, including self-write/hazard/collision guard checks (see above).

Closes #72