### PR TITLE
feat(ffmpegtool): probe whether a stream is an attached picture

### DIFF
--- a/converter/ffmpegtool.py
+++ b/converter/ffmpegtool.py
@@ -67,6 +67,13 @@ class Stream:
     #: does not care -- every test that builds a Stream by hand -- can leave it
     #: out. Read by :func:`converter.jobs.confirm_drops`, nothing else.
     codec_tag: str = ""
+    #: Whether ffprobe's ``disposition`` object flags this stream as an
+    #: embedded picture (cover art). Not a general disposition set -- only
+    #: this one flag has a decision resting on it, because ``mjpeg`` and
+    #: ``png`` are the codec of both a cover picture and a real video and
+    #: nothing else distinguishes them (docs/specs/spec-stream-disposition.md).
+    #: Defaults to false so existing construction sites are unaffected.
+    attached_pic: bool = False
 
 
 @dataclass(frozen=True)
@@ -218,8 +225,11 @@ def probe_streams(tools: Tools, src: str | os.PathLike[str]) -> list[Stream]:
             "-show_entries",
             # One query, one process: an extra field costs nothing here, and
             # codec_tag_string is the only thing that distinguishes two data
-            # tracks ffprobe reports no codec name for.
-            "stream=index,codec_type,codec_name,codec_tag_string",
+            # tracks ffprobe reports no codec name for. stream_disposition=
+            # is a separate entry clause because disposition flags arrive
+            # nested under their own JSON object rather than alongside the
+            # plain stream fields.
+            "stream=index,codec_type,codec_name,codec_tag_string:stream_disposition=attached_pic",
             "-of",
             "json",
             cli_path(src),
@@ -238,12 +248,17 @@ def probe_streams(tools: Tools, src: str | os.PathLike[str]) -> list[Stream]:
             index = int(raw["index"])
         except (KeyError, TypeError, ValueError):
             continue
+        # A stream with no disposition flagged at all -- most of them -- omits
+        # the "disposition" object entirely rather than reporting zeros, so
+        # the fallback to {} is what makes attached_pic default to false.
+        disposition = raw.get("disposition") or {}
         streams.append(
             Stream(
                 index=index,
                 codec_type=str(raw.get("codec_type", "")),
                 codec_name=str(raw.get("codec_name", "")),
                 codec_tag=str(raw.get("codec_tag_string", "")),
+                attached_pic=bool(disposition.get("attached_pic", 0)),
             )
         )
     return streams

--- a/converter/ffmpegtool.py
+++ b/converter/ffmpegtool.py
@@ -207,6 +207,30 @@ def version(tools: Tools) -> str:
     return first_line.strip() or "unknown"
 
 
+def _parse_stream(raw: dict[str, object]) -> Stream | None:
+    """Build a :class:`Stream` from one ffprobe JSON stream object.
+
+    Returns ``None`` for an entry with no usable index, so the caller can drop
+    it without duplicating the guard. Split out of :func:`probe_streams` to
+    keep that function under the constitution's 50-line ceiling.
+    """
+    try:
+        index = int(raw["index"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    # A stream with no disposition flagged at all -- most of them -- omits
+    # the "disposition" object entirely rather than reporting zeros, so the
+    # fallback to {} is what makes attached_pic default to false.
+    disposition = raw.get("disposition") or {}
+    return Stream(
+        index=index,
+        codec_type=str(raw.get("codec_type", "")),
+        codec_name=str(raw.get("codec_name", "")),
+        codec_tag=str(raw.get("codec_tag_string", "")),
+        attached_pic=bool(disposition.get("attached_pic", 0)),
+    )
+
+
 def probe_streams(tools: Tools, src: str | os.PathLike[str]) -> list[Stream]:
     """List the elementary streams of *src*.
 
@@ -242,23 +266,5 @@ def probe_streams(tools: Tools, src: str | os.PathLike[str]) -> list[Stream]:
     except json.JSONDecodeError as exc:  # pragma: no cover - malformed ffprobe output
         raise ProbeError(f"could not parse ffprobe output: {exc}") from exc
 
-    streams = []
-    for raw in payload.get("streams", []):
-        try:
-            index = int(raw["index"])
-        except (KeyError, TypeError, ValueError):
-            continue
-        # A stream with no disposition flagged at all -- most of them -- omits
-        # the "disposition" object entirely rather than reporting zeros, so
-        # the fallback to {} is what makes attached_pic default to false.
-        disposition = raw.get("disposition") or {}
-        streams.append(
-            Stream(
-                index=index,
-                codec_type=str(raw.get("codec_type", "")),
-                codec_name=str(raw.get("codec_name", "")),
-                codec_tag=str(raw.get("codec_tag_string", "")),
-                attached_pic=bool(disposition.get("attached_pic", 0)),
-            )
-        )
-    return streams
+    parsed = (_parse_stream(raw) for raw in payload.get("streams", []))
+    return [stream for stream in parsed if stream is not None]

--- a/docs/specs/spec-stream-disposition.md
+++ b/docs/specs/spec-stream-disposition.md
@@ -330,3 +330,15 @@ New-Item -ItemType Directory -Force in
   of seventeen targets rather than a correctness one. This also corrects
   `docs/roadmap.md`'s seeded "constitution — none" verdict for this phase, which
   the version floor made false.
+- 2026-08-27: Issue #75 (`converter/ffmpegtool.py`) landed. `Stream` gained
+  `attached_pic: bool = False` as its last field, and `probe_streams`'s
+  `-show_entries` argument grew the `:stream_disposition=attached_pic` clause,
+  still one ffprobe call per file. Verified against real ffprobe 9.0: an
+  `art.mp3` fixture (audio + a `disposition:v:0 attached_pic` cover stream)
+  reports `disposition: {"attached_pic": 1}` on the picture stream and `0` on
+  the audio stream; a plain h264 `.mkv` and a plain `tone.mp3` both report `0`.
+  Every payload ffprobe 9.0 actually returned carried the `disposition` object
+  regardless of value once the entry was requested, so the "no `disposition`
+  object at all" default is a defensive fallback for a payload shape this
+  ffprobe version never produced, not one observed here — the parser handles it
+  with `raw.get("disposition") or {}` regardless.

--- a/tests/test_ffmpegtool.py
+++ b/tests/test_ffmpegtool.py
@@ -140,8 +140,65 @@ class TestProbeStreams:
 
         streams = ffmpegtool.probe_streams(TOOLS, "in.mov")
 
-        assert "stream=index,codec_type,codec_name,codec_tag_string" in seen[0]
+        assert (
+            "stream=index,codec_type,codec_name,codec_tag_string:"
+            "stream_disposition=attached_pic" in seen[0]
+        )
         assert [stream.codec_tag for stream in streams] == ["tmcd", "mebx"]
+
+    def test_exactly_one_ffprobe_call_is_made_per_file(self, monkeypatch):
+        calls: list[list[str]] = []
+
+        def record(argv, **_kwargs):
+            calls.append(list(argv))
+            return CommandResult(tuple(argv), 0, "{}", "")
+
+        monkeypatch.setattr(ffmpegtool, "run", record)
+
+        ffmpegtool.probe_streams(TOOLS, "in.mkv")
+
+        assert len(calls) == 1
+
+    def test_attached_pic_is_true_for_a_picture(self, monkeypatch):
+        payload = {
+            "streams": [
+                {
+                    "index": 1,
+                    "codec_type": "video",
+                    "codec_name": "png",
+                    "disposition": {"attached_pic": 1},
+                }
+            ]
+        }
+        stub_run(monkeypatch, 0, json.dumps(payload))
+
+        streams = ffmpegtool.probe_streams(TOOLS, "in.mp3")
+
+        assert streams == [Stream(1, "video", "png", attached_pic=True)]
+
+    def test_attached_pic_is_false_for_a_plain_video(self, monkeypatch):
+        payload = {
+            "streams": [
+                {
+                    "index": 0,
+                    "codec_type": "video",
+                    "codec_name": "h264",
+                    "disposition": {"attached_pic": 0},
+                }
+            ]
+        }
+        stub_run(monkeypatch, 0, json.dumps(payload))
+
+        streams = ffmpegtool.probe_streams(TOOLS, "in.mkv")
+
+        assert streams == [Stream(0, "video", "h264", attached_pic=False)]
+
+    def test_attached_pic_defaults_to_false_when_disposition_is_absent(self, monkeypatch):
+        stub_run(monkeypatch, 0, json.dumps({"streams": [{"index": 0, "codec_type": "audio"}]}))
+
+        streams = ffmpegtool.probe_streams(TOOLS, "in.mkv")
+
+        assert streams[0].attached_pic is False
 
     def test_streams_without_a_usable_index_are_skipped(self, monkeypatch):
         payload = {

--- a/tests/test_ffmpegtool.py
+++ b/tests/test_ffmpegtool.py
@@ -200,6 +200,16 @@ class TestProbeStreams:
 
         assert streams[0].attached_pic is False
 
+    def test_attached_pic_defaults_to_false_when_the_key_is_absent(self, monkeypatch):
+        """The disposition object can be present without the one flag we read --
+        ffprobe reports it alongside every other disposition flag it knows."""
+        payload = {"streams": [{"index": 0, "codec_type": "video", "disposition": {"default": 1}}]}
+        stub_run(monkeypatch, 0, json.dumps(payload))
+
+        streams = ffmpegtool.probe_streams(TOOLS, "in.mkv")
+
+        assert streams[0].attached_pic is False
+
     def test_streams_without_a_usable_index_are_skipped(self, monkeypatch):
         payload = {
             "streams": [


### PR DESCRIPTION
## Summary
- `Stream` gains `attached_pic: bool = False` as its last field, so existing construction sites are unaffected.
- `probe_streams`'s `-show_entries` argument grows a `:stream_disposition=attached_pic` clause -- still exactly one ffprobe call per file.
- The JSON read handles the nested `disposition` shape and defaults `attached_pic` to false when the object is missing or empty.
- Decision-log entry appended to `docs/specs/spec-stream-disposition.md`.

Spec: docs/specs/spec-stream-disposition.md

## Test plan
- [x] `scripts/verify.py` green (925 tests, up from 917)
- [x] A test pinning the extended `-show_entries` argument verbatim
- [x] A test that exactly one ffprobe call is made per file
- [x] Tests: `attached_pic` true for a picture, false for a plain video, false when the disposition object is absent
- [x] Verified against real ffprobe 9.0 with a cover-art mp3 (`disposition:v:0 attached_pic`), a plain h264 video, and a plain audio-only mp3 -- `attached_pic` read true only for the picture stream

Closes #75