### PR TITLE
fix(batch): contain a too-long output path to one failed file

### DIFF
--- a/converter/batch.py
+++ b/converter/batch.py
@@ -217,6 +217,31 @@ def _interruptible(
     return work
 
 
+def _stage_output_directories(tasks: Sequence[Task]) -> tuple[list[Task], list[Result]]:
+    """Create each task's output directory, containing a path-length failure to its file.
+
+    Run single-threaded in the parent before the pool starts (see run_batch's
+    docstring note on why directory creation happens up front at all). The old
+    code let ``ensure_directory`` raise straight out of this loop: an OSError
+    from one source -- typically a derived output path over Windows' MAX_PATH --
+    propagated out of ``run_batch`` and aborted every remaining file in the
+    tree, which is exactly what ``docs/constitution.md`` rules out ("one broken
+    input file must not abort the batch"). Only ``OSError`` is caught here, not
+    a bare ``Exception``: a genuine programming error in this loop must still
+    surface as a crash rather than be filed away as a failed conversion.
+    """
+    runnable: list[Task] = []
+    failures: list[Result] = []
+    for task in tasks:
+        try:
+            ensure_directory(task.dst.parent)
+        except OSError as exc:
+            failures.append(Result(task, Outcome.FAILED, error=str(exc)))
+        else:
+            runnable.append(task)
+    return runnable, failures
+
+
 def run_batch(
     profile: Profile,
     tasks: Sequence[Task],
@@ -233,8 +258,7 @@ def run_batch(
     # Created up front, single-threaded, in the parent.  The old code ran
     # "if not exists: makedirs()" inside every worker, which races: the losers
     # died with FileExistsError and their files were never converted.
-    for task in tasks:
-        ensure_directory(task.dst.parent)
+    runnable_tasks, early_failures = _stage_output_directories(tasks)
 
     results: list[Result] = []
     work = _interruptible(profile, tools, overwrite=overwrite, interrupted=threading.Event())
@@ -245,7 +269,11 @@ def run_batch(
     pool = ThreadPoolExecutor(max_workers=workers)
     try:
         with tqdm(total=len(tasks), desc=profile.label, unit="file", disable=not progress) as bar:
-            futures = [pool.submit(work, task) for task in tasks]
+            for result in early_failures:
+                results.append(result)
+                _report(result, bar)
+                bar.update(1)
+            futures = [pool.submit(work, task) for task in runnable_tasks]
             try:
                 # as_completed, so the bar advances when a file is actually done
                 # rather than in submission order.

--- a/docs/specs/archive/spec-target-driven-cli.md
+++ b/docs/specs/archive/spec-target-driven-cli.md
@@ -568,3 +568,24 @@ reusing the fixtures the phase-1 gate synthesises:
   "not capped (default: 4, ...)", matching what the code does. A follow-up
   issue for actually capping `--jobs` at the CPU count, if desired, belongs
   to whoever owns `batch.py`.
+- 2026-08-27 (#86): `run_batch`'s up-front `ensure_directory` loop let an
+  `OSError` from one task's output directory (typically a derived path over
+  Windows' `MAX_PATH`, proven end-to-end in #73/#84) propagate straight out of
+  `run_batch` and abort the whole run before a single file converted --
+  violating `docs/constitution.md`'s "one broken input file must not abort the
+  batch". Fixed by splitting the loop into a new `_stage_output_directories`
+  helper that catches `OSError` (only `OSError`, not `Exception`, so a genuine
+  programming error in this loop still crashes rather than being filed away as
+  a failed conversion) per task, turning a failing directory into a counted
+  `Outcome.FAILED` result naming the original path-length message, and
+  excluding only that task from the pool. Every other task still converts, the
+  exit code still reflects the genuine failure, and no output file is ever
+  written for the failing task since its directory was never created. Verified
+  both with a reproduction (a 257-character output root: the two good sources
+  in the tree convert, the long one fails by name, exit code 1, and a second
+  run is idempotent -- the good outputs are skipped, the bad one fails again)
+  and with `tests/test_batch_containment.py`, a new file rather than
+  `tests/test_batch.py` (owned by the in-flight #76): it monkeypatches
+  `batch.ensure_directory` to fail for one directory the way a too-long path
+  would, so the containment is exercised without depending on an actual
+  Windows path-length failure, and stays green on Linux CI.

--- a/tests/test_batch_containment.py
+++ b/tests/test_batch_containment.py
@@ -1,0 +1,151 @@
+"""One broken output directory must not abort the rest of the batch (issue #86).
+
+``ensure_directory`` (``converter/paths.py``) raises an uncaught ``OSError``
+when a derived output path exceeds Windows' ``MAX_PATH`` -- proven end-to-end
+in issue #73. These tests exercise the containment in ``run_batch`` itself
+without depending on an actual Windows path-length failure, so the suite stays
+green on Linux CI too: ``ensure_directory`` is monkeypatched to fail for one
+task's directory exactly the way a too-long path would, and the test asserts
+the rest of the tree is unaffected. ``tests/test_batch.py`` belongs to a
+different, in-flight issue (#76), so this containment test lives in its own
+file rather than there.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from converter import batch
+from converter.batch import Outcome, Task, run_batch, summarise
+from converter.ffmpegtool import CommandResult, Tools
+from converter.profiles import Attempt, Profile, StreamRule, flags
+
+TOOLS = Tools(ffmpeg="ffmpeg", ffprobe="ffprobe")
+
+
+def _no_verification_profile() -> Profile:
+    """A profile whose cheap attempt is exhaustive, so success needs no probe.
+
+    Mirrors ``exhaustive_profile`` in ``tests/test_batch.py``: keeping this
+    file's fixtures self-contained (rather than importing across test modules
+    owned by different issues) avoids coupling to code someone else is
+    actively changing.
+    """
+    return Profile(
+        label="STUB",
+        name="stub",
+        description="test double, not a shipped format",
+        target_suffix=".out",
+        container_options=(),
+        cheap_attempt=Attempt(label="copy-all", options=flags("-c copy")),
+        explicit_streams=False,
+        partial_mapping=False,
+        rules={"video": StreamRule(frozenset({"h264"}), flags("-c:v copy"))},
+    )
+
+
+def make_task(tmp_path: Path, name: str, out_dir: str = "out") -> Task:
+    src = tmp_path / f"{name}.src"
+    src.write_bytes(b"data")
+    return Task(src, tmp_path / out_dir / f"{name}.out")
+
+
+@pytest.fixture
+def fake_ffmpeg(monkeypatch):
+    """A cheap attempt that always succeeds and writes the output file."""
+
+    def run(argv, **_kwargs):
+        argv = list(argv)
+        Path(argv[-1]).write_bytes(b"converted")
+        return CommandResult(tuple(argv), 0, "", "")
+
+    monkeypatch.setattr(batch.ffmpegtool, "run", run)
+
+
+def _fail_only_for(monkeypatch, bad_dir: Path, message: str) -> None:
+    """Make ``ensure_directory`` fail exactly like a too-long path would, but
+    only for *bad_dir* -- every other directory is created for real, so the
+    test proves containment rather than merely that a stub was called."""
+    real_ensure_directory = batch.ensure_directory
+
+    def flaky(path: Path) -> None:
+        if path == bad_dir:
+            raise OSError(206, message)
+        real_ensure_directory(path)
+
+    monkeypatch.setattr(batch, "ensure_directory", flaky)
+
+
+class TestOneBadOutputDirectoryDoesNotAbortTheBatch:
+    def test_other_files_still_convert_and_the_bad_one_is_a_named_failure(
+        self, tmp_path, monkeypatch, fake_ffmpeg
+    ):
+        bad_dir = tmp_path / "out" / "bad"
+        _fail_only_for(monkeypatch, bad_dir, "path is too long (stubbed)")
+        profile = _no_verification_profile()
+        good_a = make_task(tmp_path, "alpha")
+        good_b = make_task(tmp_path, "bravo")
+        bad = Task(tmp_path / "gamma.src", bad_dir / "gamma.out")
+        bad.src.write_bytes(b"data")
+
+        results = run_batch(profile, [good_a, good_b, bad], TOOLS, jobs=1, progress=False)
+        summary = summarise(results)
+
+        assert summary.converted == 2
+        assert summary.failed == 1
+        assert summary.exit_code == 1
+        assert good_a.dst.read_bytes() == b"converted"
+        assert good_b.dst.read_bytes() == b"converted"
+        bad_result = next(r for r in results if r.task == bad)
+        assert bad_result.outcome is Outcome.FAILED
+        assert "too long" in bad_result.error
+
+    def test_no_partial_output_is_left_for_the_failing_source(
+        self, tmp_path, monkeypatch, fake_ffmpeg
+    ):
+        bad_dir = tmp_path / "out" / "bad"
+        _fail_only_for(monkeypatch, bad_dir, "path is too long (stubbed)")
+        profile = _no_verification_profile()
+        bad = Task(tmp_path / "gamma.src", bad_dir / "gamma.out")
+        bad.src.write_bytes(b"data")
+
+        run_batch(profile, [bad], TOOLS, jobs=1, progress=False)
+
+        assert not bad.dst.exists()
+        assert not bad_dir.exists()  # never even created: ensure_directory failed first
+
+    def test_a_rerun_is_idempotent_for_the_files_that_did_convert(
+        self, tmp_path, monkeypatch, fake_ffmpeg
+    ):
+        bad_dir = tmp_path / "out" / "bad"
+        _fail_only_for(monkeypatch, bad_dir, "path is too long (stubbed)")
+        profile = _no_verification_profile()
+        good = make_task(tmp_path, "alpha")
+        bad = Task(tmp_path / "gamma.src", bad_dir / "gamma.out")
+        bad.src.write_bytes(b"data")
+        run_batch(profile, [good, bad], TOOLS, jobs=1, progress=False)
+
+        second = summarise(run_batch(profile, [good, bad], TOOLS, jobs=1, progress=False))
+
+        assert second.converted == 0
+        assert second.skipped == 1  # good.dst already exists, and overwrite defaults to False
+        assert second.failed == 1
+        assert second.exit_code == 1
+
+    def test_a_genuine_programming_error_still_aborts_instead_of_being_counted(
+        self, tmp_path, monkeypatch, fake_ffmpeg
+    ):
+        """The containment must be narrow: only the path-length OSError is
+        caught. A bug unrelated to one file's directory (here simulated as a
+        TypeError from ensure_directory) must still surface as a crash rather
+        than being filed away as a FAILED conversion."""
+        profile = _no_verification_profile()
+        task = make_task(tmp_path, "alpha")
+
+        def broken(_path: Path) -> None:
+            raise TypeError("not an OSError -- a real bug")
+
+        monkeypatch.setattr(batch, "ensure_directory", broken)
+
+        with pytest.raises(TypeError, match="not an OSError"):
+            run_batch(profile, [task], TOOLS, jobs=1, progress=False)


### PR DESCRIPTION
## Summary
- `ensure_directory` raises an uncaught `OSError` when a derived output path exceeds Windows' `MAX_PATH`. `run_batch`'s up-front directory-creation loop let that propagate straight out, aborting the entire batch before a single file converted -- violating `docs/constitution.md`'s "one broken input file must not abort the batch" (proven end-to-end in #73/#84).
- New `_stage_output_directories` helper catches `OSError` (only `OSError`, not a bare `Exception`, so a genuine programming error still surfaces) per task, turns a failing directory into a counted `FAILED` result naming the original path-length message, and excludes only that task from the pool. Every other file still converts, the exit code still reflects the genuine failure, and no partial output file is ever written for the failing task.

## Test plan
- [x] `tests/test_batch_containment.py` (new file, since `tests/test_batch.py` belongs to in-flight #76): monkeypatches `batch.ensure_directory` to fail for one directory the way a too-long path would, so the containment is exercised without depending on an actual Windows path-length failure -- green on Linux CI too. Covers: other files still convert / bad one is a named failure, no partial output left for the failing source, a re-run stays idempotent for the files that did convert, and a genuine non-`OSError` bug still propagates instead of being swallowed.
- [x] `.venv\Scripts\python.exe scripts\verify.py` -- 925 tests, green (ruff check, ruff format --check, pytest).
- [x] Hand reproduction against real ffmpeg on Windows, before and after the fix:
  - **Before**: a tree of two good `.wav` sources plus one whose mirrored output path is 257 characters aborts with an unhandled `WinError 206` traceback -- zero files converted, not even the two that sort before the bad one.
  - **After**: `2 converted, 0 skipped, 1 failed, 0 unsupported (of 3)`, exit code 1, the failing file named with the path-length explanation, no output file left for it, and a second run reports `0 converted, 2 skipped, 1 failed, 0 unsupported (of 3)` -- idempotent for the files that did convert.

Closes #86

https://claude.ai/code/session_013pdnJyntsFJyawGBSGj4cV