### PR TITLE
feat(profiles): the curated lossy-codec set and the lossless criterion

### DIFF
--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -106,6 +106,62 @@ MP4_AUDIO_CODECS = frozenset({"aac", "mp3", "ac3", "eac3", "alac", "opus", "flac
 #: Subtitle codecs that convert cleanly into MP4's own ``mov_text``.
 TEXT_SUBTITLE_CODECS = frozenset({"subrip", "srt", "ass", "ssa", "mov_text", "webvtt", "text"})
 
+#: Codecs that discard source information when they encode -- curated by hand
+#: for `docs/specs/spec-lossy-source-notes.md`'s advisory ("this lossless target
+#: cannot restore what a lossy source had already given up"), the same kind of
+#: hand-maintained artifact as the copy masks above and for the same reason:
+#: ffmpeg can be asked what a build contains, never how *this* project judges a
+#: format's behaviour.
+#:
+#: ffmpeg does ship a lossy/lossless classification (``-codecs``, columns ``L``
+#: and ``S``), and it is not simply wrong -- measured against ffmpeg 9.0, it gets
+#: every codec this set excludes exactly right: ``alac``, ``flac``,
+#: ``wmalossless``, ``truehd`` and every ``pcm_*`` decoder all report ``S`` only,
+#: no ``L``. It still cannot be the source of truth read wholesale, for three
+#: measured reasons:
+#:
+#: - Some codecs report **both** flags at once. ``webp`` does (``DEVILS``): it is
+#:   genuinely used both ways -- a lossy photograph and a lossless screenshot are
+#:   both ordinary WebP files -- so the codec name alone cannot say which *this*
+#:   stream is. The same measured ambiguity holds for ``h264``, ``hevc`` and
+#:   ``av1`` (``DEV.LS``, all three) and for ``dts`` (``DEAILS``): each format has
+#:   a real, if less common, mathematically lossless mode (x264/x265 "-qp 0",
+#:   AV1's lossless coding tools, DTS-HD Master Audio), so none of the four is in
+#:   this set either -- excluded for the identical reason as ``webp``, not merely
+#:   left out for lack of a use today.
+#: - Reading the flag at all costs a subprocess call this project does not
+#:   otherwise spend on the happy path; a curated Python literal costs nothing.
+#: - ``gif`` reports lossless (``S`` only, no ``L`` -- ffmpeg calls the format
+#:   itself lossless) and is a member of this set anyway: phase 5
+#:   (`docs/specs/archive/spec-image-formats.md`) measured a photograph through
+#:   GIF's palette encoder keeping 182 of 36 485 colours. The flag describes the
+#:   container's ceiling, not what its one encoder actually does, and this set
+#:   exists precisely to say so instead of repeating ffmpeg's classification.
+#:
+#: Otherwise scoped to the codecs this registry's own copy masks and fallback
+#: names already name (`MP4_VIDEO_CODECS` et al. above) -- every remaining one of
+#: those reports ``L`` only, with no ambiguity left to resolve by hand.
+LOSSY_CODECS = frozenset(
+    {
+        # video
+        "mjpeg",
+        "mpeg2video",
+        "mpeg4",
+        "prores",
+        "theora",
+        "vp8",
+        "vp9",
+        "gif",
+        # audio
+        "aac",
+        "ac3",
+        "eac3",
+        "mp3",
+        "opus",
+        "vorbis",
+    }
+)
+
 MP4 = Profile(
     label="MP4",
     name="mp4",

--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -117,12 +117,14 @@ TEXT_SUBTITLE_CODECS = frozenset({"subrip", "srt", "ass", "ssa", "mov_text", "we
 #: and ``S``), and for the five codecs this issue names it is not wrong -- measured
 #: against ffmpeg 9.0: ``alac``, ``flac``, ``wmalossless``, ``truehd`` and every
 #: *linear* ``pcm_*`` decoder (``pcm_s16le``, ``pcm_s24le`` and the rest of that
-#: family) report ``S`` only, no ``L``. (Three ``pcm_*`` decoders are themselves
-#: lossy and report ``L`` only -- ``pcm_alaw``/``pcm_mulaw``, G.711 companding, and
-#: ``pcm_vidc`` -- but this registry never produces or accepts any of the three, so
-#: their absence from this set, like their absence from every copy mask above,
-#: costs nothing.) The flag still cannot be read wholesale as a general rule,
-#: for three measured reasons:
+#: family) report ``S`` only, no ``L``. Three ``pcm_*`` decoders are the opposite:
+#: ``pcm_alaw``/``pcm_mulaw`` (G.711 companding) and ``pcm_vidc`` report ``L``
+#: only, no ``S`` -- genuinely and unambiguously lossy, unlike every case below --
+#: so all three are members of this set, not exceptions to it. A companded source
+#: is reachable the same way a lossy audio source of any other codec is (a G.711
+#: ``.wav`` is an ordinary `SOURCE_SUFFIXES` member), so leaving them out would
+#: have been a silent gap, not a saved judgement call. The flag still cannot be
+#: read wholesale as a general rule, for three measured reasons:
 #:
 #: - Some codecs report **both** flags at once. ``webp`` does (``DEVILS``): it is
 #:   genuinely used both ways -- a lossy photograph and a lossless screenshot are
@@ -135,9 +137,11 @@ TEXT_SUBTITLE_CODECS = frozenset({"subrip", "srt", "ass", "ssa", "mov_text", "we
 #:   ``h264``/``hevc``/``av1``, which this phase's only consumer (`flac`, an
 #:   audio-only rule) can never even map, ``dts`` is audio and genuinely reaches
 #:   that rule -- a lossy DTS core into `flac` lands on the selective rung with
-#:   no advisory, a real accepted gap rather than a free exclusion, the same
-#:   accuracy-over-coverage trade this phase's gate already made for `wav` versus
-#:   `flac` (`docs/specs/spec-lossy-source-notes.md`, Prior decisions).
+#:   no advisory. That is a real accepted gap, not a free exclusion: unlike the
+#:   companded PCM trio above, ``dts``'s ambiguity is genuine (a DTS-HD Master
+#:   Audio track really is losslessly encoded under the same codec name), so a
+#:   false "already lossy" claim against one is the worse failure mode of the
+#:   two, and exclusion is kept.
 #: - Reading the flag at all costs a subprocess call this project does not
 #:   otherwise spend on the happy path; a curated Python literal costs nothing.
 #: - ``gif`` reports lossless (``S`` only, no ``L`` -- ffmpeg calls the format
@@ -168,6 +172,9 @@ LOSSY_CODECS = frozenset(
         "mp3",
         "opus",
         "vorbis",
+        "pcm_alaw",
+        "pcm_mulaw",
+        "pcm_vidc",
     }
 )
 

--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -151,9 +151,41 @@ TEXT_SUBTITLE_CODECS = frozenset({"subrip", "srt", "ass", "ssa", "mov_text", "we
 #:   container's ceiling, not what its one encoder actually does, and this set
 #:   exists precisely to say so instead of repeating ffmpeg's classification.
 #:
-#: Otherwise scoped to the codecs this registry's own copy masks and fallback
-#: names already name (`MP4_VIDEO_CODECS` et al. above) -- every remaining one of
-#: those reports ``L`` only, with no ambiguity left to resolve by hand.
+#: "Ambiguous, so excluded" is anchored to what this ffmpeg build's flags
+#: actually report, not to an independent survey of every format's spec --
+#: ``vp9`` has a documented lossless mode too, but this build reports it
+#: ``L`` only (``DEV.L.``, no ``S``), so it is included on the same basis
+#: every other unambiguous member is, consistent with how this set already
+#: treats ``gif`` (curated against the tool's own measured output, not
+#: against every fact a format's specification could support).
+#:
+#: A codec's membership never depends on whether this registry's own copy
+#: masks or fallback encoders name it -- `LOSSY_CODECS` matches a *source*
+#: codec, which can be anything `SOURCE_SUFFIXES` admits, regardless of what
+#: any target profile does with it (the same correction that added the
+#: companded PCM trio above applies here too). Beyond the codecs already
+#: named above, this set covers the common single-codec lossy formats a
+#: media library plausibly carries as a source, each checked individually
+#: against ffmpeg 9.0 and confirmed ``L`` only: the WMA family (``wmav1``,
+#: ``wmav2``, ``wmapro`` -- reachable via the `.wma` source suffix, and the
+#: sharpest case this set would otherwise get backwards: guarding against
+#: misreading ``wmalossless`` while staying silent on the far commoner lossy
+#: WMA), ``mp2`` (`.mpg`/`.ts`/`.vob` sources), ``amr_nb``/``amr_wb``
+#: (`.3gp`), and ``nellymoser``/``speex``/``gsm``/``ilbc`` (legacy voice and
+#: streaming codecs `.flv`/`.caf`/`.wav` sources can carry).
+#:
+#: Deliberately **not** enumerated: the ADPCM family. All 62 ``adpcm_*``
+#: decoders this ffmpeg build ships report ``L`` only, no ``S`` -- uniformly
+#: lossy, unlike PCM's mixed family above -- but the family is an order of
+#: magnitude larger than every other curated set in this module and almost
+#: entirely made of obscure, game- or broadcast-specific variants
+#: (``adpcm_ea_maxis_xa``, ``adpcm_psx``, ``adpcm_thp``) a real media library
+#: is unlikely to carry under those names. Naming the two a `.wav`/`.avi`
+#: source can plausibly carry -- ``adpcm_ima_wav``, ``adpcm_ms`` -- would
+#: silently promise coverage of the other sixty; this comment names the gap
+#: instead of curating around it, the same choice this project makes rather
+#: than a false claim of completeness (`docs/vision.md`: losses are named,
+#: not hidden).
 LOSSY_CODECS = frozenset(
     {
         # video
@@ -175,6 +207,16 @@ LOSSY_CODECS = frozenset(
         "pcm_alaw",
         "pcm_mulaw",
         "pcm_vidc",
+        "wmav1",
+        "wmav2",
+        "wmapro",
+        "mp2",
+        "amr_nb",
+        "amr_wb",
+        "nellymoser",
+        "speex",
+        "gsm",
+        "ilbc",
     }
 )
 

--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -113,6 +113,12 @@ TEXT_SUBTITLE_CODECS = frozenset({"subrip", "srt", "ass", "ssa", "mov_text", "we
 #: ffmpeg can be asked what a build contains, never how *this* project judges a
 #: format's behaviour.
 #:
+#: Deliberately non-exhaustive: this project does not claim it lists every lossy
+#: codec ffmpeg can decode, only the ones checked individually and found
+#: unambiguous. A missing codec is a known, disclosable gap (the ADPCM family
+#: below is the worked example), not license to guess -- the same discipline the
+#: copy masks above already apply to what a muxer accepts.
+#:
 #: ffmpeg does ship a lossy/lossless classification (``-codecs``, columns ``L``
 #: and ``S``), and for the five codecs this issue names it is not wrong -- measured
 #: against ffmpeg 9.0: ``alac``, ``flac``, ``wmalossless``, ``truehd`` and every

--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -114,11 +114,15 @@ TEXT_SUBTITLE_CODECS = frozenset({"subrip", "srt", "ass", "ssa", "mov_text", "we
 #: format's behaviour.
 #:
 #: ffmpeg does ship a lossy/lossless classification (``-codecs``, columns ``L``
-#: and ``S``), and it is not simply wrong -- measured against ffmpeg 9.0, it gets
-#: every codec this set excludes exactly right: ``alac``, ``flac``,
-#: ``wmalossless``, ``truehd`` and every ``pcm_*`` decoder all report ``S`` only,
-#: no ``L``. It still cannot be the source of truth read wholesale, for three
-#: measured reasons:
+#: and ``S``), and for the five codecs this issue names it is not wrong -- measured
+#: against ffmpeg 9.0: ``alac``, ``flac``, ``wmalossless``, ``truehd`` and every
+#: *linear* ``pcm_*`` decoder (``pcm_s16le``, ``pcm_s24le`` and the rest of that
+#: family) report ``S`` only, no ``L``. (Three ``pcm_*`` decoders are themselves
+#: lossy and report ``L`` only -- ``pcm_alaw``/``pcm_mulaw``, G.711 companding, and
+#: ``pcm_vidc`` -- but this registry never produces or accepts any of the three, so
+#: their absence from this set, like their absence from every copy mask above,
+#: costs nothing.) The flag still cannot be read wholesale as a general rule,
+#: for three measured reasons:
 #:
 #: - Some codecs report **both** flags at once. ``webp`` does (``DEVILS``): it is
 #:   genuinely used both ways -- a lossy photograph and a lossless screenshot are
@@ -127,8 +131,13 @@ TEXT_SUBTITLE_CODECS = frozenset({"subrip", "srt", "ass", "ssa", "mov_text", "we
 #:   ``av1`` (``DEV.LS``, all three) and for ``dts`` (``DEAILS``): each format has
 #:   a real, if less common, mathematically lossless mode (x264/x265 "-qp 0",
 #:   AV1's lossless coding tools, DTS-HD Master Audio), so none of the four is in
-#:   this set either -- excluded for the identical reason as ``webp``, not merely
-#:   left out for lack of a use today.
+#:   this set either -- excluded for the identical reason as ``webp``. Unlike
+#:   ``h264``/``hevc``/``av1``, which this phase's only consumer (`flac`, an
+#:   audio-only rule) can never even map, ``dts`` is audio and genuinely reaches
+#:   that rule -- a lossy DTS core into `flac` lands on the selective rung with
+#:   no advisory, a real accepted gap rather than a free exclusion, the same
+#:   accuracy-over-coverage trade this phase's gate already made for `wav` versus
+#:   `flac` (`docs/specs/spec-lossy-source-notes.md`, Prior decisions).
 #: - Reading the flag at all costs a subprocess call this project does not
 #:   otherwise spend on the happy path; a curated Python literal costs nothing.
 #: - ``gif`` reports lossless (``S`` only, no ``L`` -- ffmpeg calls the format

--- a/docs/specs/spec-lossy-source-notes.md
+++ b/docs/specs/spec-lossy-source-notes.md
@@ -346,3 +346,19 @@ New-Item -ItemType Directory -Force in
   construction (a bare rule with no fallback at all fails the first half of
   the pair) rather than by a live conflict, and will hold the same way once
   that work lands.
+- 2026-08-27 (issue #87 review round 2): the round-1 fix above relocated the
+  same overreach it was meant to remove rather than closing it. "This registry
+  never produces or accepts any of the three [`pcm_alaw`/`pcm_mulaw`/
+  `pcm_vidc`], so their absence costs nothing" is a non sequitur: `LOSSY_CODECS`
+  matches a *source* codec, and what the registry's own copy masks and
+  fallback encoders produce is irrelevant to what a source file may carry. A
+  G.711-encoded `.wav` is an ordinary `SOURCE_SUFFIXES` member, fails `flac`'s
+  `-map 0:a? -c:a copy` the same way an MP3 does, and lands on the identical
+  selective rung the `dts` gap above already concedes reaches the advisory.
+  Unlike `dts`, none of the three has a genuine lossless-mode ambiguity to
+  trade against -- the flag reports `L` only for all three -- so there was no
+  reason to leave the gap open at all. Fixed by adding `pcm_alaw`,
+  `pcm_mulaw` and `pcm_vidc` to `LOSSY_CODECS` and narrowing
+  `test_excludes_the_named_lossless_family` from a blanket `pcm_` prefix ban
+  to the specific linear-PCM codecs the exclusion actually covers, with a new
+  `test_includes_the_lossy_pcm_companding_variants` pinning the three in.

--- a/docs/specs/spec-lossy-source-notes.md
+++ b/docs/specs/spec-lossy-source-notes.md
@@ -309,3 +309,31 @@ New-Item -ItemType Directory -Force in
   accepted cost is an inconsistency a user can notice — the same MP3 says
   something on the way to FLAC and nothing on the way to WAV — which is recorded
   in the decision row and pinned by a QA item rather than left to be discovered.
+- 2026-08-27 (issue #87): `LOSSY_CODECS` landed as a module-level frozenset in
+  `converter/profiles.py`, beside `TEXT_SUBTITLE_CODECS`. Re-verified the
+  decision row's `-codecs` claims against ffmpeg 9.0 directly rather than
+  trusting the earlier round's numbers: `alac`, `flac`, `wmalossless`, `truehd`
+  and the `pcm_*` family all still report `S` only, `webp` still reports both
+  (`DEVILS`), and `gif` still reports `S` only despite the measured 182-of-
+  36485-colour loss. One thing the earlier rounds had not checked: `h264`,
+  `hevc` and `av1` also report both `L` and `S` (`DEV.LS`), and so does `dts`
+  (`DEAILS`) — each has a real lossless mode (x264/x265 `-qp 0`, AV1's lossless
+  tools, DTS-HD Master Audio) that the codec name alone cannot rule out, the
+  same ambiguity `webp` has. All four are excluded from `LOSSY_CODECS` for that
+  reason, alongside `webp`; none of the four is currently reachable through the
+  `flac`-only advisory this phase gates (`flac` holds audio only), so the
+  exclusion costs nothing today and avoids a false advisory on a lossless
+  archival master or a Blu-ray DTS-HD track if the set is ever reused for a
+  video or a wider-audio target. The set otherwise covers the codecs this
+  registry's own copy masks and fallback names already name, limited to the
+  ones ffmpeg reports as lossy with no ambiguity (`mjpeg`, `mpeg2video`,
+  `mpeg4`, `prores`, `theora`, `vp8`, `vp9`, `aac`, `ac3`, `eac3`, `mp3`,
+  `opus`, `vorbis`), plus `gif` by the measured exception above. The lossless
+  criterion `fallback_options is not None and fallback_name is None` was
+  checked registry-wide (`tests/test_profiles.py::TestLosslessTargetCriterion`)
+  and confirmed to select exactly `flac`, `wav`, `png`, `tiff`, `bmp` against
+  the registry as it stands on `main` at this issue's base commit — milestone
+  6's `attached_pic` rules had not yet merged into this branch, so the guard is
+  proven by construction (a bare rule with no fallback at all fails the first
+  half of the pair) rather than by a live conflict, and will hold the same way
+  once that work lands.

--- a/docs/specs/spec-lossy-source-notes.md
+++ b/docs/specs/spec-lossy-source-notes.md
@@ -341,11 +341,13 @@ New-Item -ItemType Directory -Force in
   None` was checked registry-wide
   (`tests/test_profiles.py::TestLosslessTargetCriterion`) and confirmed to
   select exactly `flac`, `wav`, `png`, `tiff`, `bmp` against the registry as it
-  stands on `main` at this issue's base commit — milestone 6's `attached_pic`
-  rules had not yet merged into this branch, so the guard is proven by
-  construction (a bare rule with no fallback at all fails the first half of
-  the pair) rather than by a live conflict, and will hold the same way once
-  that work lands.
+  stands on `main` at this issue's base commit. The pair is already exercised
+  by live fallback-less rules today — `mkv`'s `attachment` rule and the bare
+  subtitle-drop rules on `mp4`/`mov`/`webm` all fail the pair's first half
+  (`fallback_options is None`) and are correctly excluded — so this is not an
+  untested guard; milestone 6's incoming `attached_pic` rules on `mp3`/`m4a`/
+  `flac` had not yet merged into this branch specifically, and will exercise
+  the identical, already-proven mechanism once that work lands.
 - 2026-08-27 (issue #87 review round 2): the round-1 fix above relocated the
   same overreach it was meant to remove rather than closing it. "This registry
   never produces or accepts any of the three [`pcm_alaw`/`pcm_mulaw`/
@@ -362,3 +364,33 @@ New-Item -ItemType Directory -Force in
   `test_excludes_the_named_lossless_family` from a blanket `pcm_` prefix ban
   to the specific linear-PCM codecs the exclusion actually covers, with a new
   `test_includes_the_lossy_pcm_companding_variants` pinning the three in.
+- 2026-08-27 (issue #87 review round 3): the round-2 fix closed the PCM gap
+  correctly but the comment's closing sentence still carried the exact
+  non sequitur round 2 had just rejected -- "otherwise scoped to the codecs
+  this registry's own copy masks and fallback names already name" treats
+  what a target profile happens to use as if it bounded what a source file
+  may carry, which it does not. `LOSSY_CODECS` matches a source codec
+  reachable through `SOURCE_SUFFIXES`, independent of any profile. Concretely:
+  `.wma` is a source suffix, so `wmav1`/`wmav2`/`wmapro` reach `flac`'s
+  audio-only rule and fail its copy the same way an MP3 does — and this set
+  already guards against misreading `wmalossless`, so staying silent on the
+  far commoner lossy WMA family was backwards. Fixed by adding the common
+  single-codec lossy audio formats a media library plausibly carries as a
+  source, each checked individually against ffmpeg 9.0 and confirmed `L`
+  only: the WMA family, `mp2`, `amr_nb`/`amr_wb`, `nellymoser`, `speex`,
+  `gsm`, `ilbc`. The ADPCM family (62 decoders, all uniformly `L` only) is
+  deliberately left unenumerated and named as a disclosed gap rather than
+  curated around: it is an order of magnitude larger than every other set in
+  this module and almost entirely obscure game/broadcast-specific variants,
+  so naming the two a real source could plausibly carry would misleadingly
+  promise coverage of the other sixty. Also corrected: the closing sentence
+  no longer implies "ambiguous per any format spec" is the exclusion test --
+  it is anchored to what this ffmpeg build's flags report, which is why
+  `vp9` (a documented but here-unreported lossless mode) stays a member on
+  the same footing as every other codec this build reports unambiguously.
+  Also corrected the round-1 log entry above: it claimed the lossless
+  criterion was "proven by construction … rather than by a live conflict",
+  which undersold it -- `mkv`'s `attachment` rule and the subtitle-drop rules
+  on `mp4`/`mov`/`webm` are live fallback-less rules today that the pair
+  already discriminates correctly against, not merely a hypothetical
+  construction.

--- a/docs/specs/spec-lossy-source-notes.md
+++ b/docs/specs/spec-lossy-source-notes.md
@@ -313,27 +313,36 @@ New-Item -ItemType Directory -Force in
   `converter/profiles.py`, beside `TEXT_SUBTITLE_CODECS`. Re-verified the
   decision row's `-codecs` claims against ffmpeg 9.0 directly rather than
   trusting the earlier round's numbers: `alac`, `flac`, `wmalossless`, `truehd`
-  and the `pcm_*` family all still report `S` only, `webp` still reports both
-  (`DEVILS`), and `gif` still reports `S` only despite the measured 182-of-
-  36485-colour loss. One thing the earlier rounds had not checked: `h264`,
-  `hevc` and `av1` also report both `L` and `S` (`DEV.LS`), and so does `dts`
-  (`DEAILS`) — each has a real lossless mode (x264/x265 `-qp 0`, AV1's lossless
-  tools, DTS-HD Master Audio) that the codec name alone cannot rule out, the
-  same ambiguity `webp` has. All four are excluded from `LOSSY_CODECS` for that
-  reason, alongside `webp`; none of the four is currently reachable through the
-  `flac`-only advisory this phase gates (`flac` holds audio only), so the
-  exclusion costs nothing today and avoids a false advisory on a lossless
-  archival master or a Blu-ray DTS-HD track if the set is ever reused for a
-  video or a wider-audio target. The set otherwise covers the codecs this
-  registry's own copy masks and fallback names already name, limited to the
-  ones ffmpeg reports as lossy with no ambiguity (`mjpeg`, `mpeg2video`,
-  `mpeg4`, `prores`, `theora`, `vp8`, `vp9`, `aac`, `ac3`, `eac3`, `mp3`,
-  `opus`, `vorbis`), plus `gif` by the measured exception above. The lossless
-  criterion `fallback_options is not None and fallback_name is None` was
-  checked registry-wide (`tests/test_profiles.py::TestLosslessTargetCriterion`)
-  and confirmed to select exactly `flac`, `wav`, `png`, `tiff`, `bmp` against
-  the registry as it stands on `main` at this issue's base commit — milestone
-  6's `attached_pic` rules had not yet merged into this branch, so the guard is
-  proven by construction (a bare rule with no fallback at all fails the first
-  half of the pair) rather than by a live conflict, and will hold the same way
-  once that work lands.
+  and every *linear* `pcm_*` decoder still report `S` only, `webp` still
+  reports both (`DEVILS`), and `gif` still reports `S` only despite the
+  measured 182-of-36485-colour loss. One thing the earlier rounds had not
+  checked: `h264`, `hevc` and `av1` also report both `L` and `S` (`DEV.LS`),
+  and so does `dts` (`DEAILS`) — each has a real lossless mode (x264/x265
+  `-qp 0`, AV1's lossless tools, DTS-HD Master Audio) that the codec name
+  alone cannot rule out, the same ambiguity `webp` has. All four are excluded
+  from `LOSSY_CODECS` for that reason.
+- 2026-08-27 (issue #87 review round 1): two claims in the entry above did not
+  survive verification and are corrected here rather than left standing.
+  First, "the `pcm_*` family all report `S` only" is false as a universal
+  claim: `pcm_alaw`/`pcm_mulaw` (G.711 companding) and `pcm_vidc` report `L`
+  only, since companding genuinely discards information — the true claim is
+  scoped to the *linear* PCM decoders (`pcm_s16le`, `pcm_s24le`, and the rest
+  of that family), the only ones this registry ever names. Second,
+  "`h264`/`hevc`/`av1`/`dts` cost nothing to exclude, since none is reachable
+  through the `flac`-only advisory" is false for `dts`: `flac`'s only rule is
+  `audio`, so a DTS source genuinely reaches the selective rung the advisory
+  would live on, unlike `h264`/`hevc`/`av1`, which are video and `flac` never
+  maps a video stream at all. Excluding `dts` is a real accuracy-over-coverage
+  trade — a lossy DTS core into `flac` stays silent — not a free hedge; kept
+  anyway, on the same footing as `webp`, because a false "this was already
+  lossy" advisory on a genuinely lossless DTS-HD Master Audio source is the
+  worse failure mode of the two.
+  The lossless criterion `fallback_options is not None and fallback_name is
+  None` was checked registry-wide
+  (`tests/test_profiles.py::TestLosslessTargetCriterion`) and confirmed to
+  select exactly `flac`, `wav`, `png`, `tiff`, `bmp` against the registry as it
+  stands on `main` at this issue's base commit — milestone 6's `attached_pic`
+  rules had not yet merged into this branch, so the guard is proven by
+  construction (a bare rule with no fallback at all fails the first half of
+  the pair) rather than by a live conflict, and will hold the same way once
+  that work lands.

--- a/docs/specs/spec-lossy-source-notes.md
+++ b/docs/specs/spec-lossy-source-notes.md
@@ -394,3 +394,12 @@ New-Item -ItemType Directory -Force in
   on `mp4`/`mov`/`webm` are live fallback-less rules today that the pair
   already discriminates correctly against, not merely a hypothetical
   construction.
+- 2026-08-27 (issue #87, self-review before round 4): added an explicit
+  non-exhaustiveness statement at the top of `LOSSY_CODECS`'s docstring,
+  stating plainly that the set does not claim to list every lossy codec
+  ffmpeg can decode, only the ones checked individually and found
+  unambiguous -- so a codec found missing later (a legacy video codec such
+  as a WMV or RealVideo variant, say) is the disclosed, by-design boundary
+  the ADPCM paragraph already demonstrates the shape of, not an
+  undiscovered instance of the round-3 reachability bug. No membership
+  change; comment only.

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1710,6 +1710,28 @@ class TestLossyCodecs:
         have been a silent gap rather than a judgement call."""
         assert {"pcm_alaw", "pcm_mulaw", "pcm_vidc"} <= LOSSY_CODECS
 
+    def test_includes_the_common_lossy_audio_codecs_reachable_as_a_source(self):
+        """Membership cannot be scoped to "whatever this registry's own copy
+        masks and fallback names already use": `LOSSY_CODECS` matches a
+        *source* codec, reachable via `SOURCE_SUFFIXES` regardless of what
+        any target profile does with it -- the same correction that added
+        the companded PCM trio applies to every codec below. `wmav1`/
+        `wmav2`/`wmapro` are the sharpest case: this set already guards
+        against misreading `wmalossless`, so staying silent on the far
+        commoner lossy WMA family would have been backwards. All eight
+        report ffmpeg's `L` flag only, no `S` -- no ambiguity to trade
+        against, unlike `dts`."""
+        assert {
+            "wmav1",
+            "wmav2",
+            "wmapro",
+            "mp2",
+            "amr_nb",
+            "amr_wb",
+            "nellymoser",
+            "speex",
+        } <= LOSSY_CODECS
+
     def test_includes_the_motivating_and_flag_contradicting_cases(self):
         """A set could satisfy the exclusion test above by being empty, which
         would not be a lossy-codec set at all. `mp3` is the motivating case

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1679,12 +1679,36 @@ class TestLossyCodecs:
     """
 
     def test_excludes_the_named_lossless_family(self):
-        """The five awkward cases the issue names: `alac`, `flac`,
-        `wmalossless` and `truehd` all report ffmpeg's own lossless flag
-        (`S`) with no `L`, and so does every `pcm_*` decoder -- none of them
-        may ever read as a lossy source."""
-        assert LOSSY_CODECS.isdisjoint({"alac", "flac", "wmalossless", "truehd"})
-        assert not any(name.startswith("pcm_") for name in LOSSY_CODECS)
+        """The four awkward codecs the issue names -- `alac`, `flac`,
+        `wmalossless`, `truehd` -- and the *linear* `pcm_*` decoders all
+        report ffmpeg's own lossless flag (`S`) with no `L`, and none of
+        them may ever read as a lossy source. Scoped to a representative
+        sample of linear PCM (`pcm_s16le`, `pcm_s24le`, `pcm_s32le`,
+        `pcm_f32le`, `pcm_u8` -- different bit depths, signedness and a
+        float variant) rather than a blanket `pcm_` prefix ban: three
+        *other* `pcm_*` decoders -- `pcm_alaw`, `pcm_mulaw`, `pcm_vidc` --
+        are genuinely lossy and are members (the next test)."""
+        assert LOSSY_CODECS.isdisjoint(
+            {
+                "alac",
+                "flac",
+                "wmalossless",
+                "truehd",
+                "pcm_s16le",
+                "pcm_s24le",
+                "pcm_s32le",
+                "pcm_f32le",
+                "pcm_u8",
+            }
+        )
+
+    def test_includes_the_lossy_pcm_companding_variants(self):
+        """`pcm_alaw`/`pcm_mulaw` (G.711 companding) and `pcm_vidc` report
+        `L` only, no `S` -- unambiguously lossy, unlike every codec this
+        set deliberately leaves out. A companded source is an ordinary
+        `SOURCE_SUFFIXES` member (a G.711 `.wav`), so omitting them would
+        have been a silent gap rather than a judgement call."""
+        assert {"pcm_alaw", "pcm_mulaw", "pcm_vidc"} <= LOSSY_CODECS
 
     def test_includes_the_motivating_and_flag_contradicting_cases(self):
         """A set could satisfy the exclusion test above by being empty, which

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -15,6 +15,7 @@ from converter.profiles import (
     FLAC,
     GIF,
     JPG,
+    LOSSY_CODECS,
     M4A,
     MKV,
     MOV,
@@ -1667,6 +1668,64 @@ class TestRegistryTargetCoherence:
         duplicates = {suffix for suffix in suffixes if suffixes.count(suffix) > 1}
 
         assert not duplicates, f"target_suffix collision(s) in the registry: {sorted(duplicates)}"
+
+
+class TestLossyCodecs:
+    """`LOSSY_CODECS` (issue #87, `docs/specs/spec-lossy-source-notes.md`): the
+    curated set the source-codec advisory checks against, hand-maintained
+    because ffmpeg's own `-codecs` classification cannot be read wholesale --
+    see the constant's own docstring in `converter/profiles.py` for the full
+    argument and the ffmpeg 9.0 flags it was measured against.
+    """
+
+    def test_excludes_the_named_lossless_family(self):
+        """The five awkward cases the issue names: `alac`, `flac`,
+        `wmalossless` and `truehd` all report ffmpeg's own lossless flag
+        (`S`) with no `L`, and so does every `pcm_*` decoder -- none of them
+        may ever read as a lossy source."""
+        assert LOSSY_CODECS.isdisjoint({"alac", "flac", "wmalossless", "truehd"})
+        assert not any(name.startswith("pcm_") for name in LOSSY_CODECS)
+
+    def test_includes_the_motivating_and_flag_contradicting_cases(self):
+        """A set could satisfy the exclusion test above by being empty, which
+        would not be a lossy-codec set at all. `mp3` is the motivating case
+        (Verification, spec-lossy-source-notes.md: "an MP3 library into
+        FLAC"); `gif` is the case ffmpeg's own flag gets wrong (reports
+        lossless, measured lossy in `docs/specs/archive/spec-image-formats.md`).
+        Both must actually be members for this set to be doing its job.
+        """
+        assert {"mp3", "gif"} <= LOSSY_CODECS
+
+
+def lossless_target_names(registry: dict[str, Profile]) -> set[str]:
+    """Names of every profile with at least one rule matching the lossless
+    criterion the spec pins: `fallback_options is not None and fallback_name
+    is None` -- it re-encodes, and the profile declared that re-encode not
+    worth naming. The bare `fallback_name is None` test is overloaded (Prior
+    decisions, spec-lossy-source-notes.md): it also matches a rule with no
+    fallback at all, which is a *drop*, not a lossless re-encode -- exactly
+    the shape phase 6's fallback-less `attached_pic` rules have, which must
+    not be misread as lossless targets the moment they land.
+    """
+    return {
+        profile.name
+        for profile in registry.values()
+        if any(
+            rule.fallback_options is not None and rule.fallback_name is None
+            for rule in profile.rules.values()
+        )
+    }
+
+
+class TestLosslessTargetCriterion:
+    """The second, load-bearing guard rail from issue #87: pins that exactly
+    the five profiles the spec's Prior decisions table names satisfy the
+    lossless criterion, checked against the *whole* registry so a profile
+    added later -- lossless or not -- is covered without editing this test.
+    """
+
+    def test_exactly_five_profiles_satisfy_the_lossless_criterion(self):
+        assert lossless_target_names(PROFILES) == {"flac", "wav", "png", "tiff", "bmp"}
 
 
 class TestResolveTarget:

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1718,7 +1718,7 @@ class TestLossyCodecs:
         the companded PCM trio applies to every codec below. `wmav1`/
         `wmav2`/`wmapro` are the sharpest case: this set already guards
         against misreading `wmalossless`, so staying silent on the far
-        commoner lossy WMA family would have been backwards. All eight
+        commoner lossy WMA family would have been backwards. All ten
         report ffmpeg's `L` flag only, no `S` -- no ambiguity to trade
         against, unlike `dts`."""
         assert {
@@ -1730,6 +1730,8 @@ class TestLossyCodecs:
             "amr_wb",
             "nellymoser",
             "speex",
+            "gsm",
+            "ilbc",
         } <= LOSSY_CODECS
 
     def test_includes_the_motivating_and_flag_contradicting_cases(self):


### PR DESCRIPTION
## Summary
- Adds `LOSSY_CODECS`, a hand-curated `frozenset` in `converter/profiles.py` beside `TEXT_SUBTITLE_CODECS`, for the source-codec advisory `docs/specs/spec-lossy-source-notes.md` describes.
- The membership comment argues why ffmpeg's own `-codecs` `L`/`S` classification is not the source of truth, verified against ffmpeg 9.0: `webp` reports both flags (and so, newly measured here, do `h264`, `hevc`, `av1` and `dts`), reading it costs a subprocess, and `gif` reports lossless despite measurably losing 182 of 36485 colours (phase 5).
- Pins the registry-wide lossless-target criterion (`fallback_options is not None and fallback_name is None`) against the whole `PROFILES` dict — exactly `flac`, `wav`, `png`, `tiff`, `bmp` satisfy it — so the guard survives milestone 6's incoming fallback-less `attached_pic` rules, which the bare flag alone would misread as lossless targets.
- Data + tests only, per the issue's scope — no advisory is emitted yet (that's #88).

Closes #87

## Test plan
- [x] `.venv/Scripts/python.exe scripts/verify.py` green (924 tests, ruff clean, format clean)
- [x] Mutation check (scratch script outside the repo): adding `alac` to a copy of `LOSSY_CODECS` fails `test_excludes_the_named_lossless_family`; giving `wav`'s rule a `fallback_name` fails `test_exactly_five_profiles_satisfy_the_lossless_criterion`; the real registry/set pass both
- [x] `ffmpeg -codecs` (build 9.0) checked directly for every codec the membership comment cites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pdnJyntsFJyawGBSGj4cV