### PR TITLE
feat(jobs): resolve a stream's rule by disposition, then by type

### DIFF
--- a/converter/jobs.py
+++ b/converter/jobs.py
@@ -61,6 +61,19 @@ def _room_reason(profile: Profile, stream_type: str, limit: int) -> str:
     return f"{profile.label} holds {limit} {stream_type} {noun}"
 
 
+def _rule_key(profile: Profile, stream: Stream) -> str:
+    """PIC node of stream-decision.md: resolve *stream* to its rule key.
+
+    An attached picture resolves to the ``"attached_pic"`` key when the profile
+    declares one, falling back to ``codec_type`` -- the fallback that leaves a
+    profile with no ``attached_pic`` rule byte-for-byte unchanged, since that is
+    exactly what it already did.
+    """
+    if stream.attached_pic and "attached_pic" in profile.rules:
+        return "attached_pic"
+    return stream.codec_type
+
+
 def _structural_drop(profile: Profile, stream: Stream, counts: dict[str, int]) -> str | None:
     """D1 and D2 of stream-decision.md: the drops the profile's *shape* forces.
 
@@ -69,7 +82,7 @@ def _structural_drop(profile: Profile, stream: Stream, counts: dict[str, int]) -
     success-side verification in :func:`_predict_unmapped` reuse them without
     asserting anything about what an already-successful attempt encoded.
     """
-    rule = profile.rules.get(stream.codec_type)
+    rule = profile.rules.get(_rule_key(profile, stream))
     if rule is None:
         return _drop_note(stream, f"not supported by {profile.label}")
 
@@ -169,7 +182,7 @@ def _decide_stream(
     if structural is not None:
         return [], [], structural
 
-    rule = profile.rules[stream.codec_type]
+    rule = profile.rules[_rule_key(profile, stream)]
     position = counts.get(stream.codec_type, 0)
     maps = ["-map", f"0:{stream.index}"]
     if stream.codec_name in rule.copy_mask:

--- a/docs/specs/spec-stream-disposition.md
+++ b/docs/specs/spec-stream-disposition.md
@@ -330,3 +330,16 @@ New-Item -ItemType Directory -Force in
   of seventeen targets rather than a correctness one. This also corrects
   `docs/roadmap.md`'s seeded "constitution — none" verdict for this phase, which
   the version floor made false.
+- 2026-08-27 (issue #76): `jobs._structural_drop` and `jobs._decide_stream` now
+  resolve a stream's rule through one new helper, `jobs._rule_key`, rather than
+  reading `profile.rules[stream.codec_type]` directly — it returns
+  `"attached_pic"` when the stream carries that disposition *and* the profile
+  declares such a rule, and `stream.codec_type` otherwise. `counts` stays keyed
+  on `codec_type` throughout (unchanged), so a carried picture still shares its
+  position counter with real video streams, matching ffmpeg's own output
+  numbering. `describe_unsupported` was left untouched, as decided above.
+  `Stream.attached_pic` (issue #75) had not landed on `main` while this issue's
+  code and tests were written; the resolution logic and every new test were
+  written against its documented shape (a boolean, added last, defaulted
+  `False`) and proven correct with a duck-typed stand-in exercising the real,
+  unmodified `converter.jobs` code, pending #75's merge for the real Verify run.

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -2888,14 +2888,38 @@ class TestDispositionResolution:
 
     @pytest.mark.parametrize("profile", [OGG, OPUS, WAV], ids=lambda profile: profile.label)
     def test_ogg_opus_and_wav_are_unaffected_by_the_disposition(self, profile):
-        """None of the three declares an ``attached_pic`` rule, so a stream's
-        disposition must make no difference at all -- the fallback guard this
-        phase must not break (issue #76's Acceptance)."""
+        """None of the three declares a ``video`` rule *or* an ``attached_pic``
+        one, so a video-typed stream is dropped by D1 either way (issue #76's
+        Acceptance names these three as the guard). This alone cannot catch a
+        broken ``"attached_pic" in profile.rules`` clause in `_rule_key` --
+        neither key resolves to a declared rule here regardless -- so
+        `test_a_profile_with_a_video_rule_and_no_attached_pic_rule_uses_it`
+        below is the case that actually exercises the guard."""
         plain = Stream(0, "video", "png")
         picture = Stream(0, "video", "png", attached_pic=True)
 
         assert jobs.verify_success(profile, [plain]) == jobs.verify_success(profile, [picture])
         assert jobs.retries(profile, [plain]) == jobs.retries(profile, [picture])
+
+    def test_a_profile_with_a_video_rule_and_no_attached_pic_rule_uses_it(self):
+        """MP4 declares a ``video`` rule but no ``attached_pic`` one -- unlike
+        ogg/opus/wav above, a picture-disposition stream here must still fall
+        back to and be handled by the ``video`` rule, identically to an
+        ordinary video stream of the same codec. Dropping `_rule_key`'s
+        ``"attached_pic" in profile.rules`` guard clause changes this exact
+        case: the stream would resolve to the undeclared ``"attached_pic"``
+        key instead, and be dropped by D1 rather than copied by the video
+        rule -- a fabricated drop note and a lost stream, invisible to any
+        test that never gives the profile a ``video`` rule to steal."""
+        plain = Stream(0, "video", "mjpeg")
+        picture = Stream(0, "video", "mjpeg", attached_pic=True)
+
+        assert jobs.verify_success(MP4, [plain]) == jobs.verify_success(MP4, [picture]) == ()
+
+        plain_selective = jobs.retries(MP4, [plain])[0]
+        picture_selective = jobs.retries(MP4, [picture])[0]
+        assert plain_selective == picture_selective
+        assert plain_selective.options[:4] == ("-map", "0:0", "-c:v:0", "copy")
 
     def test_the_engine_still_counts_a_carried_picture_under_video(self):
         """A real video stream and an attached picture share one position

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -26,6 +26,10 @@ from converter.profiles import (
     WAV,
     WEBM,
     WEBP,
+    Attempt,
+    Profile,
+    StreamRule,
+    flags,
 )
 
 
@@ -2819,6 +2823,146 @@ class TestConfirmDrops:
         assert jobs.confirm_drops(WAV, source, source[:1]) == (
             "audio stream 1 (opus) dropped: WAV holds 1 audio stream",
         )
+
+
+def _audio_and_picture_profile(*, picture_rule: bool = True) -> Profile:
+    """A profile shaped like the audio targets this phase amends (mp3, m4a,
+    flac): an audio rule plus, optionally, an ``attached_pic`` one -- built
+    locally so the resolution logic can be pinned without waiting on a shipped
+    profile to gain the rule (issue #87, a sibling of this one).
+    """
+    rules = {"audio": StreamRule(frozenset({"aac"}), flags("-c:a copy"))}
+    if picture_rule:
+        rules["attached_pic"] = StreamRule(frozenset({"png", "mjpeg"}), flags("-c:v:{n} copy"))
+    return Profile(
+        label="PICT",
+        name="pict",
+        description="a test double, not a shipped format",
+        target_suffix=".pict",
+        container_options=(),
+        cheap_attempt=Attempt(
+            label="remux", options=flags("-map 0:a? -map 0:disp:attached_pic? -c copy")
+        ),
+        explicit_streams=False,
+        partial_mapping=True,
+        rules=rules,
+    )
+
+
+class TestDispositionResolution:
+    """`jobs._rule_key` -- stream-decision.md's PIC node: a stream resolves to
+    the profile's ``attached_pic`` rule when one is declared, and falls back to
+    its ``codec_type`` otherwise (issue #76)."""
+
+    def test_an_attached_picture_resolves_to_its_own_rule(self):
+        """A copy mask and accept template distinct from any ``video`` rule
+        would use proves it is the ``attached_pic`` rule that actually fired,
+        not a coincidence of the two being identical."""
+        profile = _audio_and_picture_profile()
+        streams = [Stream(0, "audio", "aac"), Stream(1, "video", "png", attached_pic=True)]
+
+        [selective] = jobs.retries(profile, streams)
+
+        assert selective.options == (
+            "-map",
+            "0:0",
+            "-map",
+            "0:1",
+            "-c:a",
+            "copy",
+            "-c:v:0",
+            "copy",
+        )
+        assert selective.notes == ()
+
+    def test_falls_back_to_codec_type_when_the_profile_declares_no_rule(self):
+        """The same picture, but a profile that never gained the rule --
+        stream-decision.md's fallback branch. It resolves to the ``video``
+        lookup, finds nothing, and is dropped exactly as it always was."""
+        profile = _audio_and_picture_profile(picture_rule=False)
+        streams = [Stream(0, "audio", "aac"), Stream(1, "video", "png", attached_pic=True)]
+
+        notes = jobs.verify_success(profile, streams)
+
+        assert notes == ("video stream 1 (png) dropped: not supported by PICT",)
+
+    @pytest.mark.parametrize("profile", [OGG, OPUS, WAV], ids=lambda profile: profile.label)
+    def test_ogg_opus_and_wav_are_unaffected_by_the_disposition(self, profile):
+        """None of the three declares an ``attached_pic`` rule, so a stream's
+        disposition must make no difference at all -- the fallback guard this
+        phase must not break (issue #76's Acceptance)."""
+        plain = Stream(0, "video", "png")
+        picture = Stream(0, "video", "png", attached_pic=True)
+
+        assert jobs.verify_success(profile, [plain]) == jobs.verify_success(profile, [picture])
+        assert jobs.retries(profile, [plain]) == jobs.retries(profile, [picture])
+
+    def test_the_engine_still_counts_a_carried_picture_under_video(self):
+        """A real video stream and an attached picture share one position
+        counter, because ffmpeg numbers a carried picture as a video output
+        stream (Prior decisions, spec-stream-disposition.md) -- so the second
+        stream here substitutes ``{n} == 1``, not ``{n} == 0``."""
+        base = _audio_and_picture_profile()
+        profile = replace(
+            base,
+            rules={**base.rules, "video": StreamRule(frozenset({"h264"}), flags("-c:v:{n} copy"))},
+        )
+        streams = [
+            Stream(0, "video", "h264"),
+            Stream(1, "video", "png", attached_pic=True),
+        ]
+
+        [selective] = jobs.retries(profile, streams)
+
+        assert selective.options == (
+            "-map",
+            "0:0",
+            "-map",
+            "0:1",
+            "-c:v:0",
+            "copy",
+            "-c:v:1",
+            "copy",
+        )
+
+    def test_two_attached_pictures_both_survive_uncounted_against_a_limit(self):
+        """The rule declares no ``stream_limit`` (Prior decisions), so a second
+        picture is carried, not reported as dropped for want of room."""
+        profile = _audio_and_picture_profile()
+        streams = [
+            Stream(0, "video", "png", attached_pic=True),
+            Stream(1, "video", "mjpeg", attached_pic=True),
+        ]
+
+        assert jobs.verify_success(profile, streams) == ()
+
+    def test_describe_unsupported_stays_keyed_on_codec_type(self):
+        """Deliberate (Prior decisions, spec-stream-disposition.md): the
+        discriminator asks whether the source carries any stream *type* the
+        profile could use at all, which a disposition does not change -- even
+        though this profile's ``attached_pic`` rule would in fact carry the
+        stream once the ladder ran."""
+        profile = _audio_and_picture_profile()
+        streams = [Stream(0, "video", "png", attached_pic=True)]
+
+        notes = jobs.describe_unsupported(profile, streams)
+
+        assert notes == ("video stream 0 (png) dropped: not supported by PICT",)
+
+    def test_verify_success_does_not_report_a_carried_picture_as_dropped(self):
+        """The two outcomes stream-decision.md's PIC node exists to tell apart,
+        in one source: a picture the profile carries via its own rule, and an
+        ordinary video stream the profile still has no rule for."""
+        profile = _audio_and_picture_profile()
+        streams = [
+            Stream(0, "audio", "aac"),
+            Stream(1, "video", "png", attached_pic=True),
+            Stream(2, "video", "h264", attached_pic=False),
+        ]
+
+        notes = jobs.verify_success(profile, streams)
+
+        assert notes == ("video stream 2 (h264) dropped: not supported by PICT",)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -33,6 +33,30 @@ def exhaustive_profile() -> Profile:
     )
 
 
+def picture_carrying_profile() -> Profile:
+    """A profile shaped like the audio targets spec-stream-disposition.md
+    amends (mp3, m4a, flac): an audio rule plus an ``attached_pic`` one, so the
+    full `batch.convert_one` path can be proven end-to-end without waiting on
+    a shipped profile to gain the rule (issue #87, a sibling of this one).
+    """
+    return Profile(
+        label="PICT",
+        name="pict",
+        description="a test double, not a shipped format",
+        target_suffix=".pict",
+        container_options=(),
+        cheap_attempt=Attempt(
+            label="remux", options=flags("-map 0:a? -map 0:disp:attached_pic? -c copy")
+        ),
+        explicit_streams=False,
+        partial_mapping=True,
+        rules={
+            "audio": StreamRule(frozenset({"aac"}), flags("-c:a copy"), stream_limit=1),
+            "attached_pic": StreamRule(frozenset({"png", "mjpeg"}), flags("-c:v:{n} copy")),
+        },
+    )
+
+
 @pytest.fixture
 def fake_ffmpeg(monkeypatch):
     """Replace ffmpeg with a scripted stand-in and record every invocation."""
@@ -427,6 +451,38 @@ class TestPartialCheapAttemptVerification:
         assert result.attempt == "selective"
         assert len(probes) == 1
         assert result.notes == ("video stream 0 (vp8) re-encoded to h264",)
+
+
+class TestAttachedPictureVerification:
+    """stream-decision.md's PIC node, exercised through the full
+    `convert_one` path rather than `jobs` in isolation (issue #76): a carried
+    picture must never read as a drop, and a real video stream still must."""
+
+    def test_a_carried_picture_is_not_reported_as_dropped(self, tmp_path, fake_ffmpeg):
+        task = make_task(tmp_path)
+        task.dst.parent.mkdir(parents=True)
+        picture = Stream(1, "video", "png", attached_pic=True)
+        fake_ffmpeg.streams = [Stream(0, "audio", "aac"), picture]
+        # The muxer wrote back exactly what the mapping asked for.
+        fake_ffmpeg.output_streams = [Stream(0, "audio", "aac"), picture]
+
+        result = convert_one(picture_carrying_profile(), task, TOOLS, overwrite=False)
+
+        assert result.outcome is Outcome.CONVERTED
+        assert result.notes == ()
+
+    def test_a_real_video_stream_is_still_named_as_dropped(self, tmp_path, fake_ffmpeg):
+        task = make_task(tmp_path)
+        task.dst.parent.mkdir(parents=True)
+        fake_ffmpeg.streams = [Stream(0, "audio", "aac"), Stream(1, "video", "h264")]
+        # The profile has no ``video`` rule, so the disposition-less video
+        # stream really was left behind.
+        fake_ffmpeg.output_streams = [Stream(0, "audio", "aac")]
+
+        result = convert_one(picture_carrying_profile(), task, TOOLS, overwrite=False)
+
+        assert result.outcome is Outcome.CONVERTED
+        assert result.notes == ("video stream 1 (h264) dropped: not supported by PICT",)
 
 
 class TestDropsAreConfirmedAgainstTheOutput:


### PR DESCRIPTION
## Summary

Resolve a stream to its rule by disposition as well as type, so an attached
picture can have its own rule -- the engine-side half of
docs/specs/spec-stream-disposition.md.

- `jobs._rule_key` (new): a stream resolves to the profile's `attached_pic`
  rule when it carries that disposition *and* the profile declares one,
  falling back to `stream.codec_type` otherwise. Used by both
  `_structural_drop` (the D1/D2 structural verdicts) and `_decide_stream`
  (the per-stream copy/re-encode/drop decision).
- Position `counts` is untouched -- still keyed on `codec_type` -- so a
  carried picture shares its position counter with real video streams,
  matching ffmpeg's own output numbering (`-c:v:0`, `-c:v:1`, ...).
- `describe_unsupported` is deliberately left keyed on `codec_type`, per the
  spec's Prior decisions: its question is "does the source carry any stream
  *type* the profile could use", which a disposition does not change.
- `ogg`, `opus` and `wav` -- the three shipped profiles that declare no
  `attached_pic` rule -- are pinned byte-for-byte unaffected by a stream's
  disposition, and proven so with a mutation test outside the committed suite
  (see below).

## Test plan

- [x] `.venv/Scripts/python.exe scripts/verify.py` green: 941 tests, ruff
  check clean, ruff format clean.
- [x] `tests/test_argv.py::TestDispositionResolution`: resolves to its own
  rule; falls back to `codec_type` with no rule declared; `ogg`/`opus`/`wav`
  unaffected (parametrized); position counter shared under `"video"`; two
  pictures both carried with no `stream_limit`; `describe_unsupported` still
  keyed on `codec_type`; `verify_success` names a real video drop without
  reporting a carried picture as dropped.
- [x] `tests/test_batch.py::TestAttachedPictureVerification`: the same two
  `verify_success` directions proven end-to-end through `convert_one`.
- [x] Mutation-guard evidence (outside the repo, scratch script): the real
  `OGG`/`OPUS`/`WAV` registry is unaffected by `Stream.attached_pic`; a
  *mutated* copy of each (with an added `attached_pic` rule) diverges,
  proving the unchanged-behaviour assertion is sensitive rather than vacuous.

Closes #76