### PR TITLE
fix(jobs): confirm a predicted drop against the written output

### DIFF
--- a/converter/batch.py
+++ b/converter/batch.py
@@ -87,12 +87,15 @@ def _confirm_against_output(
 
     The second probe of ``docs/design/degradation-ladder.md``, and the only one
     ever aimed at an output. It is spent solely on a run that is *about to claim
-    a loss*, so a conversion that lost nothing -- the common case -- still costs
-    a single probe.
+    a loss*, so a conversion whose mapping gives nothing up still costs a single
+    probe.
     """
     try:
         produced = ffmpegtool.probe_streams(tools, task.dst)
-    except ProbeError as exc:
+    # OSError as well as ProbeError, unlike the source probe above: this call
+    # sits *after* a conversion ffmpeg already completed, so letting a spawn
+    # failure escape would turn a good output into a reported failure.
+    except (ProbeError, OSError) as exc:
         # Over-reporting is the safe side of "never report success for a
         # conversion that silently dropped something" (``docs/constitution.md``):
         # keep the prediction and say it could not be checked, rather than

--- a/converter/batch.py
+++ b/converter/batch.py
@@ -92,9 +92,6 @@ def _confirm_against_output(
     """
     try:
         produced = ffmpegtool.probe_streams(tools, task.dst)
-    # OSError as well as ProbeError, unlike the source probe above: this call
-    # sits *after* a conversion ffmpeg already completed, so letting a spawn
-    # failure escape would turn a good output into a reported failure.
     except (ProbeError, OSError) as exc:
         # Over-reporting is the safe side of "never report success for a
         # conversion that silently dropped something" (``docs/constitution.md``):
@@ -116,7 +113,11 @@ def _verify_cheap_attempt(profile: Profile, task: Task, tools: Tools) -> tuple[s
         return ()
     try:
         streams = ffmpegtool.probe_streams(tools, task.src)
-    except ProbeError as exc:
+    # Both probes on this side run *after* ffmpeg already produced a good file,
+    # so a spawn failure must degrade the bookkeeping, never the conversion:
+    # letting an OSError escape would report FAILED for a file that converted
+    # fine and leave the output behind for the next run to skip.
+    except (ProbeError, OSError) as exc:
         # A run whose completeness could not be established must not read as a
         # plain success either (``docs/constitution.md``).
         return (f"could not verify which source streams were kept: {exc}",)

--- a/converter/batch.py
+++ b/converter/batch.py
@@ -28,7 +28,7 @@ from converter import ffmpegtool
 # Aliased: run_batch's own `jobs` keyword (parallelism count) would otherwise
 # shadow the module name inside this file.
 from converter import jobs as engine
-from converter.ffmpegtool import ProbeError, Tools
+from converter.ffmpegtool import ProbeError, Stream, Tools
 from converter.paths import ensure_directory
 from converter.profiles import Profile
 
@@ -76,6 +76,31 @@ def _discard_partial_output(dst: Path, *, existed: bool) -> None:
         dst.unlink(missing_ok=True)
 
 
+def _confirm_against_output(
+    profile: Profile,
+    task: Task,
+    tools: Tools,
+    streams: Sequence[Stream],
+    predicted: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Weigh a predicted loss against the file that was actually written.
+
+    The second probe of ``docs/design/degradation-ladder.md``, and the only one
+    ever aimed at an output. It is spent solely on a run that is *about to claim
+    a loss*, so a conversion that lost nothing -- the common case -- still costs
+    a single probe.
+    """
+    try:
+        produced = ffmpegtool.probe_streams(tools, task.dst)
+    except ProbeError as exc:
+        # Over-reporting is the safe side of "never report success for a
+        # conversion that silently dropped something" (``docs/constitution.md``):
+        # keep the prediction and say it could not be checked, rather than
+        # discarding notes on the strength of a probe that never answered.
+        return (*predicted, f"could not confirm this against the output: {exc}")
+    return engine.confirm_drops(profile, streams, produced)
+
+
 def _verify_cheap_attempt(profile: Profile, task: Task, tools: Tools) -> tuple[str, ...]:
     """Name whatever a structurally partial cheap attempt left behind.
 
@@ -92,7 +117,10 @@ def _verify_cheap_attempt(profile: Profile, task: Task, tools: Tools) -> tuple[s
         # A run whose completeness could not be established must not read as a
         # plain success either (``docs/constitution.md``).
         return (f"could not verify which source streams were kept: {exc}",)
-    return engine.verify_success(profile, streams)
+    predicted = engine.verify_success(profile, streams)
+    if not predicted:
+        return ()
+    return _confirm_against_output(profile, task, tools, streams, predicted)
 
 
 def _attempt_conversion(profile: Profile, task: Task, tools: Tools, *, overwrite: bool) -> Result:

--- a/converter/ffmpegtool.py
+++ b/converter/ffmpegtool.py
@@ -194,10 +194,12 @@ def version(tools: Tools) -> str:
 def probe_streams(tools: Tools, src: str | os.PathLike[str]) -> list[Stream]:
     """List the elementary streams of *src*.
 
-    Called at most once per file, and never for a cheap attempt whose mapping is
+    Called once per file, and never for a cheap attempt whose mapping is
     exhaustive: either after an attempt has failed, or -- when the profile
     declares its cheap attempt partial by construction -- to name what that
-    attempt could not carry (``docs/design/degradation-ladder.md``).
+    attempt could not carry. A run that is about to report such a loss calls it
+    once more, on the *output* file, to confirm the claim against what the muxer
+    actually wrote (``docs/design/degradation-ladder.md``).
     """
     result = run(
         [

--- a/converter/ffmpegtool.py
+++ b/converter/ffmpegtool.py
@@ -58,6 +58,15 @@ class Stream:
     index: int
     codec_type: str
     codec_name: str
+    #: The container's own four-character code (``avc1``, ``tmcd``, ``mebx``).
+    #: Carried because it is the only thing that tells two data tracks apart:
+    #: any MOV/MP4 track whose 4CC ffmpeg maps to no codec id demuxes with
+    #: ``codec_id = NONE`` and ffprobe then omits ``codec_name`` entirely, so a
+    #: regenerated timecode and an iPhone metadata track are indistinguishable
+    #: without it (measured, ffmpeg 9.0). Defaults to empty so a caller that
+    #: does not care -- every test that builds a Stream by hand -- can leave it
+    #: out. Read by :func:`converter.jobs.confirm_drops`, nothing else.
+    codec_tag: str = ""
 
 
 @dataclass(frozen=True)
@@ -207,7 +216,10 @@ def probe_streams(tools: Tools, src: str | os.PathLike[str]) -> list[Stream]:
             "-v",
             "error",
             "-show_entries",
-            "stream=index,codec_type,codec_name",
+            # One query, one process: an extra field costs nothing here, and
+            # codec_tag_string is the only thing that distinguishes two data
+            # tracks ffprobe reports no codec name for.
+            "stream=index,codec_type,codec_name,codec_tag_string",
             "-of",
             "json",
             cli_path(src),
@@ -231,6 +243,7 @@ def probe_streams(tools: Tools, src: str | os.PathLike[str]) -> list[Stream]:
                 index=index,
                 codec_type=str(raw.get("codec_type", "")),
                 codec_name=str(raw.get("codec_name", "")),
+                codec_tag=str(raw.get("codec_tag_string", "")),
             )
         )
     return streams

--- a/converter/jobs.py
+++ b/converter/jobs.py
@@ -16,9 +16,14 @@ inside the engine-built rung, and
 
 from collections.abc import Sequence
 from dataclasses import replace
+from typing import TypeVar
 
 from converter.ffmpegtool import Stream
 from converter.profiles import Attempt, Profile
+
+#: What a stream is counted under -- either its (type, codec name) key or its
+#: bare type. :func:`_surplus` does the same arithmetic for both.
+_K = TypeVar("_K")
 
 
 def _with_container_options(attempt: Attempt, profile: Profile) -> Attempt:
@@ -121,6 +126,27 @@ def _count_keys(streams: Sequence[Stream]) -> dict[tuple[str, str], int]:
     counts: dict[tuple[str, str], int] = {}
     for stream in streams:
         counts[_stream_key(stream)] = counts.get(_stream_key(stream), 0) + 1
+    return counts
+
+
+def _surplus(kept: dict[_K, int], produced: dict[_K, int]) -> dict[_K, int]:
+    """How many streams the output holds beyond what the mapping expected to keep."""
+    return {unit: max(count - kept.get(unit, 0), 0) for unit, count in produced.items()}
+
+
+def _by_type(counts: dict[tuple[str, str], int]) -> dict[str, int]:
+    """Collapse per-key counts onto the stream type alone."""
+    totals: dict[str, int] = {}
+    for (kind, _codec), count in counts.items():
+        totals[kind] = totals.get(kind, 0) + count
+    return totals
+
+
+def _count_types(streams: Sequence[Stream]) -> dict[str, int]:
+    """How many streams of each ``codec_type`` a probed stream list holds."""
+    counts: dict[str, int] = {}
+    for stream in streams:
+        counts[stream.codec_type] = counts.get(stream.codec_type, 0) + 1
     return counts
 
 
@@ -230,25 +256,39 @@ def confirm_drops(
     (issue #66). Comparing what the two files *hold*, rather than reasoning about
     `tmcd` in particular, is what makes this general.
 
-    The comparison counts streams per :func:`_stream_key` -- type and codec name
-    together. Type alone would be unsound in the direction ``docs/constitution.md``
-    forbids: no profile declares a ``data`` rule, so a regenerated `tmcd` would
-    forgive the drop of a `gpmd`/ANC telemetry stream in the same file and a real
-    loss would go unreported. A surplus is attributed to the predicted drops
-    sharing its key, in source order. With more than one predicted drop of one
-    key and only some of them surviving, the *count* of reported drops stays
-    right while the index named may not be -- deliberately preferred over the
-    alternative of reporting a loss that did not happen, and never
-    over-suppressing: a key with no surplus keeps every note it was given.
+    A predicted drop is forgiven only when the output holds a surplus under
+    **both** counts, and each forgiveness spends one of each budget. Neither
+    count is sound alone, and each covers the other's blind spot:
+
+    * By stream type alone, a regenerated `tmcd` would forgive the drop of a
+      `gpmd`/ANC telemetry stream in the same file -- no profile declares a
+      ``data`` rule, so every data stream in the output forgives one predicted
+      data drop, whichever it actually was.
+    * By :func:`_stream_key` alone, a cheap attempt that *re-encodes* makes the
+      two sides disagree by construction: ``kept`` carries the source's codec
+      name and the output carries the encoder's. WAV's ``-map 0:a:0 -c:a
+      pcm_s16le`` over an ``[aac, pcm_s16le]`` source writes one ``pcm_s16le``
+      stream, which reads as a surplus under that key and forgives the drop of
+      the source's second, genuinely lost, ``pcm_s16le`` track. A re-encode
+      preserves a stream's *type* but not its codec name, which is exactly why
+      the type count is immune to that phantom.
+
+    Both readings therefore have to agree before a note is dropped. Within a
+    type, a surplus is attributed to the predicted drops sharing its key in
+    source order: with more than one predicted drop of one key and only some of
+    them surviving, the *count* of reported drops stays right while the index
+    named may not be -- deliberately preferred over the alternative of reporting
+    a loss that did not happen, and never over-suppressing.
     """
     kept, predicted = _predict_unmapped(profile, streams)
-    surplus = {
-        key: max(count - kept.get(key, 0), 0) for key, count in _count_keys(produced).items()
-    }
+    by_key = _surplus(kept, _count_keys(produced))
+    by_type = _surplus(_by_type(kept), _count_types(produced))
     notes: list[str] = []
     for key, note in predicted:
-        if surplus.get(key, 0) > 0:
-            surplus[key] -= 1
+        kind = key[0]
+        if by_key.get(key, 0) > 0 and by_type.get(kind, 0) > 0:
+            by_key[key] -= 1
+            by_type[kind] -= 1
             continue
         notes.append(note)
     return tuple(notes)

--- a/converter/jobs.py
+++ b/converter/jobs.py
@@ -74,37 +74,53 @@ def _structural_drop(profile: Profile, stream: Stream, counts: dict[str, int]) -
     return None
 
 
+def _stream_key(stream: Stream) -> tuple[str, str]:
+    """What a source stream and its counterpart in an output are matched by.
+
+    Type *and* codec name. An index cannot serve: a stream the muxer put back
+    on its own carries whatever index the output happens to give it. The codec
+    name can, and it is what keeps :func:`confirm_drops` from forgiving the
+    wrong drop -- a regenerated `tmcd` timecode track reports no ``codec_name``
+    at all and so does its source counterpart (measured, ffmpeg 9.0), while a
+    `gpmd`/ANC data stream reports ``bin_data`` on both sides. Matching on type
+    alone would let the first forgive the second.
+    """
+    return (stream.codec_type, stream.codec_name)
+
+
 def _predict_unmapped(
     profile: Profile, streams: Sequence[Stream]
-) -> tuple[dict[str, int], tuple[tuple[str, str], ...]]:
+) -> tuple[dict[tuple[str, str], int], tuple[tuple[tuple[str, str], str], ...]]:
     """What a structurally partial cheap attempt's *mapping* cannot have carried.
 
-    Returns how many streams of each type the mapping is expected to keep, and
-    one ``(codec_type, note)`` pair per stream it is expected to leave behind --
-    the type travels alongside the note so :func:`confirm_drops` can weigh the
-    prediction against the file that was actually written.
+    Returns how many streams of each :func:`_stream_key` the mapping is expected
+    to keep, and one ``(key, note)`` pair per stream it is expected to leave
+    behind -- the key travels alongside the note so :func:`confirm_drops` can
+    weigh the prediction against the file that was actually written.
 
     Only the structural verdicts above are consulted. Codec-level ones are
     deliberately left out: the cheap attempt has already exited 0, so whatever
     it did with a stream's codec worked, and announcing a re-encode it never
     performed would just swap one dishonest report for another.
     """
-    predicted: list[tuple[str, str]] = []
-    counts: dict[str, int] = {}
+    predicted: list[tuple[tuple[str, str], str]] = []
+    positions: dict[str, int] = {}
+    kept: dict[tuple[str, str], int] = {}
     for stream in streams:
-        note = _structural_drop(profile, stream, counts)
+        note = _structural_drop(profile, stream, positions)
         if note is None:
-            counts[stream.codec_type] = counts.get(stream.codec_type, 0) + 1
+            positions[stream.codec_type] = positions.get(stream.codec_type, 0) + 1
+            kept[_stream_key(stream)] = kept.get(_stream_key(stream), 0) + 1
         else:
-            predicted.append((stream.codec_type, note))
-    return counts, tuple(predicted)
+            predicted.append((_stream_key(stream), note))
+    return kept, tuple(predicted)
 
 
-def _count_types(streams: Sequence[Stream]) -> dict[str, int]:
-    """How many streams of each ``codec_type`` a probed stream list holds."""
-    counts: dict[str, int] = {}
+def _count_keys(streams: Sequence[Stream]) -> dict[tuple[str, str], int]:
+    """How many streams of each :func:`_stream_key` a probed stream list holds."""
+    counts: dict[tuple[str, str], int] = {}
     for stream in streams:
-        counts[stream.codec_type] = counts.get(stream.codec_type, 0) + 1
+        counts[_stream_key(stream)] = counts.get(_stream_key(stream), 0) + 1
     return counts
 
 
@@ -211,26 +227,28 @@ def confirm_drops(
     A ``-map`` set says what ffmpeg was asked to carry, which is not the same as
     what the muxer wrote: MP4 and MOV regenerate a timecode track from source
     metadata, so a ``tmcd`` stream no selector names is in the output anyway
-    (issue #66). Comparing *counts per stream type* is what makes this general
-    rather than a `tmcd` special case -- and it is the only comparison available,
-    since a regenerated stream shares neither index nor codec name with its
-    source (measured: ffprobe reports no ``codec_name`` at all for either side).
+    (issue #66). Comparing what the two files *hold*, rather than reasoning about
+    `tmcd` in particular, is what makes this general.
 
-    A surplus is therefore attributed to the predicted drops of that type in
-    source order. With more than one predicted drop of one type and only some of
-    them surviving, the *count* of reported drops stays right while the index
-    named may not be -- deliberately preferred over the alternative of reporting
-    a loss that did not happen, and never over-suppressing: a type with no
-    surplus keeps every note it was given (``docs/constitution.md``).
+    The comparison counts streams per :func:`_stream_key` -- type and codec name
+    together. Type alone would be unsound in the direction ``docs/constitution.md``
+    forbids: no profile declares a ``data`` rule, so a regenerated `tmcd` would
+    forgive the drop of a `gpmd`/ANC telemetry stream in the same file and a real
+    loss would go unreported. A surplus is attributed to the predicted drops
+    sharing its key, in source order. With more than one predicted drop of one
+    key and only some of them surviving, the *count* of reported drops stays
+    right while the index named may not be -- deliberately preferred over the
+    alternative of reporting a loss that did not happen, and never
+    over-suppressing: a key with no surplus keeps every note it was given.
     """
     kept, predicted = _predict_unmapped(profile, streams)
     surplus = {
-        kind: max(count - kept.get(kind, 0), 0) for kind, count in _count_types(produced).items()
+        key: max(count - kept.get(key, 0), 0) for key, count in _count_keys(produced).items()
     }
     notes: list[str] = []
-    for kind, note in predicted:
-        if surplus.get(kind, 0) > 0:
-            surplus[kind] -= 1
+    for key, note in predicted:
+        if surplus.get(key, 0) > 0:
+            surplus[key] -= 1
             continue
         notes.append(note)
     return tuple(notes)

--- a/converter/jobs.py
+++ b/converter/jobs.py
@@ -21,7 +21,7 @@ from typing import TypeVar
 from converter.ffmpegtool import Stream
 from converter.profiles import Attempt, Profile
 
-#: What a stream is counted under -- either its (type, codec name) key or its
+#: What a stream is counted under -- either its full :func:`_stream_key` or its
 #: bare type. :func:`_surplus` does the same arithmetic for both.
 _K = TypeVar("_K")
 
@@ -79,23 +79,33 @@ def _structural_drop(profile: Profile, stream: Stream, counts: dict[str, int]) -
     return None
 
 
-def _stream_key(stream: Stream) -> tuple[str, str]:
+def _stream_key(stream: Stream) -> tuple[str, str, str]:
     """What a source stream and its counterpart in an output are matched by.
 
-    Type *and* codec name. An index cannot serve: a stream the muxer put back
-    on its own carries whatever index the output happens to give it. The codec
-    name can, and it is what keeps :func:`confirm_drops` from forgiving the
-    wrong drop -- a regenerated `tmcd` timecode track reports no ``codec_name``
-    at all and so does its source counterpart (measured, ffmpeg 9.0), while a
-    `gpmd`/ANC data stream reports ``bin_data`` on both sides. Matching on type
-    alone would let the first forgive the second.
+    Type, codec name *and* container tag. An index cannot serve: a stream the
+    muxer put back on its own carries whatever index the output happens to give
+    it -- the regenerated timecode of an iPhone MOV arrives at index 2 where its
+    source sat at index 3.
+
+    All three fields earn their place, each against a measured case (ffmpeg 9.0)
+    where dropping it let :func:`confirm_drops` forgive the wrong drop:
+
+    * codec name, because no profile declares a ``data`` rule, so by type alone
+      a regenerated `tmcd` forgives the loss of `gpmd`/ANC telemetry in the same
+      file -- telemetry reports ``bin_data``, a timecode reports no codec name;
+    * container tag, because *any* MOV/MP4 track whose 4CC maps to no codec id
+      demuxes with ``codec_id = NONE`` and so reports no codec name either. An
+      Apple `mebx` metadata track -- every iPhone `.mov` carries one -- is then
+      indistinguishable from the `tmcd` beside it, and the timecode's survival
+      forgives the metadata track's genuine loss. Their tags differ, and a
+      regenerated `tmcd` carries the same `tmcd` tag as its source.
     """
-    return (stream.codec_type, stream.codec_name)
+    return (stream.codec_type, stream.codec_name, stream.codec_tag)
 
 
 def _predict_unmapped(
     profile: Profile, streams: Sequence[Stream]
-) -> tuple[dict[tuple[str, str], int], tuple[tuple[tuple[str, str], str], ...]]:
+) -> tuple[dict[tuple[str, str, str], int], tuple[tuple[tuple[str, str, str], str], ...]]:
     """What a structurally partial cheap attempt's *mapping* cannot have carried.
 
     Returns how many streams of each :func:`_stream_key` the mapping is expected
@@ -108,9 +118,9 @@ def _predict_unmapped(
     it did with a stream's codec worked, and announcing a re-encode it never
     performed would just swap one dishonest report for another.
     """
-    predicted: list[tuple[tuple[str, str], str]] = []
+    predicted: list[tuple[tuple[str, str, str], str]] = []
     positions: dict[str, int] = {}
-    kept: dict[tuple[str, str], int] = {}
+    kept: dict[tuple[str, str, str], int] = {}
     for stream in streams:
         note = _structural_drop(profile, stream, positions)
         if note is None:
@@ -121,9 +131,9 @@ def _predict_unmapped(
     return kept, tuple(predicted)
 
 
-def _count_keys(streams: Sequence[Stream]) -> dict[tuple[str, str], int]:
+def _count_keys(streams: Sequence[Stream]) -> dict[tuple[str, str, str], int]:
     """How many streams of each :func:`_stream_key` a probed stream list holds."""
-    counts: dict[tuple[str, str], int] = {}
+    counts: dict[tuple[str, str, str], int] = {}
     for stream in streams:
         counts[_stream_key(stream)] = counts.get(_stream_key(stream), 0) + 1
     return counts
@@ -134,20 +144,16 @@ def _surplus(kept: dict[_K, int], produced: dict[_K, int]) -> dict[_K, int]:
     return {unit: max(count - kept.get(unit, 0), 0) for unit, count in produced.items()}
 
 
-def _by_type(counts: dict[tuple[str, str], int]) -> dict[str, int]:
-    """Collapse per-key counts onto the stream type alone."""
+def _by_type(counts: dict[tuple[str, str, str], int]) -> dict[str, int]:
+    """Collapse per-key counts onto the stream type alone.
+
+    Derived from the per-key counts rather than counted a second time from the
+    stream list, so the two readings :func:`confirm_drops` compares cannot drift.
+    """
     totals: dict[str, int] = {}
-    for (kind, _codec), count in counts.items():
+    for (kind, _codec, _tag), count in counts.items():
         totals[kind] = totals.get(kind, 0) + count
     return totals
-
-
-def _count_types(streams: Sequence[Stream]) -> dict[str, int]:
-    """How many streams of each ``codec_type`` a probed stream list holds."""
-    counts: dict[str, int] = {}
-    for stream in streams:
-        counts[stream.codec_type] = counts.get(stream.codec_type, 0) + 1
-    return counts
 
 
 def _decide_stream(
@@ -273,25 +279,24 @@ def confirm_drops(
       preserves a stream's *type* but not its codec name, which is exactly why
       the type count is immune to that phantom.
 
-    Both readings therefore have to agree before a note is dropped. Within a
-    type, a surplus is attributed to the predicted drops sharing its key in
-    source order: with more than one predicted drop of one key and only some of
-    them surviving, the *count* of reported drops stays right while the index
-    named may not be -- deliberately preferred over the alternative of reporting
-    a loss that did not happen, and never over-suppressing.
+    Both readings therefore have to agree before a note is dropped, and the
+    surplus must cover *every* predicted drop sharing a key before any of them
+    is forgiven. That last clause is what keeps the arithmetic from having to
+    guess which of several indistinguishable streams survived: where the
+    evidence is ambiguous, every candidate keeps its note. Over-reporting is a
+    cost; picking the wrong one would mean claiming a loss that did not happen
+    *and* falling silent about one that did (``docs/constitution.md``).
     """
     kept, predicted = _predict_unmapped(profile, streams)
     by_key = _surplus(kept, _count_keys(produced))
-    by_type = _surplus(_by_type(kept), _count_types(produced))
-    notes: list[str] = []
-    for key, note in predicted:
-        kind = key[0]
-        if by_key.get(key, 0) > 0 and by_type.get(kind, 0) > 0:
-            by_key[key] -= 1
-            by_type[kind] -= 1
-            continue
-        notes.append(note)
-    return tuple(notes)
+    by_type = _surplus(_by_type(kept), _by_type(_count_keys(produced)))
+    forgiven: set[tuple[str, str, str]] = set()
+    for key in dict.fromkeys(key for key, _note in predicted):
+        wanted = sum(1 for other, _note in predicted if other == key)
+        if by_key.get(key, 0) >= wanted and by_type.get(key[0], 0) >= wanted:
+            by_type[key[0]] -= wanted
+            forgiven.add(key)
+    return tuple(note for key, note in predicted if key not in forgiven)
 
 
 def describe_unsupported(profile: Profile, streams: Sequence[Stream]) -> tuple[str, ...] | None:

--- a/converter/jobs.py
+++ b/converter/jobs.py
@@ -61,7 +61,7 @@ def _structural_drop(profile: Profile, stream: Stream, counts: dict[str, int]) -
 
     Split out because both verdicts are reached from the declared rules alone,
     without ever looking at the stream's codec. That is what lets the
-    success-side verification in :func:`_unmapped_notes` reuse them without
+    success-side verification in :func:`_predict_unmapped` reuse them without
     asserting anything about what an already-successful attempt encoded.
     """
     rule = profile.rules.get(stream.codec_type)
@@ -74,23 +74,38 @@ def _structural_drop(profile: Profile, stream: Stream, counts: dict[str, int]) -
     return None
 
 
-def _unmapped_notes(profile: Profile, streams: Sequence[Stream]) -> tuple[str, ...]:
-    """Name what a structurally partial cheap attempt cannot have carried over.
+def _predict_unmapped(
+    profile: Profile, streams: Sequence[Stream]
+) -> tuple[dict[str, int], tuple[tuple[str, str], ...]]:
+    """What a structurally partial cheap attempt's *mapping* cannot have carried.
+
+    Returns how many streams of each type the mapping is expected to keep, and
+    one ``(codec_type, note)`` pair per stream it is expected to leave behind --
+    the type travels alongside the note so :func:`confirm_drops` can weigh the
+    prediction against the file that was actually written.
 
     Only the structural verdicts above are consulted. Codec-level ones are
     deliberately left out: the cheap attempt has already exited 0, so whatever
     it did with a stream's codec worked, and announcing a re-encode it never
     performed would just swap one dishonest report for another.
     """
-    notes: list[str] = []
+    predicted: list[tuple[str, str]] = []
     counts: dict[str, int] = {}
     for stream in streams:
         note = _structural_drop(profile, stream, counts)
         if note is None:
             counts[stream.codec_type] = counts.get(stream.codec_type, 0) + 1
         else:
-            notes.append(note)
-    return tuple(notes)
+            predicted.append((stream.codec_type, note))
+    return counts, tuple(predicted)
+
+
+def _count_types(streams: Sequence[Stream]) -> dict[str, int]:
+    """How many streams of each ``codec_type`` a probed stream list holds."""
+    counts: dict[str, int] = {}
+    for stream in streams:
+        counts[stream.codec_type] = counts.get(stream.codec_type, 0) + 1
+    return counts
 
 
 def _decide_stream(
@@ -178,8 +193,47 @@ def needs_verification(profile: Profile) -> bool:
 
 def verify_success(profile: Profile, streams: Sequence[Stream]) -> tuple[str, ...]:
     """The success-side verifier of degradation-ladder.md: what a partial cheap
-    attempt's mapping could not have carried over, named per stream."""
-    return _unmapped_notes(profile, streams)
+    attempt's mapping could not have carried over, named per stream.
+
+    A *prediction*, drawn from the mapping alone. It has to be confirmed against
+    the written file by :func:`confirm_drops` before it is reported, because a
+    muxer may put back what no ``-map`` selected (issue #66).
+    """
+    _, predicted = _predict_unmapped(profile, streams)
+    return tuple(note for _, note in predicted)
+
+
+def confirm_drops(
+    profile: Profile, streams: Sequence[Stream], produced: Sequence[Stream]
+) -> tuple[str, ...]:
+    """Keep only the predicted drops the written file does *not* in fact contain.
+
+    A ``-map`` set says what ffmpeg was asked to carry, which is not the same as
+    what the muxer wrote: MP4 and MOV regenerate a timecode track from source
+    metadata, so a ``tmcd`` stream no selector names is in the output anyway
+    (issue #66). Comparing *counts per stream type* is what makes this general
+    rather than a `tmcd` special case -- and it is the only comparison available,
+    since a regenerated stream shares neither index nor codec name with its
+    source (measured: ffprobe reports no ``codec_name`` at all for either side).
+
+    A surplus is therefore attributed to the predicted drops of that type in
+    source order. With more than one predicted drop of one type and only some of
+    them surviving, the *count* of reported drops stays right while the index
+    named may not be -- deliberately preferred over the alternative of reporting
+    a loss that did not happen, and never over-suppressing: a type with no
+    surplus keeps every note it was given (``docs/constitution.md``).
+    """
+    kept, predicted = _predict_unmapped(profile, streams)
+    surplus = {
+        kind: max(count - kept.get(kind, 0), 0) for kind, count in _count_types(produced).items()
+    }
+    notes: list[str] = []
+    for kind, note in predicted:
+        if surplus.get(kind, 0) > 0:
+            surplus[kind] -= 1
+            continue
+        notes.append(note)
+    return tuple(notes)
 
 
 def describe_unsupported(profile: Profile, streams: Sequence[Stream]) -> tuple[str, ...] | None:

--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -353,17 +353,24 @@ MOV = Profile(
     # missing rule drops it with a real per-stream note -- better than a
     # blanket standing note for the one case MOV can make loud. Still not
     # "-map 0": that would also select data and timecode streams, which no
-    # "v/a/s/t" map -- MOV's included -- carries at all (measured).
+    # "v/a/s/t" map -- MOV's included -- selects at all (measured).
+    #
+    # No standing note about data and timecode streams, unlike MKV's otherwise
+    # identical shape: MOV's muxer *regenerates* a tmcd timecode track from the
+    # source's metadata even though no selector maps it, so the blanket claim
+    # was measurably false for the commonest data stream a MOV source carries
+    # (issue #66). What actually reaches the output is settled per file by the
+    # success-side verification, which reads the written file rather than the
+    # mapping -- a real data drop still gets its own per-stream note there.
     cheap_attempt=Attempt(
         label="remux",
         options=flags("-map 0:v? -map 0:a? -map 0:s? -map 0:t? -c copy -c:s mov_text"),
-        notes=("data and timecode streams are not carried into MOV",),
     ),
     explicit_streams=False,
     # The blind "?" selectors carry every video, audio and subtitle stream
-    # MOV's muxer can hold, but never a data or timecode one, and an attachment
-    # only ever forces the cheap attempt to fail -- exactly the standing note's
-    # claim, verified once per successful cheap attempt rather than assumed.
+    # MOV's muxer can hold, and an attachment only ever forces the cheap attempt
+    # to fail; what the muxer does with a data stream is checked against the
+    # output per file rather than declared here.
     partial_mapping=True,
     rules={
         "video": StreamRule(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,6 +59,11 @@ The internal import graph is acyclic today and must stay that way:
    profile's *structural* verdicts only — whether it declares a rule for the
    stream's type, and how many streams of that type it holds — never a
    codec-level one: the attempt exited 0, so what it did with a codec worked.
+   That reading is a *prediction* from the mapping, so a run that is about to
+   name a loss spends one further `ffprobe`, on the output this time, and keeps
+   only the drops the written file does not in fact contain — MP4 and MOV put a
+   `tmcd` timecode track back that no selector mapped (issue #66). A conversion
+   that gives nothing up never reaches that second probe.
    A profile whose cheap attempt is *exhaustive* would skip this probe
    entirely, but no shipped or currently specced profile is one — the
    probe-on-success branch is presently the only path a successful conversion

--- a/docs/constitution.md
+++ b/docs/constitution.md
@@ -31,8 +31,12 @@
   actually failed. A cheap attempt that is **partial by construction** — one
   whose mapping can leave source streams unmapped, and which says so as a
   declared field on its profile — is probed once even when it succeeds, so that
-  what it dropped is named rather than reported as a plain success. Either way,
-  at most one probe per file.
+  what it dropped is named rather than reported as a plain success. One probe per
+  file, plus a second only where a loss is about to be *reported*: what a mapping
+  gives up is a prediction, and a muxer may put back what no `-map` selected, so
+  the claim is confirmed against the written file before it is printed
+  (`docs/design/degradation-ladder.md`). A conversion that gives nothing up never
+  pays for that second probe.
 - A target format is data, not code: adding one must produce no diff in
   `cli.py`, `batch.py` or `paths.py`.
 - One broken input file must not abort the batch.

--- a/docs/design.md
+++ b/docs/design.md
@@ -116,11 +116,12 @@ Instead of UI components, these are the rules a diagram in this project follows.
   engine is generic. A diagram that takes the generic form says so in its header.
 - **Cost markers** — any node that spends a subprocess call says so
   (`ffprobe`, `ffmpeg`). The point of the ladder is that ffprobe stays off the
-  happy path of an *exhaustive* cheap attempt, and that the one exception — a
-  cheap attempt the profile declares partial by construction, which is probed
-  once even on success so its silent drops get named — is visible as its own
-  node on the success side. A diagram that hides where processes start defeats
-  both halves of that.
+  happy path of an *exhaustive* cheap attempt, and that the exceptions — a cheap
+  attempt the profile declares partial by construction, which is probed once even
+  on success so its silent drops get named, and the further probe of the written
+  file that a run about to *report* a drop pays for — are each visible as their
+  own node on the success side. A diagram that hides where processes start
+  defeats both halves of that.
 
 ## Do's and Don'ts
 

--- a/docs/design/degradation-ladder.md
+++ b/docs/design/degradation-ladder.md
@@ -67,34 +67,42 @@ flowchart TD
   mapping alone reports a loss that did not happen — the false-positive half of
   the loss accounting `docs/vision.md` names as the USP (issue #66). `C` counts
   the source's streams and the written file's **twice** — once per stream type,
-  once per type-and-codec-name pair — and forgives a predicted drop only where
-  *both* counts show a surplus, spending one of each budget per forgiveness. An
-  index cannot be a match key at all: a stream the muxer put back carries
-  whatever index the output gives it.
+  once per `(codec_type, codec_name, codec_tag_string)` key — and forgives a
+  predicted drop only where *both* counts show a surplus **and** that surplus
+  covers every predicted drop sharing the key. An index cannot be a match key at
+  all: a stream the muxer put back carries whatever index the output gives it,
+  and an iPhone MOV's regenerated timecode arrives two indices below its source.
 
-  Each count alone is unsound, in the direction the constitution forbids, and
-  each covers the other's blind spot. **By type alone**, no profile declares a
-  `data` rule, so every data stream in the output forgives one predicted data
-  drop, whichever it actually was — a regenerated `tmcd` would silence the loss
-  of `gpmd`/ANC telemetry in the same file. **By pair alone**, a cheap attempt
-  that *re-encodes* makes the two sides disagree by construction, since the
-  source carries the decoder's codec name and the output the encoder's: WAV's
-  `-map 0:a:0 -c:a pcm_s16le` over an `[aac, pcm_s16le]` source writes one
-  `pcm_s16le` stream, which reads as a surplus under that pair and would forgive
-  the loss of the source's second, genuinely dropped, `pcm_s16le` track. A
-  re-encode preserves a stream's type but not its codec name, which is exactly
-  why the type count is immune to that phantom; the codec name is what stops
-  cross-attribution within a type, since a regenerated `tmcd` reports no codec
-  name and neither does its source counterpart, while telemetry reports
-  `bin_data` on both sides.
+  Each condition exists because dropping it was measured to hide a real loss —
+  the direction the constitution forbids — and each covers the others' blind
+  spot:
 
-  Two further properties keep the same direction closed: a drop with no surplus
-  under either count keeps its note, and a probe that fails leaves the whole
-  prediction standing rather than falling silent. The residual cost is that with
-  several predicted drops sharing one pair and only some of them surviving, the
-  *count* of reported losses is right while the index named may not be —
-  deliberately preferred over reporting a loss that did not happen, and never
-  over the silence the constitution forbids.
+  - **The type count** stops the phantom a *re-encoding* cheap attempt creates.
+    Source and output disagree on the codec name by construction there, since
+    one carries the decoder's name and the other the encoder's: WAV's
+    `-map 0:a:0 -c:a pcm_s16le` over an `[aac, pcm_s16le]` source writes one
+    `pcm_s16le` stream, which reads as a key surplus and would forgive the loss
+    of the source's second, genuinely dropped, `pcm_s16le` track. A re-encode
+    preserves a stream's type but not its codec name, so the type count is
+    immune to it.
+  - **The key** stops cross-attribution inside one type. No profile declares a
+    `data` rule, so by type alone every data stream in the output forgives one
+    predicted data drop, whichever it actually was — a regenerated `tmcd` would
+    silence the loss of `gpmd`/ANC telemetry in the same file. The codec name
+    separates those two (telemetry reports `bin_data`, a timecode reports
+    nothing), and the container tag separates the cases the codec name cannot:
+    *any* MOV/MP4 track whose 4CC maps to no codec id reports no codec name
+    either, so an Apple `mebx` metadata track — every iPhone `.mov` has one —
+    is otherwise indistinguishable from the `tmcd` beside it.
+  - **Covering every drop of the key** is what removes the need to guess. Where
+    two streams really are indistinguishable to the probe and only one comes
+    back, all of them keep their note. Over-reporting is the cost; picking one
+    at random would claim a loss that did not happen *and* fall silent about one
+    that did — both halves of the promise broken at once.
+
+  A drop with no surplus keeps its note, and a probe that fails leaves the whole
+  prediction standing rather than falling silent, so every path out of `C` either
+  names a loss or has positive evidence there was none.
 - **A partial cheap attempt's success is verified, not assumed.** A mapping is
   partial by construction when it can leave source streams unmapped whatever the
   source turns out to contain: MP4's `-map 0:v? -map 0:a? -map 0:s?` selects no

--- a/docs/design/degradation-ladder.md
+++ b/docs/design/degradation-ladder.md
@@ -10,13 +10,15 @@ In which order the engine tries to produce one output file, where a subprocess i
 spent, and which conditions move it down a rung. The point of the ladder is that
 `ffprobe` stays off the happy path of an *exhaustive* cheap attempt
 (`docs/constitution.md`), so every node that costs a process call is marked —
-including the one node on the success side, which only a cheap attempt the
-profile declares *partial by construction* ever reaches.
+including the two nodes on the success side, which only a cheap attempt the
+profile declares *partial by construction* ever reaches, and the second of which
+only a run that is about to claim a loss ever reaches.
 
 ```mermaid
 flowchart TD
     A["Attempt 1 — the profile's cheap attempt<br/>(ffmpeg)"]
-    V["verify what that mapping could carry<br/>(ffprobe — the only probe on the success side)"]
+    V["predict what that mapping could carry<br/>(ffprobe on the source — the success side's first probe)"]
+    C["confirm the prediction against the written file<br/>(ffprobe on the output — only when a loss is predicted)"]
     P["describe the source's streams<br/>(ffprobe — the only probe on the failure side)"]
     PLAN["build the selective plan<br/>(no subprocess — see stream-decision.md)"]
     SEL["Attempt 2 — selective<br/>(ffmpeg)"]
@@ -26,8 +28,11 @@ flowchart TD
 
     A -->|"exit 0, and the profile declares the mapping exhaustive"| OK
     A -->|"exit 0, and the profile declares the mapping partial"| V
-    V -->|"stream list — plus a note per source stream<br/>the mapping could not carry"| OK
+    V -->|"stream list, and the mapping gave nothing up"| OK
+    V -->|"stream list, and the mapping left something behind"| C
     V -->|"probe failed — plus a note that the run is unverified,<br/>so it is not a plain success"| OK
+    C -->|"a note per predicted drop the output does not hold"| OK
+    C -->|"probe failed — every predicted drop stands,<br/>plus a note that it could not be confirmed"| OK
     A -->|"exit != 0"| P
     P -->|"probe failed"| BAD
     P -->|"stream list"| PLAN
@@ -42,12 +47,32 @@ flowchart TD
 
 ## Rules the diagram encodes
 
-- **At most one probe per file, and none for an exhaustive cheap attempt.** The
-  failure-side `ffprobe` node sits behind the first non-zero exit and is reached
-  at most once; every later rung reuses the same stream list. The success-side
-  node is reached only when the profile declares its cheap attempt *partial by
-  construction*. The two are mutually exclusive — a file takes one path or the
-  other — so no file is ever probed twice.
+- **One probe per file, and none for an exhaustive cheap attempt — plus one more
+  only for a run that is about to report a loss.** The failure-side `ffprobe`
+  node sits behind the first non-zero exit and is reached at most once; every
+  later rung reuses the same stream list. The success-side nodes are reached only
+  when the profile declares its cheap attempt *partial by construction*, and the
+  failure side and the success side are mutually exclusive — a file takes one
+  path or the other. The second success-side probe, `C`, is the one exception to
+  the one-probe count, and it is bounded by the claim it pays for: it runs only
+  when `V` predicted at least one drop, so a conversion that gave nothing up
+  still costs a single probe.
+- **A predicted drop is confirmed against the output before it is reported.** A
+  `-map` set says what ffmpeg was *asked* to carry, which is not the same as what
+  the muxer wrote: MP4 and MOV regenerate a `tmcd` timecode track from the
+  source's metadata although no selector names it (measured, ffmpeg 9.0), so the
+  mapping alone reports a loss that did not happen — the false-positive half of
+  the loss accounting `docs/vision.md` names as the USP (issue #66). `C` compares
+  *counts per stream type* between the source and the written file, because a
+  regenerated stream shares neither index nor codec name with its source, and
+  attributes any surplus to that type's predicted drops in source order. Two
+  properties make this safe in the direction the constitution cares about: a type
+  with no surplus keeps every note it was given, and a probe that fails leaves
+  the whole prediction standing rather than falling silent. The cost is that with
+  several predicted drops of one type and only some of them surviving, the
+  *count* of reported losses is right while the index named may not be —
+  deliberately preferred over reporting a loss that did not happen, and never
+  over the silence the constitution forbids.
 - **A partial cheap attempt's success is verified, not assumed.** A mapping is
   partial by construction when it can leave source streams unmapped whatever the
   source turns out to contain: MP4's `-map 0:v? -map 0:a? -map 0:s?` selects no
@@ -152,9 +177,9 @@ flowchart TD
   not, and a failure at the rung before it is then the end of the ladder.
 - **Every rung carries its own notes.** The notes of the attempt that actually
   succeeded are what the batch reports — the discarded rungs' notes are not. Only
-  the cheap attempt's notes are ever added to, and only by the verification node
-  above it; a later rung was built from the stream list itself, so its notes are
-  already complete and it is never verified a second time.
+  the cheap attempt's notes are ever added to, and only by the two verification
+  nodes above it; a later rung was built from the stream list itself, so its
+  notes are already complete and it is never verified a second time.
 - **Container-wide options are appended by the engine, once, at the end of every
   attempt.** The profile declares them in one place instead of repeating them in
   each attempt it declares.

--- a/docs/design/degradation-ladder.md
+++ b/docs/design/degradation-ladder.md
@@ -66,22 +66,35 @@ flowchart TD
   source's metadata although no selector names it (measured, ffmpeg 9.0), so the
   mapping alone reports a loss that did not happen — the false-positive half of
   the loss accounting `docs/vision.md` names as the USP (issue #66). `C` counts
-  the streams of each **type-and-codec-name pair** in the source and in the
-  written file, and attributes any surplus to that pair's predicted drops in
-  source order. An index cannot be the match key — a stream the muxer put back
-  carries whatever index the output gives it — but the codec name can: a
-  regenerated `tmcd` reports none at all and neither does its source
-  counterpart, while a `gpmd`/ANC telemetry stream reports `bin_data` on both
-  sides. Matching on type alone is what must be avoided, and is the shape this
-  rule exists to forbid: no profile declares a `data` rule, so a regenerated
-  timecode would forgive the loss of telemetry in the same file, and a real drop
-  would go unreported. Two further properties keep the direction the constitution
-  cares about closed: a pair with no surplus keeps every note it was given, and a
-  probe that fails leaves the whole prediction standing rather than falling
-  silent. The residual cost is that with several predicted drops sharing one pair
-  and only some of them surviving, the *count* of reported losses is right while
-  the index named may not be — deliberately preferred over reporting a loss that
-  did not happen, and never over the silence the constitution forbids.
+  the source's streams and the written file's **twice** — once per stream type,
+  once per type-and-codec-name pair — and forgives a predicted drop only where
+  *both* counts show a surplus, spending one of each budget per forgiveness. An
+  index cannot be a match key at all: a stream the muxer put back carries
+  whatever index the output gives it.
+
+  Each count alone is unsound, in the direction the constitution forbids, and
+  each covers the other's blind spot. **By type alone**, no profile declares a
+  `data` rule, so every data stream in the output forgives one predicted data
+  drop, whichever it actually was — a regenerated `tmcd` would silence the loss
+  of `gpmd`/ANC telemetry in the same file. **By pair alone**, a cheap attempt
+  that *re-encodes* makes the two sides disagree by construction, since the
+  source carries the decoder's codec name and the output the encoder's: WAV's
+  `-map 0:a:0 -c:a pcm_s16le` over an `[aac, pcm_s16le]` source writes one
+  `pcm_s16le` stream, which reads as a surplus under that pair and would forgive
+  the loss of the source's second, genuinely dropped, `pcm_s16le` track. A
+  re-encode preserves a stream's type but not its codec name, which is exactly
+  why the type count is immune to that phantom; the codec name is what stops
+  cross-attribution within a type, since a regenerated `tmcd` reports no codec
+  name and neither does its source counterpart, while telemetry reports
+  `bin_data` on both sides.
+
+  Two further properties keep the same direction closed: a drop with no surplus
+  under either count keeps its note, and a probe that fails leaves the whole
+  prediction standing rather than falling silent. The residual cost is that with
+  several predicted drops sharing one pair and only some of them surviving, the
+  *count* of reported losses is right while the index named may not be —
+  deliberately preferred over reporting a loss that did not happen, and never
+  over the silence the constitution forbids.
 - **A partial cheap attempt's success is verified, not assumed.** A mapping is
   partial by construction when it can leave source streams unmapped whatever the
   source turns out to contain: MP4's `-map 0:v? -map 0:a? -map 0:s?` selects no

--- a/docs/design/degradation-ladder.md
+++ b/docs/design/degradation-ladder.md
@@ -55,24 +55,33 @@ flowchart TD
   failure side and the success side are mutually exclusive — a file takes one
   path or the other. The second success-side probe, `C`, is the one exception to
   the one-probe count, and it is bounded by the claim it pays for: it runs only
-  when `V` predicted at least one drop, so a conversion that gave nothing up
-  still costs a single probe.
+  when `V` predicted at least one drop, so a conversion whose mapping gives
+  nothing up still costs a single probe. How often that is depends on the
+  profile, not on some general "common case" — an audio target over a library
+  whose files all carry cover art predicts a drop on every one of them, and pays
+  for `C` on every one of them.
 - **A predicted drop is confirmed against the output before it is reported.** A
   `-map` set says what ffmpeg was *asked* to carry, which is not the same as what
   the muxer wrote: MP4 and MOV regenerate a `tmcd` timecode track from the
   source's metadata although no selector names it (measured, ffmpeg 9.0), so the
   mapping alone reports a loss that did not happen — the false-positive half of
-  the loss accounting `docs/vision.md` names as the USP (issue #66). `C` compares
-  *counts per stream type* between the source and the written file, because a
-  regenerated stream shares neither index nor codec name with its source, and
-  attributes any surplus to that type's predicted drops in source order. Two
-  properties make this safe in the direction the constitution cares about: a type
-  with no surplus keeps every note it was given, and a probe that fails leaves
-  the whole prediction standing rather than falling silent. The cost is that with
-  several predicted drops of one type and only some of them surviving, the
-  *count* of reported losses is right while the index named may not be —
-  deliberately preferred over reporting a loss that did not happen, and never
-  over the silence the constitution forbids.
+  the loss accounting `docs/vision.md` names as the USP (issue #66). `C` counts
+  the streams of each **type-and-codec-name pair** in the source and in the
+  written file, and attributes any surplus to that pair's predicted drops in
+  source order. An index cannot be the match key — a stream the muxer put back
+  carries whatever index the output gives it — but the codec name can: a
+  regenerated `tmcd` reports none at all and neither does its source
+  counterpart, while a `gpmd`/ANC telemetry stream reports `bin_data` on both
+  sides. Matching on type alone is what must be avoided, and is the shape this
+  rule exists to forbid: no profile declares a `data` rule, so a regenerated
+  timecode would forgive the loss of telemetry in the same file, and a real drop
+  would go unreported. Two further properties keep the direction the constitution
+  cares about closed: a pair with no surplus keeps every note it was given, and a
+  probe that fails leaves the whole prediction standing rather than falling
+  silent. The residual cost is that with several predicted drops sharing one pair
+  and only some of them surviving, the *count* of reported losses is right while
+  the index named may not be — deliberately preferred over reporting a loss that
+  did not happen, and never over the silence the constitution forbids.
 - **A partial cheap attempt's success is verified, not assumed.** A mapping is
   partial by construction when it can leave source streams unmapped whatever the
   source turns out to contain: MP4's `-map 0:v? -map 0:a? -map 0:s?` selects no

--- a/docs/prior-art.md
+++ b/docs/prior-art.md
@@ -84,7 +84,9 @@ evidenced, not assumed — see the image-conversion concern.
     (`mp4_remux` to `_mp4_selective` to `mp4_reencode`). ffprobe never runs on
     the happy path of an *exhaustive* cheap attempt — issue #18 narrowed this
     to admit one probe on the success of a mapping that is partial by
-    construction, which is what keeps the loss accounting honest.
+    construction, and issue #66 a further one on the written output whenever
+    that probe is about to report a loss, which is what keeps the loss
+    accounting honest in both directions.
     Combined with HandBrake's copy mask this gets both: the mask
     PREDICTS a doomed attempt, trial-and-fallback remains the safety net for what
     the mask gets wrong.

--- a/docs/specs/archive/spec-video-formats.md
+++ b/docs/specs/archive/spec-video-formats.md
@@ -583,15 +583,19 @@ New-Item -ItemType Directory -Force in
   is now explicitly a *prediction* from the mapping, and `jobs.confirm_drops`
   weighs it against the file that was actually written, keeping only the drops
   the output does not contain. The comparison counts both files' streams
-  **twice** -- once per stream type, once per type-and-codec-name pair -- and
-  forgives a predicted drop only where *both* counts show a surplus, spending one
-  of each budget per forgiveness. An index cannot be a match key at all: a stream
-  the muxer put back carries whatever index the output gives it.
+  **twice** -- once per stream type, once per `(codec_type, codec_name,
+  codec_tag_string)` key -- and forgives a predicted drop only where *both*
+  counts show a surplus **and** that surplus covers every predicted drop sharing
+  the key. An index cannot be a match key at all: a stream the muxer put back
+  carries whatever index the output gives it.
 
-  It took two review rounds to arrive at both halves, and each half exists
-  because review built a counter-example that turned a real loss into a silent
-  success -- the direction `docs/constitution.md` forbids outright, and the one
-  this fix must not open while closing its mirror image.
+  It took three review rounds to arrive at those conditions, and every one of
+  them exists because review built a counter-example that hid a real loss -- the
+  direction `docs/constitution.md` forbids outright, and the one this fix must
+  not open while closing its mirror image. Recorded in full because the sequence
+  is the argument: each round's fix was locally correct and opened the next hole,
+  so the final rule is not a stack of patches but the shape the three failures
+  jointly describe.
 
   **Round 1 killed matching by type alone.** No profile declares a `data` rule,
   so `kept["data"]` is always 0 and *any* data stream in the output forgave one
@@ -618,15 +622,36 @@ New-Item -ItemType Directory -Force in
   but the hazard is structural: it arms itself for any future profile that
   combines a re-encoding cheap attempt with a `stream_limit`.
 
-  Within a type, a surplus is attributed to the predicted drops sharing its key
-  in source order, so with several predicted drops sharing one pair and only some
-  surviving the *count* of reported losses is right while the index named may not
-  be -- accepted deliberately, since the alternative is reporting a loss that did
-  not happen. The forbidden direction is closed on three further sides: a drop
-  with no surplus under either count keeps its note, a probe that fails leaves the
-  whole prediction standing with an added note saying it could not be confirmed,
-  and the output probe catches `OSError` as well as `ProbeError` rather than
-  turning a conversion ffmpeg already completed into a reported failure.
+  **Round 3 killed attributing a partial surplus in source order.** The rule as
+  of round 2 forgave one predicted drop per surviving stream, and disclosed the
+  residual as "the *count* of reported losses is right while the index named may
+  not be" -- which read as cosmetic mis-numbering and was not. Review measured
+  the case that makes it substantive: an Apple `mebx` metadata track, which every
+  iPhone `.mov` carries, demuxes with `codec_id = NONE` because its 4CC maps to
+  no codec id, so ffprobe omits `codec_name` for it exactly as it does for a
+  `tmcd`. A source carrying both, converted to `mov` or `mp4`, keeps only the
+  regenerated timecode -- and source order put the genuinely lost metadata track
+  first, so it was forgiven while the *survivor* was reported as the loss. That
+  is issue #66's own failure mode with a real loss hidden behind it, and on
+  `main` both streams had at least been named.
+
+  Two changes close it. `codec_tag_string` joins the probe's `-show_entries` and
+  the match key -- one extra field on a query that was already being made, no
+  extra process -- so `mebx` and `tmcd` are distinguishable and a regenerated
+  timecode still matches its source, both carrying the tag `tmcd` (measured).
+  And a key's predicted drops are now forgiven **all or none**: where the probe
+  genuinely cannot tell two streams apart and only one returns, every candidate
+  keeps its note. Guessing would break both halves of the promise at once, so
+  the residual is now over-reporting on real ambiguity rather than a
+  possibly-wrong index -- and the disclosure says so.
+
+  The forbidden direction is closed on three further sides: a drop with no
+  surplus under either count keeps its note, a probe that fails leaves the whole
+  prediction standing with an added note saying it could not be confirmed, and
+  *both* success-side probes catch `OSError` as well as `ProbeError` rather than
+  turning a conversion ffmpeg already completed into a reported failure -- the
+  source probe included, since review pointed out it runs after a successful
+  conversion for the same reason the output probe does.
 
   **ffprobe frequency changed, deliberately.** The success side now spends a
   second probe -- on the *output* -- but only on a run that has already predicted

--- a/docs/specs/archive/spec-video-formats.md
+++ b/docs/specs/archive/spec-video-formats.md
@@ -582,22 +582,42 @@ New-Item -ItemType Directory -Force in
   Fixed **generally rather than by special-casing `tmcd`**: `jobs.verify_success`
   is now explicitly a *prediction* from the mapping, and `jobs.confirm_drops`
   weighs it against the file that was actually written, keeping only the drops
-  the output does not contain. The comparison is *counts per stream type*,
-  because a regenerated stream shares neither index nor codec name with its
-  source (ffprobe reports no `codec_name` at all for either side of a `tmcd`
-  pair). Any surplus is attributed to that type's predicted drops in source
-  order, so with several predicted drops of one type and only some surviving the
-  *count* of reported losses is right while the index named may not be --
-  accepted deliberately, since the alternative is reporting a loss that did not
-  happen. The direction `docs/constitution.md` forbids is closed on both sides: a
-  type with no surplus keeps every note it was given, and a probe that fails
-  leaves the whole prediction standing, with an added note saying it could not be
-  confirmed.
+  the output does not contain. The comparison counts streams per **type and
+  codec name together**. An index cannot be the match key -- a stream the muxer
+  put back carries whatever index the output gives it -- but the codec name can:
+  ffprobe reports none at all for a `tmcd` stream on *either* side, and reports
+  `bin_data` on both sides of a `gpmd`/ANC telemetry stream. Any surplus is
+  attributed to that pair's predicted drops in source order, so with several
+  predicted drops sharing one pair and only some surviving the *count* of
+  reported losses is right while the index named may not be -- accepted
+  deliberately, since the alternative is reporting a loss that did not happen.
+  The direction `docs/constitution.md` forbids is closed on three sides: a pair
+  with no surplus keeps every note it was given, a probe that fails leaves the
+  whole prediction standing with an added note saying it could not be confirmed,
+  and the output probe now also catches `OSError` rather than turning a
+  conversion ffmpeg already completed into a reported failure.
+
+  The first draft of this fix matched on `codec_type` alone, and review built the
+  counter-example that killed it: no profile declares a `data` rule, so
+  `kept["data"]` is always 0 and *any* data stream in the output forgave one
+  predicted data drop. A source carrying `gpmd` telemetry *and* a source-level
+  timecode therefore reported a clean success while the telemetry was genuinely
+  gone -- trading the common false positive for the rarer false negative that
+  `docs/constitution.md` forbids outright. Re-measured on ffmpeg 9.0 to settle
+  it: a source with a `TIMECODE` tag and no data stream at all still produces a
+  `tmcd` data stream in a MOV output (so the track comes from *metadata*), and a
+  `video + bin_data` source produces an output with zero data streams (so
+  `bin_data` really is lost). Both facts are now pinned by tests.
 
   **ffprobe frequency changed, deliberately.** The success side now spends a
   second probe -- on the *output* -- but only on a run that has already predicted
-  at least one drop, so a conversion that gives nothing up costs exactly the one
-  probe it cost before. This is the same trade issue #18 made and
+  at least one drop, so a conversion whose mapping gives nothing up costs exactly
+  the one probe it cost before. How often that is depends on the profile rather
+  than on any general "common case": every one of the 17 shipped profiles
+  declares `partial_mapping=True`, so the change reaches all of them, and an
+  audio target over a library whose files all carry cover art predicts a drop --
+  and pays for the second probe -- on every file. This is the same trade issue
+  #18 made and
   `spec-profile-registry.md`'s Decision log records (the loss-accounting USP over
   a probe on a minority of runs), applied to the mirror-image bug, so it was
   resolved as settled by precedent rather than escalated as a design fork. The
@@ -612,6 +632,13 @@ New-Item -ItemType Directory -Force in
   not this issue's to write -- the live normative statement in
   `docs/constitution.md` is corrected, and the archived one is a record of what
   phase 1 decided.
+
+  Review also proposed renaming `jobs.verify_success` to `predict_drops`, since
+  it now returns something that must never be reported unconfirmed. Declined for
+  now, and recorded rather than dropped: `spec-target-driven-cli.md` names the
+  symbol and belongs to a concurrently edited branch, so the rename would leave a
+  dangling reference in a file this issue must not touch. The docstring carries
+  the correction instead, and the rename is cheap to make once that branch lands.
 
   `mov`'s standing note (`"data and timecode streams are not carried into MOV"`,
   Prior decisions row 3 and the Verification item pinning its wording) is

--- a/docs/specs/archive/spec-video-formats.md
+++ b/docs/specs/archive/spec-video-formats.md
@@ -605,7 +605,13 @@ New-Item -ItemType Directory -Force in
   principles), `docs/design/degradation-ladder.md` (the diagram gains node `C`
   and a rule for it), `docs/design.md` (Cost markers), `docs/architecture.md`
   (Key flows section 1), `docs/prior-art.md`'s ADOPT note, and
-  `converter/ffmpegtool.probe_streams`'s docstring.
+  `converter/ffmpegtool.probe_streams`'s docstring. One restatement is left
+  stale on purpose: `spec-profile-registry.md`'s Constraints still say "the
+  engine probes at most once per file". That file was being edited concurrently
+  by another issue's branch, and a Decision log entry outside one's own spec is
+  not this issue's to write -- the live normative statement in
+  `docs/constitution.md` is corrected, and the archived one is a record of what
+  phase 1 decided.
 
   `mov`'s standing note (`"data and timecode streams are not carried into MOV"`,
   Prior decisions row 3 and the Verification item pinning its wording) is

--- a/docs/specs/archive/spec-video-formats.md
+++ b/docs/specs/archive/spec-video-formats.md
@@ -582,32 +582,51 @@ New-Item -ItemType Directory -Force in
   Fixed **generally rather than by special-casing `tmcd`**: `jobs.verify_success`
   is now explicitly a *prediction* from the mapping, and `jobs.confirm_drops`
   weighs it against the file that was actually written, keeping only the drops
-  the output does not contain. The comparison counts streams per **type and
-  codec name together**. An index cannot be the match key -- a stream the muxer
-  put back carries whatever index the output gives it -- but the codec name can:
-  ffprobe reports none at all for a `tmcd` stream on *either* side, and reports
-  `bin_data` on both sides of a `gpmd`/ANC telemetry stream. Any surplus is
-  attributed to that pair's predicted drops in source order, so with several
-  predicted drops sharing one pair and only some surviving the *count* of
-  reported losses is right while the index named may not be -- accepted
-  deliberately, since the alternative is reporting a loss that did not happen.
-  The direction `docs/constitution.md` forbids is closed on three sides: a pair
-  with no surplus keeps every note it was given, a probe that fails leaves the
-  whole prediction standing with an added note saying it could not be confirmed,
-  and the output probe now also catches `OSError` rather than turning a
-  conversion ffmpeg already completed into a reported failure.
+  the output does not contain. The comparison counts both files' streams
+  **twice** -- once per stream type, once per type-and-codec-name pair -- and
+  forgives a predicted drop only where *both* counts show a surplus, spending one
+  of each budget per forgiveness. An index cannot be a match key at all: a stream
+  the muxer put back carries whatever index the output gives it.
 
-  The first draft of this fix matched on `codec_type` alone, and review built the
-  counter-example that killed it: no profile declares a `data` rule, so
-  `kept["data"]` is always 0 and *any* data stream in the output forgave one
-  predicted data drop. A source carrying `gpmd` telemetry *and* a source-level
-  timecode therefore reported a clean success while the telemetry was genuinely
-  gone -- trading the common false positive for the rarer false negative that
-  `docs/constitution.md` forbids outright. Re-measured on ffmpeg 9.0 to settle
-  it: a source with a `TIMECODE` tag and no data stream at all still produces a
-  `tmcd` data stream in a MOV output (so the track comes from *metadata*), and a
-  `video + bin_data` source produces an output with zero data streams (so
-  `bin_data` really is lost). Both facts are now pinned by tests.
+  It took two review rounds to arrive at both halves, and each half exists
+  because review built a counter-example that turned a real loss into a silent
+  success -- the direction `docs/constitution.md` forbids outright, and the one
+  this fix must not open while closing its mirror image.
+
+  **Round 1 killed matching by type alone.** No profile declares a `data` rule,
+  so `kept["data"]` is always 0 and *any* data stream in the output forgave one
+  predicted data drop. A source carrying `gpmd`/ANC telemetry *and* a
+  source-level timecode reported a clean success while the telemetry was
+  genuinely gone. Re-measured on ffmpeg 9.0 to settle the key: a source with a
+  `TIMECODE` tag and no data stream at all still produces a `tmcd` data stream in
+  a MOV output (so the track comes from *metadata*), and a `video + bin_data`
+  source produces an output with zero data streams (so `bin_data` really is
+  lost). ffprobe reports no `codec_name` on *either* side of a `tmcd` pair and
+  `bin_data` on both sides of a telemetry one -- which is what makes the codec
+  name a usable match key.
+
+  **Round 2 killed matching by that key alone.** A cheap attempt that
+  *re-encodes* makes the two sides disagree by construction: `kept` carries the
+  source's codec name, the output carries the encoder's. WAV's `-map 0:a:0 -c:a
+  pcm_s16le` over an `[aac, pcm_s16le]` source writes one `pcm_s16le` stream,
+  which read as a surplus under that key and forgave the drop of the source's
+  second, genuinely lost, `pcm_s16le` track -- an ordinary camera/pro-video MOV
+  through `--to wav`, not a corner case. A re-encode preserves a stream's *type*
+  but not its codec name, which is exactly why the type count is immune to that
+  phantom, and why requiring both is not a patch on top of the first rule but the
+  rule the two failures jointly describe. WAV is the only live instance today,
+  but the hazard is structural: it arms itself for any future profile that
+  combines a re-encoding cheap attempt with a `stream_limit`.
+
+  Within a type, a surplus is attributed to the predicted drops sharing its key
+  in source order, so with several predicted drops sharing one pair and only some
+  surviving the *count* of reported losses is right while the index named may not
+  be -- accepted deliberately, since the alternative is reporting a loss that did
+  not happen. The forbidden direction is closed on three further sides: a drop
+  with no surplus under either count keeps its note, a probe that fails leaves the
+  whole prediction standing with an added note saying it could not be confirmed,
+  and the output probe catches `OSError` as well as `ProbeError` rather than
+  turning a conversion ffmpeg already completed into a reported failure.
 
   **ffprobe frequency changed, deliberately.** The success side now spends a
   second probe -- on the *output* -- but only on a run that has already predicted

--- a/docs/specs/archive/spec-video-formats.md
+++ b/docs/specs/archive/spec-video-formats.md
@@ -566,3 +566,52 @@ New-Item -ItemType Directory -Force in
 - 2026-08-26: Close-out. The final QA gate ran against real ffmpeg 9.0 on
   Windows 11, verifying all 17 target formats end-to-end with ffprobe.
   Verdict: PASS WITH FINDINGS; the findings are filed as issues #66-#73.
+
+- 2026-08-27 (issue #66): the muxer fact this phase measured -- "neither MKV nor
+  a `v/a/s/t` map carries data or timecode streams" (Prior decisions, row 3) --
+  is right about the *mapping* and wrong about the *output* for `mp4` and `mov`.
+  Re-measured against ffmpeg 9.0 on Windows 11 with a `-timecode`-bearing source:
+  the `tmcd` stream is absent from an `.mkv` and a `.webm` output, exactly as the
+  table says, but present in both an `.mp4` and a `.mov` one, because MOV/MP4's
+  muxer regenerates a timecode track from the source's metadata although no
+  selector maps it. The phase therefore shipped a note claiming a loss that did
+  not happen -- the false-positive half of the loss accounting `docs/vision.md`
+  names as the USP, and the reason this was treated as a correctness bug rather
+  than cosmetics.
+
+  Fixed **generally rather than by special-casing `tmcd`**: `jobs.verify_success`
+  is now explicitly a *prediction* from the mapping, and `jobs.confirm_drops`
+  weighs it against the file that was actually written, keeping only the drops
+  the output does not contain. The comparison is *counts per stream type*,
+  because a regenerated stream shares neither index nor codec name with its
+  source (ffprobe reports no `codec_name` at all for either side of a `tmcd`
+  pair). Any surplus is attributed to that type's predicted drops in source
+  order, so with several predicted drops of one type and only some surviving the
+  *count* of reported losses is right while the index named may not be --
+  accepted deliberately, since the alternative is reporting a loss that did not
+  happen. The direction `docs/constitution.md` forbids is closed on both sides: a
+  type with no surplus keeps every note it was given, and a probe that fails
+  leaves the whole prediction standing, with an added note saying it could not be
+  confirmed.
+
+  **ffprobe frequency changed, deliberately.** The success side now spends a
+  second probe -- on the *output* -- but only on a run that has already predicted
+  at least one drop, so a conversion that gives nothing up costs exactly the one
+  probe it cost before. This is the same trade issue #18 made and
+  `spec-profile-registry.md`'s Decision log records (the loss-accounting USP over
+  a probe on a minority of runs), applied to the mirror-image bug, so it was
+  resolved as settled by precedent rather than escalated as a design fork. The
+  restatements moved with it in this PR: `docs/constitution.md` (Architecture
+  principles), `docs/design/degradation-ladder.md` (the diagram gains node `C`
+  and a rule for it), `docs/design.md` (Cost markers), `docs/architecture.md`
+  (Key flows section 1), `docs/prior-art.md`'s ADOPT note, and
+  `converter/ffmpegtool.probe_streams`'s docstring.
+
+  `mov`'s standing note (`"data and timecode streams are not carried into MOV"`,
+  Prior decisions row 3 and the Verification item pinning its wording) is
+  **removed**, and its test now pins the absence. It was a blanket claim, printed
+  on every MOV conversion, that the measurement above shows to be false for the
+  commonest data stream a MOV source carries; the per-file confirmation names a
+  real data drop per stream instead, so nothing is lost by dropping it. `mkv`'s
+  and `webm`'s standing notes are untouched -- there the loss is real, and the
+  issue's acceptance asked for that behaviour to stay unchanged.

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -2,6 +2,7 @@
 
 import subprocess
 from dataclasses import replace
+from typing import ClassVar
 
 import pytest
 
@@ -2636,6 +2637,75 @@ class TestSuccessSideVerification:
         streams = [Stream(0, "video", "vp8"), Stream(1, "subtitle", "dvd_subtitle")]
 
         assert jobs.verify_success(MP4, streams) == ()
+
+
+class TestConfirmDrops:
+    """`jobs.confirm_drops`: the prediction weighed against the written file.
+
+    `verify_success` reads the mapping, which says what ffmpeg was *asked* to
+    carry. MP4 and MOV regenerate a `tmcd` timecode track from source metadata
+    with no selector naming it (issue #66), so the mapping alone over-reports.
+    """
+
+    SOURCE: ClassVar[list[Stream]] = [
+        Stream(0, "video", "h264"),
+        Stream(1, "audio", "aac"),
+        Stream(2, "data", ""),
+    ]
+
+    def test_a_stream_the_output_still_holds_is_not_reported_as_dropped(self):
+        assert jobs.confirm_drops(MP4, self.SOURCE, self.SOURCE) == ()
+
+    def test_a_stream_the_output_does_not_hold_keeps_its_note(self):
+        produced = [Stream(0, "video", "h264"), Stream(1, "audio", "aac")]
+
+        assert jobs.confirm_drops(MKV, self.SOURCE, produced) == (
+            "data stream 2 (unknown) dropped: not supported by MKV",
+        )
+
+    def test_an_output_that_holds_nothing_keeps_every_note(self):
+        """Nothing survived, so nothing is forgiven -- the direction that
+        over-reports rather than falling silent."""
+        assert jobs.confirm_drops(MP4, self.SOURCE, []) == jobs.verify_success(MP4, self.SOURCE)
+
+    def test_a_surplus_forgives_one_predicted_drop_per_surviving_stream(self):
+        """Two of a type predicted dropped, one of them back in the output: the
+        reported count follows the output, and the note that remains is still
+        the profile's own wording."""
+        source = [Stream(0, "video", "h264"), Stream(1, "data", ""), Stream(2, "data", "")]
+        produced = [Stream(0, "video", "h264"), Stream(1, "data", "")]
+
+        notes = jobs.confirm_drops(MP4, source, produced)
+
+        assert notes == ("data stream 2 (unknown) dropped: not supported by MP4",)
+
+    def test_a_stream_of_another_type_never_forgives_a_drop(self):
+        """The surplus is counted per stream type, so an extra audio stream in
+        the output cannot silence a dropped attachment."""
+        source = [Stream(0, "video", "h264"), Stream(1, "attachment", "ttf")]
+        produced = [Stream(0, "video", "h264"), Stream(1, "audio", "aac")]
+
+        assert jobs.confirm_drops(MP4, source, produced) == (
+            "attachment stream 1 (ttf) dropped: not supported by MP4",
+        )
+
+    def test_a_surplus_of_a_type_with_no_predicted_drop_changes_nothing(self):
+        source = [Stream(0, "video", "h264"), Stream(1, "attachment", "ttf")]
+        produced = [Stream(0, "video", "h264"), Stream(1, "video", "h264")]
+
+        assert jobs.confirm_drops(MP4, source, produced) == (
+            "attachment stream 1 (ttf) dropped: not supported by MP4",
+        )
+
+    def test_a_stream_limit_drop_the_output_disproves_is_forgiven(self):
+        """Not a `tmcd` special case: the same confirmation covers D2, where the
+        prediction is "the container holds only so many of this type"."""
+        source = [Stream(0, "audio", "opus"), Stream(1, "audio", "opus")]
+
+        assert jobs.confirm_drops(WAV, source, source) == ()
+        assert jobs.confirm_drops(WAV, source, source[:1]) == (
+            "audio stream 1 (opus) dropped: WAV holds 1 audio stream",
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -2680,16 +2680,61 @@ class TestConfirmDrops:
         over-reports rather than falling silent."""
         assert jobs.confirm_drops(MP4, self.SOURCE, []) == jobs.verify_success(MP4, self.SOURCE)
 
-    def test_a_surplus_forgives_one_predicted_drop_per_surviving_stream(self):
-        """Two of a type predicted dropped, one of them back in the output: the
-        reported count follows the output, and the note that remains is still
-        the profile's own wording."""
-        source = [Stream(0, "video", "h264"), Stream(1, "data", ""), Stream(2, "data", "")]
-        produced = [Stream(0, "video", "h264"), Stream(1, "data", "")]
+    def test_an_ambiguous_surplus_forgives_nothing(self):
+        """Two streams that are indistinguishable to the probe are predicted
+        dropped and exactly one comes back. Which one survived is unknowable, so
+        both keep their note: forgiving one at a guess would claim a loss that
+        did not happen *and* fall silent about one that did."""
+        source = [
+            Stream(0, "video", "h264", "avc1"),
+            Stream(1, "data", "", "tmcd"),
+            Stream(2, "data", "", "tmcd"),
+        ]
+        produced = [Stream(0, "video", "h264", "avc1"), Stream(1, "data", "", "tmcd")]
 
-        notes = jobs.confirm_drops(MP4, source, produced)
+        assert jobs.confirm_drops(MP4, source, produced) == (
+            "data stream 1 (unknown) dropped: not supported by MP4",
+            "data stream 2 (unknown) dropped: not supported by MP4",
+        )
 
-        assert notes == ("data stream 2 (unknown) dropped: not supported by MP4",)
+    def test_the_same_streams_all_surviving_are_all_forgiven(self):
+        """The counterpart: the surplus covers every predicted drop of the key,
+        so there is nothing to guess and none of them is reported."""
+        source = [
+            Stream(0, "video", "h264", "avc1"),
+            Stream(1, "data", "", "tmcd"),
+            Stream(2, "data", "", "tmcd"),
+        ]
+
+        assert jobs.confirm_drops(MP4, source, source) == ()
+
+    @pytest.mark.parametrize("profile", [MP4, MOV], ids=lambda profile: profile.label)
+    def test_a_regenerated_timecode_never_forgives_a_metadata_drop(self, profile):
+        """The counter-example that added the container tag to the key.
+
+        Apple `mebx` metadata -- every iPhone `.mov` has one -- demuxes with no
+        codec id, so ffprobe omits `codec_name` for it exactly as it does for a
+        `tmcd`. Source stream 2 is genuinely gone and stream 3 is the one the
+        muxer put back at a *different index*; without the tag the two were
+        indistinguishable, the first was forgiven and the survivor was reported
+        as the loss -- issue #66's own failure mode, with the real loss hidden
+        behind it.
+        """
+        source = [
+            Stream(0, "video", "h264", "avc1"),
+            Stream(1, "audio", "aac", "mp4a"),
+            Stream(2, "data", "", "mebx"),
+            Stream(3, "data", "", "tmcd"),
+        ]
+        produced = [
+            Stream(0, "video", "h264", "avc1"),
+            Stream(1, "audio", "aac", "mp4a"),
+            Stream(2, "data", "", "tmcd"),
+        ]
+
+        assert jobs.confirm_drops(profile, source, produced) == (
+            f"data stream 2 (unknown) dropped: not supported by {profile.label}",
+        )
 
     @pytest.mark.parametrize("profile", [MP4, MOV], ids=lambda profile: profile.label)
     def test_a_regenerated_timecode_never_forgives_a_telemetry_drop(self, profile):
@@ -2708,13 +2753,15 @@ class TestConfirmDrops:
     @pytest.mark.parametrize("profile", [MP4, MOV], ids=lambda profile: profile.label)
     def test_both_verdicts_are_reached_when_both_data_streams_are_present(self, profile):
         """The same file carrying both: the timecode is forgiven, the telemetry
-        is not. One key forgiving another would collapse the two."""
+        is not. One key forgiving another would collapse the two. Note the
+        surviving stream's output index differs from its source index, so an
+        index-based match would fail this even though every field agrees."""
         source = [
-            Stream(0, "video", "h264"),
-            Stream(1, "data", "bin_data"),
-            Stream(2, "data", ""),
+            Stream(0, "video", "h264", "avc1"),
+            Stream(1, "data", "bin_data", "gpmd"),
+            Stream(2, "data", "", "tmcd"),
         ]
-        produced = [Stream(0, "video", "h264"), Stream(1, "data", "")]
+        produced = [Stream(0, "video", "h264", "avc1"), Stream(1, "data", "", "tmcd")]
 
         assert jobs.confirm_drops(profile, source, produced) == (
             f"data stream 1 (bin_data) dropped: not supported by {profile.label}",

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -2645,6 +2645,12 @@ class TestConfirmDrops:
     `verify_success` reads the mapping, which says what ffmpeg was *asked* to
     carry. MP4 and MOV regenerate a `tmcd` timecode track from source metadata
     with no selector naming it (issue #66), so the mapping alone over-reports.
+
+    The match key is type *and* codec name. The first review of this fix
+    matched on type alone and built the counter-example that kills it: no
+    profile declares a `data` rule, so a regenerated `tmcd` forgave the drop of
+    a `gpmd`/ANC telemetry stream in the same file, turning a real loss into a
+    silent success -- the one direction `docs/constitution.md` forbids outright.
     """
 
     SOURCE: ClassVar[list[Stream]] = [
@@ -2678,6 +2684,35 @@ class TestConfirmDrops:
         notes = jobs.confirm_drops(MP4, source, produced)
 
         assert notes == ("data stream 2 (unknown) dropped: not supported by MP4",)
+
+    @pytest.mark.parametrize("profile", [MP4, MOV], ids=lambda profile: profile.label)
+    def test_a_regenerated_timecode_never_forgives_a_telemetry_drop(self, profile):
+        """The counter-example that decided the match key: one source data
+        stream (`gpmd`/ANC telemetry, `bin_data`) genuinely lost, and one data
+        stream in the output that the muxer synthesised from metadata (`tmcd`,
+        no codec name on either side). Matching on `codec_type` alone reported
+        this as a clean success while a real stream was gone."""
+        source = [Stream(0, "video", "h264"), Stream(1, "data", "bin_data")]
+        produced = [Stream(0, "video", "h264"), Stream(1, "data", "")]
+
+        assert jobs.confirm_drops(profile, source, produced) == (
+            f"data stream 1 (bin_data) dropped: not supported by {profile.label}",
+        )
+
+    @pytest.mark.parametrize("profile", [MP4, MOV], ids=lambda profile: profile.label)
+    def test_both_verdicts_are_reached_when_both_data_streams_are_present(self, profile):
+        """The same file carrying both: the timecode is forgiven, the telemetry
+        is not. One key forgiving another would collapse the two."""
+        source = [
+            Stream(0, "video", "h264"),
+            Stream(1, "data", "bin_data"),
+            Stream(2, "data", ""),
+        ]
+        produced = [Stream(0, "video", "h264"), Stream(1, "data", "")]
+
+        assert jobs.confirm_drops(profile, source, produced) == (
+            f"data stream 1 (bin_data) dropped: not supported by {profile.label}",
+        )
 
     def test_a_stream_of_another_type_never_forgives_a_drop(self):
         """The surplus is counted per stream type, so an extra audio stream in

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -2646,11 +2646,17 @@ class TestConfirmDrops:
     carry. MP4 and MOV regenerate a `tmcd` timecode track from source metadata
     with no selector naming it (issue #66), so the mapping alone over-reports.
 
-    The match key is type *and* codec name. The first review of this fix
-    matched on type alone and built the counter-example that kills it: no
-    profile declares a `data` rule, so a regenerated `tmcd` forgave the drop of
-    a `gpmd`/ANC telemetry stream in the same file, turning a real loss into a
-    silent success -- the one direction `docs/constitution.md` forbids outright.
+    A drop is forgiven only when the output holds a surplus by stream type
+    *and* by (type, codec name). Review killed both halves in turn, each with a
+    counter-example that turned a real loss into a silent success -- the one
+    direction `docs/constitution.md` forbids outright:
+
+    * by type alone, a regenerated `tmcd` forgave the drop of a `gpmd`/ANC
+      telemetry stream in the same file, since no profile declares a `data`
+      rule;
+    * by key alone, WAV's re-encoding cheap attempt made source and output
+      disagree on the codec name, so its own `pcm_s16le` output forgave the
+      drop of a second, genuinely lost `pcm_s16le` source track.
     """
 
     SOURCE: ClassVar[list[Stream]] = [
@@ -2714,9 +2720,27 @@ class TestConfirmDrops:
             f"data stream 1 (bin_data) dropped: not supported by {profile.label}",
         )
 
+    def test_a_re_encoded_output_stream_never_forgives_a_real_drop(self):
+        """The counter-example that decided the *second* half of the rule.
+
+        WAV's cheap attempt re-encodes (`-map 0:a:0 -c:a pcm_s16le`), so the
+        source's codec name and the output's disagree by construction. Its one
+        `pcm_s16le` output stream reads as a surplus under that key, and by key
+        alone it forgave the drop of the source's second track -- which happens
+        to be `pcm_s16le` too and is genuinely gone. The stream-type count is
+        what closes it: a re-encode preserves the type, so `audio` shows no
+        surplus at all.
+        """
+        source = [Stream(0, "audio", "aac"), Stream(1, "audio", "pcm_s16le")]
+        produced = [Stream(0, "audio", "pcm_s16le")]
+
+        assert jobs.confirm_drops(WAV, source, produced) == (
+            "audio stream 1 (pcm_s16le) dropped: WAV holds 1 audio stream",
+        )
+
     def test_a_stream_of_another_type_never_forgives_a_drop(self):
-        """The surplus is counted per stream type, so an extra audio stream in
-        the output cannot silence a dropped attachment."""
+        """Neither budget is spendable across stream types, so an extra audio
+        stream in the output cannot silence a dropped attachment."""
         source = [Stream(0, "video", "h264"), Stream(1, "attachment", "ttf")]
         produced = [Stream(0, "video", "h264"), Stream(1, "audio", "aac")]
 

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -2647,16 +2647,23 @@ class TestConfirmDrops:
     with no selector naming it (issue #66), so the mapping alone over-reports.
 
     A drop is forgiven only when the output holds a surplus by stream type
-    *and* by (type, codec name). Review killed both halves in turn, each with a
-    counter-example that turned a real loss into a silent success -- the one
-    direction `docs/constitution.md` forbids outright:
+    *and* by `(type, codec name, container tag)`, and only when that surplus
+    covers every predicted drop sharing the key. Three review rounds killed the
+    weaker forms in turn, each with a counter-example that hid a real loss --
+    the one direction `docs/constitution.md` forbids outright:
 
     * by type alone, a regenerated `tmcd` forgave the drop of a `gpmd`/ANC
       telemetry stream in the same file, since no profile declares a `data`
       rule;
-    * by key alone, WAV's re-encoding cheap attempt made source and output
-      disagree on the codec name, so its own `pcm_s16le` output forgave the
-      drop of a second, genuinely lost `pcm_s16le` source track.
+    * by type and codec name, WAV's re-encoding cheap attempt made source and
+      output disagree on the codec name, so its own `pcm_s16le` output forgave
+      the drop of a second, genuinely lost `pcm_s16le` source track;
+    * without the container tag, an Apple `mebx` metadata track -- which reports
+      no codec name either -- was forgiven in place of the `tmcd` beside it, so
+      the survivor was named as the loss and the real loss went unreported;
+    * without the all-or-nothing clause, a partial surplus had to guess which of
+      several indistinguishable streams survived, and guessing wrong breaks both
+      halves of the promise at once.
     """
 
     SOURCE: ClassVar[list[Stream]] = [

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -7,7 +7,7 @@ import pytest
 from converter import batch
 from converter.batch import Outcome, Result, Task, convert_one, run_batch, summarise
 from converter.ffmpegtool import CommandResult, ProbeError, Stream, Tools
-from converter.profiles import FLAC, MP4, WAV, Attempt, Profile, StreamRule, flags
+from converter.profiles import FLAC, MKV, MOV, MP4, WAV, WEBM, Attempt, Profile, StreamRule, flags
 
 TOOLS = Tools(ffmpeg="ffmpeg", ffprobe="ffprobe")
 
@@ -42,8 +42,15 @@ def fake_ffmpeg(monkeypatch):
             self.calls: list[list[str]] = []
             self.exit_codes: list[int] = [0]
             self.streams: list[Stream] = []
+            #: What a probe of the *written file* reports, as opposed to
+            #: ``streams`` (the source). Empty by default: the muxer kept
+            #: nothing the mapping did not ask for, so every predicted drop
+            #: stands. A profile whose container puts a stream back (MOV's
+            #: regenerated timecode track, issue #66) sets this instead.
+            self.output_streams: list[Stream] = []
             self.probe_error: str | None = None
             self.creates_output = True
+            self.written: set[Path] = set()
 
         def run(self, argv, **_kwargs):
             argv = list(argv)
@@ -51,12 +58,16 @@ def fake_ffmpeg(monkeypatch):
             code = self.exit_codes[min(len(self.calls) - 1, len(self.exit_codes) - 1)]
             if self.creates_output:
                 Path(argv[-1]).write_bytes(b"partial")
+                self.written.add(Path(argv[-1]))
             return CommandResult(tuple(argv), code, "", "boom" if code else "")
 
-        def probe_streams(self, _tools, _src):
+        def probe_streams(self, _tools, src):
             if self.probe_error is not None:
                 raise ProbeError(self.probe_error)
-            return self.streams
+            # Which file is being probed is the whole point of the
+            # confirmation step, so the fake has to tell the two apart rather
+            # than answering the same list for both.
+            return self.output_streams if Path(src) in self.written else self.streams
 
     fake = Fake()
     monkeypatch.setattr(batch.ffmpegtool, "run", fake.run)
@@ -70,17 +81,25 @@ def make_task(tmp_path: Path, name: str = "clip") -> Task:
     return Task(src, tmp_path / "out" / f"{name}.mp4")
 
 
-def spy_on_probe(monkeypatch, streams: list[Stream]) -> list[Path]:
+def spy_on_probe(
+    monkeypatch, streams: list[Stream], output_streams: list[Stream] | None = None
+) -> list[Path]:
     """Replace probe_streams on the module and record what it was asked about.
 
     Patching the module attribute matters: rebinding the attribute on the fake
     object would leave the already-installed reference untouched, and the spy
     would silently never be called.
+
+    The source is probed first and the output only afterwards, and only when a
+    loss is about to be claimed (``batch._confirm_against_output``), so call
+    order is enough to tell the two apart for a single-file conversion.
     """
     seen: list[Path] = []
 
     def probe(_tools, src):
         seen.append(src)
+        if len(seen) > 1:
+            return list(output_streams or [])
         return list(streams)
 
     monkeypatch.setattr(batch.ffmpegtool, "probe_streams", probe)
@@ -272,9 +291,9 @@ class TestPartialCheapAttemptVerification:
         assert result.outcome is Outcome.CONVERTED
         assert result.attempt == "remux"
         assert len(fake_ffmpeg.calls) == 1
-        # The other half of "at most one probe per file": the success side pays
-        # for exactly one, never one per rung and never a second on the way out.
-        assert probes == [task.src]
+        # One probe per file, plus the one the claim itself pays for: the source
+        # says what was there, the output says what survived. Never one per rung.
+        assert probes == [task.src, task.dst]
         assert result.notes == ("attachment stream 1 (ttf) dropped: not supported by MP4",)
 
     def test_a_dropped_surplus_audio_stream_is_named_on_a_successful_pcm_run(
@@ -285,6 +304,9 @@ class TestPartialCheapAttemptVerification:
         task = Task(src, tmp_path / "out" / "two-tone.wav")
         task.dst.parent.mkdir(parents=True)
         fake_ffmpeg.streams = [Stream(0, "audio", "opus"), Stream(1, "audio", "opus")]
+        # WAV really does hold one: the drop the mapping predicts is confirmed
+        # by the written file rather than assumed from the mapping alone.
+        fake_ffmpeg.output_streams = [Stream(0, "audio", "pcm_s16le")]
 
         result = convert_one(WAV, task, TOOLS, overwrite=False)
 
@@ -327,6 +349,29 @@ class TestPartialCheapAttemptVerification:
         assert result.outcome is Outcome.CONVERTED
         assert result.notes == ("could not verify which source streams were kept: unreadable",)
 
+    def test_a_probe_of_the_output_that_fails_leaves_the_prediction_standing(
+        self, tmp_path, fake_ffmpeg, monkeypatch
+    ):
+        """The confirmation is what can *remove* a note, so losing it must fall
+        back to over-reporting, never to silence (``docs/constitution.md``)."""
+        task = make_task(tmp_path)
+        task.dst.parent.mkdir(parents=True)
+
+        def probe(_tools, src):
+            if Path(src) == task.dst:
+                raise ProbeError("output vanished")
+            return [Stream(0, "video", "h264"), Stream(1, "attachment", "ttf")]
+
+        monkeypatch.setattr(batch.ffmpegtool, "probe_streams", probe)
+
+        result = convert_one(MP4, task, TOOLS, overwrite=False)
+
+        assert result.outcome is Outcome.CONVERTED
+        assert result.notes == (
+            "attachment stream 1 (ttf) dropped: not supported by MP4",
+            "could not confirm this against the output: output vanished",
+        )
+
     def test_a_later_rung_is_not_verified_a_second_time(self, tmp_path, fake_ffmpeg, monkeypatch):
         """The selective rung was built from the stream list itself, so its own
         notes are already accurate and a second probe would buy nothing."""
@@ -340,6 +385,80 @@ class TestPartialCheapAttemptVerification:
         assert result.attempt == "selective"
         assert len(probes) == 1
         assert result.notes == ("video stream 0 (vp8) re-encoded to h264",)
+
+
+class TestDropsAreConfirmedAgainstTheOutput:
+    """Issue #66: a `-map` set says what ffmpeg was *asked* to carry, which is
+    not the same as what the muxer wrote.
+
+    Measured against ffmpeg 9.0: MP4 and MOV regenerate a `tmcd` timecode track
+    from the source's metadata although no selector names it, while MKV and
+    WebM really do leave it behind. Every test here drives the
+    cheap-attempt-succeeds path through `convert_one`, so it exercises the
+    success-side verification rather than `jobs.confirm_drops` in isolation.
+    """
+
+    #: What ffprobe reports for a `tmcd` stream: a data stream whose codec name
+    #: is absent on both sides, which is why the confirmation compares counts
+    #: per stream type and not indices or codec names.
+    TIMECODE = Stream(2, "data", "")
+
+    def _task(self, tmp_path: Path, suffix: str) -> Task:
+        src = tmp_path / "tcsrc.mp4"
+        src.write_bytes(b"data")
+        task = Task(src, tmp_path / "out" / f"tcsrc.{suffix}")
+        task.dst.parent.mkdir(parents=True)
+        return task
+
+    @pytest.mark.parametrize("profile", [MP4, MOV], ids=lambda profile: profile.label)
+    def test_a_timecode_stream_the_muxer_puts_back_is_not_reported_as_dropped(
+        self, tmp_path, fake_ffmpeg, profile
+    ):
+        task = self._task(tmp_path, profile.target_suffix.lstrip("."))
+        fake_ffmpeg.streams = [Stream(0, "video", "h264"), Stream(1, "audio", "aac"), self.TIMECODE]
+        fake_ffmpeg.output_streams = list(fake_ffmpeg.streams)
+
+        result = convert_one(profile, task, TOOLS, overwrite=False)
+
+        assert result.outcome is Outcome.CONVERTED
+        assert result.notes == ()
+
+    @pytest.mark.parametrize("profile", [MKV, WEBM], ids=lambda profile: profile.label)
+    def test_a_timecode_stream_the_muxer_really_drops_is_still_named(
+        self, tmp_path, fake_ffmpeg, profile
+    ):
+        task = self._task(tmp_path, profile.target_suffix.lstrip("."))
+        fake_ffmpeg.streams = [Stream(0, "video", "h264"), Stream(1, "audio", "aac"), self.TIMECODE]
+        fake_ffmpeg.output_streams = [Stream(0, "video", "h264"), Stream(1, "audio", "aac")]
+
+        result = convert_one(profile, task, TOOLS, overwrite=False)
+
+        assert f"data stream 2 (unknown) dropped: not supported by {profile.label}" in result.notes
+
+    def test_only_the_surviving_share_of_a_predicted_drop_is_forgiven(self, tmp_path, fake_ffmpeg):
+        """Two data streams predicted dropped, one of them in the output: the
+        count of reported losses has to follow the output, not the mapping."""
+        task = self._task(tmp_path, "mp4")
+        fake_ffmpeg.streams = [Stream(0, "video", "h264"), Stream(1, "data", ""), self.TIMECODE]
+        fake_ffmpeg.output_streams = [Stream(0, "video", "h264"), Stream(1, "data", "")]
+
+        result = convert_one(MP4, task, TOOLS, overwrite=False)
+
+        assert len(result.notes) == 1
+        assert result.notes[0].startswith("data stream ")
+
+    def test_the_output_is_probed_only_when_a_loss_is_about_to_be_claimed(
+        self, tmp_path, fake_ffmpeg, monkeypatch
+    ):
+        """The confirmation's whole cost argument: a conversion that lost
+        nothing still spends the single probe it spent before."""
+        task = self._task(tmp_path, "mp4")
+        probes = spy_on_probe(monkeypatch, [Stream(0, "video", "h264"), Stream(1, "audio", "aac")])
+
+        result = convert_one(MP4, task, TOOLS, overwrite=False)
+
+        assert result.notes == ()
+        assert probes == [task.src]
 
 
 class TestUnsupportedOutcome:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -95,8 +95,13 @@ def spy_on_probe(
 
     Source and output are told apart by *path*, the same way the `fake_ffmpeg`
     fixture does it, so a test cannot pass on the strength of the order the two
-    probes happen to run in. Pass `task` to answer differently for the output.
+    probes happen to run in. Pass `task` to answer differently for the output;
+    passing `output_streams` without it is refused rather than silently ignored,
+    so a test cannot look like it exercises the output probe while in fact
+    answering the source list twice.
     """
+    if output_streams is not None and task is None:
+        raise TypeError("output_streams needs task, to tell the output path apart")
     seen: list[Path] = []
 
     def probe(_tools, src):
@@ -356,17 +361,26 @@ class TestPartialCheapAttemptVerification:
         assert result.outcome is Outcome.CONVERTED
         assert result.notes == ("could not verify which source streams were kept: unreadable",)
 
+    @pytest.mark.parametrize(
+        "failure",
+        [ProbeError("output vanished"), OSError("output vanished")],
+        ids=["ProbeError", "OSError"],
+    )
     def test_a_probe_of_the_output_that_fails_leaves_the_prediction_standing(
-        self, tmp_path, fake_ffmpeg, monkeypatch
+        self, tmp_path, fake_ffmpeg, monkeypatch, failure
     ):
         """The confirmation is what can *remove* a note, so losing it must fall
-        back to over-reporting, never to silence (``docs/constitution.md``)."""
+        back to over-reporting, never to silence (``docs/constitution.md``).
+
+        `OSError` as well: the probe is a spawn, and this one happens after
+        ffmpeg already wrote a good file, so a failure to start it must not turn
+        that conversion into a reported failure."""
         task = make_task(tmp_path)
         task.dst.parent.mkdir(parents=True)
 
         def probe(_tools, src):
             if Path(src) == task.dst:
-                raise ProbeError("output vanished")
+                raise failure
             return [Stream(0, "video", "h264"), Stream(1, "attachment", "ttf")]
 
         monkeypatch.setattr(batch.ffmpegtool, "probe_streams", probe)
@@ -377,6 +391,27 @@ class TestPartialCheapAttemptVerification:
         assert result.notes == (
             "attachment stream 1 (ttf) dropped: not supported by MP4",
             "could not confirm this against the output: output vanished",
+        )
+
+    def test_a_source_probe_that_cannot_even_spawn_is_not_a_failed_conversion(
+        self, tmp_path, fake_ffmpeg, monkeypatch
+    ):
+        """Same argument one function up: the success-side source probe also runs
+        after ffmpeg produced a good file, so an `OSError` there degrades the
+        bookkeeping rather than the conversion."""
+        task = make_task(tmp_path)
+        task.dst.parent.mkdir(parents=True)
+
+        def probe(_tools, _src):
+            raise OSError("ffprobe could not be started")
+
+        monkeypatch.setattr(batch.ffmpegtool, "probe_streams", probe)
+
+        result = convert_one(MP4, task, TOOLS, overwrite=False)
+
+        assert result.outcome is Outcome.CONVERTED
+        assert result.notes == (
+            "could not verify which source streams were kept: ffprobe could not be started",
         )
 
     def test_a_later_rung_is_not_verified_a_second_time(self, tmp_path, fake_ffmpeg, monkeypatch):
@@ -447,17 +482,56 @@ class TestDropsAreConfirmedAgainstTheOutput:
             f"data stream 2 (unknown) dropped: not supported by {profile.label}",
         )
 
-    def test_only_the_surviving_share_of_a_predicted_drop_is_forgiven(self, tmp_path, fake_ffmpeg):
-        """Two data streams of the same key predicted dropped, one of them in
-        the output: the count of reported losses follows the output, not the
-        mapping. The index named may be either -- the count is what is pinned."""
+    def test_an_ambiguous_surplus_forgives_nothing(self, tmp_path, fake_ffmpeg):
+        """Two streams the probe cannot tell apart are predicted dropped and one
+        comes back. Which one survived is unknowable, so both keep their note --
+        guessing would claim a loss that did not happen *and* hide one that
+        did."""
         task = self._task(tmp_path, "mp4")
-        fake_ffmpeg.streams = [Stream(0, "video", "h264"), Stream(1, "data", ""), self.TIMECODE]
-        fake_ffmpeg.output_streams = [Stream(0, "video", "h264"), Stream(1, "data", "")]
+        fake_ffmpeg.streams = [
+            Stream(0, "video", "h264", "avc1"),
+            Stream(1, "data", "", "tmcd"),
+            Stream(2, "data", "", "tmcd"),
+        ]
+        fake_ffmpeg.output_streams = [
+            Stream(0, "video", "h264", "avc1"),
+            Stream(1, "data", "", "tmcd"),
+        ]
 
         result = convert_one(MP4, task, TOOLS, overwrite=False)
 
-        assert result.notes == ("data stream 2 (unknown) dropped: not supported by MP4",)
+        assert result.notes == (
+            "data stream 1 (unknown) dropped: not supported by MP4",
+            "data stream 2 (unknown) dropped: not supported by MP4",
+        )
+
+    @pytest.mark.parametrize("profile", [MP4, MOV], ids=lambda profile: profile.label)
+    def test_a_metadata_track_is_not_hidden_behind_the_timecode_that_survived(
+        self, tmp_path, fake_ffmpeg, profile
+    ):
+        """The iPhone `.mov` shape review measured: an Apple `mebx` metadata
+        track and a `tmcd` beside it, neither reporting a codec name. Only the
+        timecode comes back, at a *different index*. The container tag is what
+        keeps the engine from forgiving the metadata track and reporting the
+        survivor in its place."""
+        task = self._task(tmp_path, profile.target_suffix.lstrip("."))
+        fake_ffmpeg.streams = [
+            Stream(0, "video", "h264", "avc1"),
+            Stream(1, "audio", "aac", "mp4a"),
+            Stream(2, "data", "", "mebx"),
+            Stream(3, "data", "", "tmcd"),
+        ]
+        fake_ffmpeg.output_streams = [
+            Stream(0, "video", "h264", "avc1"),
+            Stream(1, "audio", "aac", "mp4a"),
+            Stream(2, "data", "", "tmcd"),
+        ]
+
+        result = convert_one(profile, task, TOOLS, overwrite=False)
+
+        assert result.notes == (
+            f"data stream 2 (unknown) dropped: not supported by {profile.label}",
+        )
 
     def test_a_real_drop_is_not_forgiven_by_the_re_encode_that_replaced_it(
         self, tmp_path, fake_ffmpeg

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -82,7 +82,10 @@ def make_task(tmp_path: Path, name: str = "clip") -> Task:
 
 
 def spy_on_probe(
-    monkeypatch, streams: list[Stream], output_streams: list[Stream] | None = None
+    monkeypatch,
+    streams: list[Stream],
+    output_streams: list[Stream] | None = None,
+    task: Task | None = None,
 ) -> list[Path]:
     """Replace probe_streams on the module and record what it was asked about.
 
@@ -90,15 +93,15 @@ def spy_on_probe(
     object would leave the already-installed reference untouched, and the spy
     would silently never be called.
 
-    The source is probed first and the output only afterwards, and only when a
-    loss is about to be claimed (``batch._confirm_against_output``), so call
-    order is enough to tell the two apart for a single-file conversion.
+    Source and output are told apart by *path*, the same way the `fake_ffmpeg`
+    fixture does it, so a test cannot pass on the strength of the order the two
+    probes happen to run in. Pass `task` to answer differently for the output.
     """
     seen: list[Path] = []
 
     def probe(_tools, src):
         seen.append(src)
-        if len(seen) > 1:
+        if task is not None and Path(src) == task.dst:
             return list(output_streams or [])
         return list(streams)
 
@@ -283,7 +286,11 @@ class TestPartialCheapAttemptVerification:
         task = make_task(tmp_path)
         task.dst.parent.mkdir(parents=True)
         probes = spy_on_probe(
-            monkeypatch, [Stream(0, "video", "h264"), Stream(1, "attachment", "ttf")]
+            monkeypatch,
+            [Stream(0, "video", "h264"), Stream(1, "attachment", "ttf")],
+            # MP4 really cannot hold a font attachment, so the output has none.
+            output_streams=[Stream(0, "video", "h264")],
+            task=task,
         )
 
         result = convert_one(MP4, task, TOOLS, overwrite=False)
@@ -399,8 +406,8 @@ class TestDropsAreConfirmedAgainstTheOutput:
     """
 
     #: What ffprobe reports for a `tmcd` stream: a data stream whose codec name
-    #: is absent on both sides, which is why the confirmation compares counts
-    #: per stream type and not indices or codec names.
+    #: is absent on both sides, which is what lets the confirmation match a
+    #: regenerated timecode to its source without ever matching indices.
     TIMECODE = Stream(2, "data", "")
 
     def _task(self, tmp_path: Path, suffix: str) -> Task:
@@ -433,19 +440,40 @@ class TestDropsAreConfirmedAgainstTheOutput:
 
         result = convert_one(profile, task, TOOLS, overwrite=False)
 
-        assert f"data stream 2 (unknown) dropped: not supported by {profile.label}" in result.notes
+        # The full tuple, not a membership check: the standing note these two
+        # profiles still carry is part of what must not have changed.
+        assert result.notes == (
+            *profile.cheap_attempt.notes,
+            f"data stream 2 (unknown) dropped: not supported by {profile.label}",
+        )
 
     def test_only_the_surviving_share_of_a_predicted_drop_is_forgiven(self, tmp_path, fake_ffmpeg):
-        """Two data streams predicted dropped, one of them in the output: the
-        count of reported losses has to follow the output, not the mapping."""
+        """Two data streams of the same key predicted dropped, one of them in
+        the output: the count of reported losses follows the output, not the
+        mapping. The index named may be either -- the count is what is pinned."""
         task = self._task(tmp_path, "mp4")
         fake_ffmpeg.streams = [Stream(0, "video", "h264"), Stream(1, "data", ""), self.TIMECODE]
         fake_ffmpeg.output_streams = [Stream(0, "video", "h264"), Stream(1, "data", "")]
 
         result = convert_one(MP4, task, TOOLS, overwrite=False)
 
-        assert len(result.notes) == 1
-        assert result.notes[0].startswith("data stream ")
+        assert result.notes == ("data stream 2 (unknown) dropped: not supported by MP4",)
+
+    def test_a_real_drop_is_not_forgiven_by_a_stream_the_muxer_synthesised(
+        self, tmp_path, fake_ffmpeg
+    ):
+        """The regression the first review of this fix caught: a `gpmd`/ANC
+        telemetry stream really lost, and a `tmcd` the muxer put back. Matching
+        on stream type alone reported a clean success while a stream was gone --
+        the direction `docs/constitution.md` forbids outright."""
+        task = self._task(tmp_path, "mov")
+        fake_ffmpeg.streams = [Stream(0, "video", "h264"), Stream(1, "data", "bin_data")]
+        fake_ffmpeg.output_streams = [Stream(0, "video", "h264"), Stream(1, "data", "")]
+
+        result = convert_one(MOV, task, TOOLS, overwrite=False)
+
+        assert result.outcome is Outcome.CONVERTED
+        assert result.notes == ("data stream 1 (bin_data) dropped: not supported by MOV",)
 
     def test_the_output_is_probed_only_when_a_loss_is_about_to_be_claimed(
         self, tmp_path, fake_ffmpeg, monkeypatch

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -459,6 +459,26 @@ class TestDropsAreConfirmedAgainstTheOutput:
 
         assert result.notes == ("data stream 2 (unknown) dropped: not supported by MP4",)
 
+    def test_a_real_drop_is_not_forgiven_by_the_re_encode_that_replaced_it(
+        self, tmp_path, fake_ffmpeg
+    ):
+        """The second regression review caught: WAV's cheap attempt re-encodes,
+        so its `pcm_s16le` output stream reads as a surplus under the source's
+        own `pcm_s16le` key and forgave a track that really was lost. An
+        ordinary camera/pro-video MOV carrying one compressed and one PCM track
+        reaches this, so it is not a corner case."""
+        src = tmp_path / "two-track.mov"
+        src.write_bytes(b"data")
+        task = Task(src, tmp_path / "out" / "two-track.wav")
+        task.dst.parent.mkdir(parents=True)
+        fake_ffmpeg.streams = [Stream(0, "audio", "aac"), Stream(1, "audio", "pcm_s16le")]
+        fake_ffmpeg.output_streams = [Stream(0, "audio", "pcm_s16le")]
+
+        result = convert_one(WAV, task, TOOLS, overwrite=False)
+
+        assert result.outcome is Outcome.CONVERTED
+        assert result.notes == ("audio stream 1 (pcm_s16le) dropped: WAV holds 1 audio stream",)
+
     def test_a_real_drop_is_not_forgiven_by_a_stream_the_muxer_synthesised(
         self, tmp_path, fake_ffmpeg
     ):

--- a/tests/test_ffmpegtool.py
+++ b/tests/test_ffmpegtool.py
@@ -120,6 +120,29 @@ class TestProbeStreams:
 
         assert ffmpegtool.probe_streams(TOOLS, "in.mkv") == [Stream(7, "", "")]
 
+    def test_the_container_tag_is_asked_for_and_parsed(self, monkeypatch):
+        """A `tmcd` timecode track and an Apple `mebx` metadata track both report
+        no `codec_name` at all, so the tag is the only thing that tells them
+        apart -- and `jobs.confirm_drops` needs to (issue #66)."""
+        payload = {
+            "streams": [
+                {"index": 0, "codec_type": "data", "codec_tag_string": "tmcd"},
+                {"index": 1, "codec_type": "data", "codec_tag_string": "mebx"},
+            ]
+        }
+        seen: list[list[str]] = []
+
+        def record(argv, **_kwargs):
+            seen.append(list(argv))
+            return CommandResult(tuple(argv), 0, json.dumps(payload), "")
+
+        monkeypatch.setattr(ffmpegtool, "run", record)
+
+        streams = ffmpegtool.probe_streams(TOOLS, "in.mov")
+
+        assert "stream=index,codec_type,codec_name,codec_tag_string" in seen[0]
+        assert [stream.codec_tag for stream in streams] == ["tmcd", "mebx"]
+
     def test_streams_without_a_usable_index_are_skipped(self, monkeypatch):
         payload = {
             "streams": [

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -693,8 +693,13 @@ class TestMovProfile:
     def test_cheap_attempt_is_declared_partial(self):
         assert MOV.partial_mapping is True
 
-    def test_cheap_attempt_carries_the_standing_note(self):
-        assert MOV.cheap_attempt.notes == ("data and timecode streams are not carried into MOV",)
+    def test_cheap_attempt_carries_no_standing_note(self):
+        """MOV's muxer regenerates a `tmcd` timecode track from source metadata
+        even though no selector maps it, so the standing note MKV still carries
+        was measurably false here (issue #66). The per-file success-side
+        verification reads the written output and names a real data drop
+        itself, so nothing is lost by dropping the blanket claim."""
+        assert MOV.cheap_attempt.notes == ()
 
     def test_last_resort_excludes_container_options(self):
         assert MOV.last_resort is not None


### PR DESCRIPTION
Closes #66.

## The defect

A source carrying a `tmcd` timecode/data stream, converted to **mp4** or **mov**, printed a drop note — but the stream was **still in the output**. The note mechanism predicted loss from the `-map` set; MOV/MP4's muxer regenerates the timecode track from source metadata, so the prediction was wrong. `--to mkv` and `--to webm` were correct — there the stream really is gone.

`docs/vision.md` names loss accounting as the USP, so a false loss report is a correctness bug, not cosmetics.

## The fix — general, not a `tmcd` special case

The success-side verification issue #18 built already probed the source. It now separates the two questions it was conflating:

- `jobs.verify_success` — **predicts** what the mapping could not carry (unchanged behaviour, renamed intent).
- `jobs.confirm_drops` — weighs that prediction against the file that was **actually written**, keeping only the drops the output does not contain.

The comparison is *counts per stream type*: a regenerated stream shares neither index nor codec name with its source (ffprobe reports no `codec_name` at all for either side of a `tmcd` pair). A surplus is attributed to that type's predicted drops in source order.

## Not traded for a false negative

- A stream type with **no** surplus in the output keeps **every** note it was given.
- A surplus of one type never forgives a drop of another.
- If the output probe **fails**, the whole prediction stands, plus `could not confirm this against the output: <error>` — over-reporting, never silence (`docs/constitution.md`).

## ffprobe frequency: changed, deliberately, recorded

The success side spends a second probe — on the output — but **only on a run that has already predicted at least one drop**. A conversion that gives nothing up costs exactly the one probe it cost before. Same trade issue #18 made (loss-accounting USP over a probe on a minority of runs), applied to the mirror-image bug, so it was resolved as settled by precedent rather than escalated. Recorded in `docs/specs/archive/spec-video-formats.md`'s Decision log, with the restatements moved alongside: `constitution.md`, `design/degradation-ladder.md` (diagram gains node `C`), `design.md`, `architecture.md`, `prior-art.md`, `ffmpegtool.probe_streams`'s docstring.

MOV's blanket standing note (`data and timecode streams are not carried into MOV`) is removed — the same measurement shows it false, and the per-file confirmation names a real data drop per stream instead. MKV's and WebM's stay: there the loss is real.

## Evidence (real ffmpeg 9.0, Windows 11)

Before — `tmcd` source, `--to mov`:
```
note    tcsrc.mp4: data and timecode streams are not carried into MOV
note    tcsrc.mp4: data stream 2 (unknown) dropped: not supported by MOV
1 converted, 0 skipped, 0 failed, 0 unsupported (of 1)
ffprobe out-mov/tcsrc.mov -> 0 video avc1 | 1 audio mp4a | 2 data tmcd   <- still there
```

After — `--to mov` and `--to mp4`:
```
1 converted, 0 skipped, 0 failed, 0 unsupported (of 1)
ffprobe -> 0 video avc1 | 1 audio mp4a | 2 data tmcd
```

Genuine drops still named (unchanged):
```
--to mkv    data stream 2 (unknown) dropped: not supported by MKV
--to webm   data stream 2 (unknown) dropped: not supported by WebM
--to mov    attachment stream 2 (ttf) dropped: not supported by MOV
--to mp4    attachment stream 2 (ttf) dropped: not supported by MP4
--to wav    audio stream 1 (opus) dropped: WAV holds 1 audio stream
--to mp3    audio stream 1 (opus) dropped: MP3 holds 1 audio stream
--to flac   audio stream 1 (opus) dropped: FLAC holds 1 audio stream
--to mp3    video stream 1 (mjpeg) dropped: not supported by MP3   (cover art)
```

## Verify

`scripts/verify.py`: OK lint, format, test — 902 passed (888 before; 14 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pdnJyntsFJyawGBSGj4cV