### PR TITLE
docs(cli): stop claiming --jobs is capped by CPU count

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ option list (`converter mirror --help` for the mirror sub-command's own).
 | `--list-formats` | list the target formats available and exit |
 | `-r`, `--recursive` | also convert files in sub-directories, keeping the tree in the output |
 | `--mirror-to ROOT` | derive the output directory by re-rooting `INPUT_DIR` onto `ROOT`, e.g. `E:` — use instead of `OUTPUT_DIR` |
-| `-j N`, `--jobs N` | conversions to run in parallel (default: 4, capped by CPU count) |
+| `-j N`, `--jobs N` | conversions to run in parallel, not capped (default: 4, or fewer if the machine has fewer CPUs) |
 | `--overwrite` | replace existing output files instead of skipping them |
 | `--dry-run` | print what would be converted and stop |
 | `-q`, `--quiet` | hide the progress bar |

--- a/converter/cli.py
+++ b/converter/cli.py
@@ -79,7 +79,7 @@ def _add_convert_arguments(parser: argparse.ArgumentParser) -> None:
         type=int,
         default=None,
         metavar="N",
-        help=f"conversions to run in parallel (default: {default_jobs()})",
+        help=f"conversions to run in parallel, not capped (default: {default_jobs()})",
     )
     parser.add_argument(
         "--overwrite",

--- a/docs/specs/archive/spec-target-driven-cli.md
+++ b/docs/specs/archive/spec-target-driven-cli.md
@@ -549,3 +549,22 @@ reusing the fixtures the phase-1 gate synthesises:
   or `converter/paths.py` in this round -- the reviewer's verdict was that
   the fix itself does not weaken the guards, only that the tests proving it
   and the docs explaining it needed to be right.
+- 2026-08-27 (#71): `README.md` claimed `-j`/`--jobs` is "capped by CPU count";
+  `--help` only said "(default: 4)". Traced both code paths in `batch.py`
+  (read-only for this issue -- it belongs to #66): `default_jobs()` returns
+  `min(4, os.cpu_count() or 4)`, but that function only runs inside
+  `run_batch`'s `workers = max(1, jobs or default_jobs())` when no `--jobs`
+  value was given at all (`jobs` is `None`, since `cli.py` already rejects
+  `< 1`). An explicit `--jobs` value -- however large -- reaches
+  `ThreadPoolExecutor(max_workers=...)` unchanged. Confirmed by hand:
+  `-j 999` against a real one-file batch converts and exits 0 with no
+  observable throttling, `-j 1` and `-j 0` behave as already documented. So
+  the CPU count only bounds the *default* shown when `--jobs` is omitted,
+  never a value the user actually passes -- the README claim was false as
+  read. No cap was implemented (would mean editing `batch.py`, out of scope
+  for this issue and not required by `docs/vision.md`'s "bounded
+  parallelism", which the existing pool bound already satisfies). Both
+  `README.md`'s options table and `cli.py`'s `--jobs` help text now say
+  "not capped (default: 4, ...)", matching what the code does. A follow-up
+  issue for actually capping `--jobs` at the CPU count, if desired, belongs
+  to whoever owns `batch.py`.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,6 +100,15 @@ class TestConvertParser:
         assert args.jobs == 8
         assert args.quiet is True
 
+    def test_jobs_is_not_capped_by_cpu_count(self):
+        """`--jobs` reaches `run_batch` unmodified (see `converter/batch.py`);
+        only the *default* used when `--jobs` is omitted is derived from the
+        CPU count. `cli.py` must not add a cap of its own -- issue #71 found
+        the docs claiming one existed when the code never enforced it."""
+        args = parse(convert_argv("in", "out", "-j", "999"))
+
+        assert args.jobs == 999
+
     def test_the_epilog_leads_to_mirror_and_the_format_list(self):
         """Asserted on the epilog itself, not on the rendered help: `--mirror-to`
         contains the mirror token and `--list-formats` is an option on this very


### PR DESCRIPTION
## Summary
- Traced `converter/batch.py` (read-only, owned by #66): `default_jobs()` (`min(4, os.cpu_count() or 4)`) only feeds `run_batch`'s fallback when `--jobs` is omitted; an explicit `--jobs` value reaches `ThreadPoolExecutor(max_workers=...)` unmodified.
- Verified by hand against a real one-file batch: `-j 999` converts and exits 0 with no observable throttling; `-j 1` converts normally; `-j 0` is rejected with `error: --jobs must be 1 or more, got 0`.
- `README.md`'s options table and `--help`'s `--jobs` text now both say "not capped", matching the code. No cap was implemented (that would mean editing `batch.py`, out of scope for this issue and not required by `docs/vision.md`'s "bounded parallelism", which the existing pool bound already satisfies).
- Added `docs/specs/archive/spec-target-driven-cli.md` decision-log entry, and a `tests/test_cli.py` test pinning that the CLI layer adds no cap of its own.

## Test plan
- [x] `.venv/Scripts/python.exe scripts/verify.py` — 892 tests green (lint, format, pytest)
- [x] Manual `-j 1`, `-j 0`, `-j 999` against a real ffmpeg conversion

Closes #71