### PR TITLE
feat(profiles): carry cover art into mp3, m4a and flac

### DIFF
--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -510,14 +510,26 @@ MP3 = Profile(
     # out; that is what lets stream_limit=1 coexist with a blind "-map 0:a?"
     # below, the muxer-enforced exemption docs/design/degradation-ladder.md
     # names, rather than WAV's index-named one.
+    #
+    # "-map 0:disp:attached_pic?" (docs/specs/spec-stream-disposition.md): the
+    # disposition specifier maps an embedded cover picture and nothing else --
+    # measured, it never matches a real video stream, so this cheap attempt
+    # still never sees one. "-c copy" replaces "-c:a copy" deliberately: with
+    # no codec option covering the picture, ffmpeg would re-encode it to the
+    # muxer's default instead of copying it, an undeclared loss the mask would
+    # hide; "-c copy" behaves identically to "-c:a copy" for the audio stream
+    # since the map now selects only audio and pictures.
     cheap_attempt=Attempt(
         label="remux",
-        options=flags("-map 0:a? -c:a copy"),
+        options=flags("-map 0:a? -map 0:disp:attached_pic? -c copy"),
         # partial_mapping's success-side verification (docs/design/degradation-
         # ladder.md) already names a dropped stream precisely when the ladder
         # actually drops one; this line is the standing note the audio-formats
         # spec's gate chose to keep alongside it -- always true, so it costs
         # nothing to state even for the many files that had nothing to lose.
+        # (Now stale for cover art specifically -- issue #78, a dependent of
+        # this one, retires it once the verifier's per-stream note is the only
+        # place that claim needs to live.)
         notes=("non-audio streams, including cover art, are not carried into MP3",),
     ),
     explicit_streams=False,
@@ -534,6 +546,17 @@ MP3 = Profile(
             fallback_options=flags("-c:a libmp3lame -q:a 2"),
             fallback_name="mp3",
             stream_limit=1,
+        ),
+        # Accept-anything mask, the same mechanism MKV's attachment rule uses
+        # (_AcceptAnyCodec above): the decision resting on this rule is the
+        # disposition, not the codec, so enumerating codec names would repeat
+        # the phase-4 mistake the MP4 attachment rule corrected. No
+        # stream_limit: one "-map 0:disp:attached_pic?" carries *every*
+        # picture a source holds (measured), so a limit of 1 would report a
+        # carried picture as dropped (Prior decisions, spec-stream-disposition.md).
+        "attached_pic": StreamRule(
+            copy_mask=_AcceptAnyCodec(),
+            accept_options=flags("-c:v:{n} copy"),
         ),
     },
     last_resort=Attempt(
@@ -557,9 +580,13 @@ FLAC = Profile(
     container_options=(),
     # Same blind-by-type shape and the same reason as MP3's above: the flac
     # muxer enforces "at most one audio stream" itself.
+    #
+    # Same disposition addition as MP3's, and the same "-c copy" reasoning --
+    # see its comment (docs/specs/spec-stream-disposition.md).
     cheap_attempt=Attempt(
         label="remux",
-        options=flags("-map 0:a? -c:a copy"),
+        options=flags("-map 0:a? -map 0:disp:attached_pic? -c copy"),
+        # Stale for cover art -- see MP3's identical note and its comment.
         notes=("non-audio streams, including cover art, are not carried into FLAC",),
     ),
     explicit_streams=False,
@@ -572,6 +599,11 @@ FLAC = Profile(
             # No fallback_name: encoding into a container's own lossless codec
             # gives up nothing, the same rule WAV's PCM fallback carries.
             stream_limit=1,
+        ),
+        # Same accept-anything shape as MP3's -- see its comment.
+        "attached_pic": StreamRule(
+            copy_mask=_AcceptAnyCodec(),
+            accept_options=flags("-c:v:{n} copy"),
         ),
     },
     last_resort=Attempt(
@@ -596,9 +628,17 @@ M4A = Profile(
     # standard MP4's -- it rejects mp3, opus and flac stream copies -- so the
     # mask below is curated by hand rather than reused from MP4_AUDIO_CODECS
     # (docs/specs/archive/spec-audio-formats.md).
+    #
+    # Same disposition addition as MP3's cheap attempt, and the same reason
+    # "-c:a copy" becomes "-c copy": trap 1 in
+    # docs/specs/spec-stream-disposition.md. Measured, this one matters most --
+    # the ipod muxer's *default* video encoder is h264, which ipod then
+    # rejects, so leaving "-c:a copy" in place would fail every artwork-bearing
+    # "--to m4a" at rung 1 rather than silently mis-encoding as mp3/flac would.
     cheap_attempt=Attempt(
         label="remux",
-        options=flags("-map 0:a? -c:a copy"),
+        options=flags("-map 0:a? -map 0:disp:attached_pic? -c copy"),
+        # Stale for cover art -- see MP3's identical note and its comment.
         notes=("non-audio streams, including cover art, are not carried into M4A",),
     ),
     explicit_streams=False,
@@ -620,6 +660,11 @@ M4A = Profile(
             accept_options=flags("-c:a:{n} copy"),
             fallback_options=flags("-c:a:{n} aac -b:a:{n} 192k"),
             fallback_name="aac",
+        ),
+        # Same accept-anything shape as MP3's -- see its comment.
+        "attached_pic": StreamRule(
+            copy_mask=_AcceptAnyCodec(),
+            accept_options=flags("-c:v:{n} copy"),
         ),
     },
     last_resort=Attempt(

--- a/docs/specs/spec-stream-disposition.md
+++ b/docs/specs/spec-stream-disposition.md
@@ -356,3 +356,33 @@ New-Item -ItemType Directory -Force in
   `False`) and proven correct with a duck-typed stand-in exercising the real,
   unmodified `converter.jobs` code, then re-proven against the real `Stream`
   type once #75 merged.
+- 2026-08-27 (issue #77): `mp3`, `m4a` and `flac` gained the carry-through.
+  Each cheap attempt is now exactly
+  `flags("-map 0:a? -map 0:disp:attached_pic? -c copy")` — pinned in full per
+  the Prior decisions row, including the `-c:a copy` → `-c copy` change that
+  matters most for `m4a` (trap 1: the ipod muxer's default video encoder is
+  h264, which ipod then rejects). Each profile gained an `attached_pic` rule
+  reusing `_AcceptAnyCodec` (added for MKV's attachments, issue #38) rather
+  than a second accept-anything mechanism: `copy_mask=_AcceptAnyCodec()`,
+  `accept_options=flags("-c:v:{n} copy")`, no `stream_limit`. Cheap-attempt
+  standing notes are left untouched — their removal is issue #78, which
+  depends on this one, so they read as an over-broad statement between the
+  two merges rather than a false one this issue is scoped to fix.
+  `tests/test_profiles.py`'s `mapped_types` and `named_index_counts` learned
+  the `0:disp:<qualifier>?` selector form via a new `DISPOSITION_QUALIFIERS`
+  table, resolving it to the blind branch of both invariants per
+  `degradation-ladder.md`'s third-selector-kind decision above; all three
+  shipped invariants pass over all 17 profiles with the new selector
+  recognised. Verified against real ffmpeg 9.0 with distinct-stem fixtures:
+  artwork survives `--to mp3`, `--to m4a` and `--to flac`, including the
+  selective-rung case (a flac-with-art source into `--to mp3`, which forces an
+  audio re-encode); a real h264 and a real mjpeg video stream are both dropped
+  with a note on `--to mp3` and `--to m4a` rather than carried; a two-picture
+  source is carried whole with no loss note on both the cheap-attempt and
+  selective-rung paths; `--to ogg` and `--to wav` over an artwork-bearing
+  source are unaffected; a second run over a converted tree reports 0
+  converted, exit 0. Every new assertion was proven non-vacuous by mutating a
+  profile copy in a scratch script outside the repo (dropping the
+  `attached_pic` rule, or giving it `stream_limit=1`) and confirming both the
+  scratch check and the shipped `tests/test_profiles.py` invariants fail
+  against the mutation.

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -174,7 +174,14 @@ class TestMp3Job:
     def test_first_attempt_carries_the_standing_note(self):
         attempt = jobs.first_attempt(MP3)
 
-        assert attempt.options == ("-map", "0:a?", "-c:a", "copy")
+        assert attempt.options == (
+            "-map",
+            "0:a?",
+            "-map",
+            "0:disp:attached_pic?",
+            "-c",
+            "copy",
+        )
         assert attempt.notes == (
             "non-audio streams, including cover art, are not carried into MP3",
         )
@@ -223,6 +230,34 @@ class TestMp3Job:
 
         assert selective.notes == ("video stream 1 (h264) dropped: not supported by MP3",)
 
+    def test_a_carried_picture_is_not_reported_as_dropped_while_a_real_video_still_is(self):
+        """Issue #77, `docs/specs/spec-stream-disposition.md`: the distinction
+        the whole phase is for, proven against the real `MP3` profile rather
+        than a stand-in. Both streams share the codec `mjpeg` -- the codec of
+        both a cover picture and a real video (Prior art) -- so the note this
+        asserts can only come from the disposition, never from the codec name."""
+        streams = [
+            Stream(0, "audio", "mp3"),
+            Stream(1, "video", "mjpeg", attached_pic=True),
+            Stream(2, "video", "mjpeg", attached_pic=False),
+        ]
+
+        notes = jobs.verify_success(MP3, streams)
+
+        assert notes == ("video stream 2 (mjpeg) dropped: not supported by MP3",)
+
+    def test_a_two_picture_source_is_carried_whole_with_no_loss(self):
+        """The `attached_pic` rule declares no `stream_limit` (Prior
+        decisions): one `-map 0:disp:attached_pic?` carries every picture a
+        source holds, so neither is reported as dropped for want of room."""
+        streams = [
+            Stream(0, "audio", "mp3"),
+            Stream(1, "video", "png", attached_pic=True),
+            Stream(2, "video", "mjpeg", attached_pic=True),
+        ]
+
+        assert jobs.verify_success(MP3, streams) == ()
+
     def test_last_resort_notes_are_pinned(self):
         """The explicit-index last resort cannot name a per-stream drop itself
         (unlike the selective rung), so what it gives up has to be its own
@@ -245,7 +280,14 @@ class TestFlacJob:
     def test_first_attempt_carries_the_standing_note(self):
         attempt = jobs.first_attempt(FLAC)
 
-        assert attempt.options == ("-map", "0:a?", "-c:a", "copy")
+        assert attempt.options == (
+            "-map",
+            "0:a?",
+            "-map",
+            "0:disp:attached_pic?",
+            "-c",
+            "copy",
+        )
         assert attempt.notes == (
             "non-audio streams, including cover art, are not carried into FLAC",
         )
@@ -290,6 +332,27 @@ class TestFlacJob:
 
         assert selective.notes == ("video stream 1 (h264) dropped: not supported by FLAC",)
 
+    def test_a_carried_picture_is_not_reported_as_dropped_while_a_real_video_still_is(self):
+        """Same distinction as `TestMp3Job`'s equivalent -- see its comment."""
+        streams = [
+            Stream(0, "audio", "flac"),
+            Stream(1, "video", "mjpeg", attached_pic=True),
+            Stream(2, "video", "mjpeg", attached_pic=False),
+        ]
+
+        notes = jobs.verify_success(FLAC, streams)
+
+        assert notes == ("video stream 2 (mjpeg) dropped: not supported by FLAC",)
+
+    def test_a_two_picture_source_is_carried_whole_with_no_loss(self):
+        streams = [
+            Stream(0, "audio", "flac"),
+            Stream(1, "video", "png", attached_pic=True),
+            Stream(2, "video", "mjpeg", attached_pic=True),
+        ]
+
+        assert jobs.verify_success(FLAC, streams) == ()
+
     def test_last_resort_notes_are_pinned(self):
         """Unlike its `StreamRule.fallback_name=None`, the last resort still
         needs its own note: it is an explicit-index attempt, so it cannot name
@@ -312,7 +375,14 @@ class TestM4aJob:
     def test_first_attempt_carries_the_standing_note(self):
         attempt = jobs.first_attempt(M4A)
 
-        assert attempt.options == ("-map", "0:a?", "-c:a", "copy")
+        assert attempt.options == (
+            "-map",
+            "0:a?",
+            "-map",
+            "0:disp:attached_pic?",
+            "-c",
+            "copy",
+        )
         assert attempt.notes == (
             "non-audio streams, including cover art, are not carried into M4A",
         )
@@ -387,6 +457,30 @@ class TestM4aJob:
         selective = jobs.retries(M4A, streams)[0]
 
         assert selective.notes == ("video stream 1 (h264) dropped: not supported by M4A",)
+
+    def test_a_carried_picture_is_not_reported_as_dropped_while_a_real_video_still_is(self):
+        """Same distinction as `TestMp3Job`'s equivalent -- see its comment.
+        The trap this guards is trap 1: were `-c:a copy` still in place, the
+        picture would be re-encoded to h264 and the ipod muxer would reject
+        it, so this test would never even reach the notes it asserts."""
+        streams = [
+            Stream(0, "audio", "aac"),
+            Stream(1, "video", "mjpeg", attached_pic=True),
+            Stream(2, "video", "mjpeg", attached_pic=False),
+        ]
+
+        notes = jobs.verify_success(M4A, streams)
+
+        assert notes == ("video stream 2 (mjpeg) dropped: not supported by M4A",)
+
+    def test_a_two_picture_source_is_carried_whole_with_no_loss(self):
+        streams = [
+            Stream(0, "audio", "aac"),
+            Stream(1, "video", "png", attached_pic=True),
+            Stream(2, "video", "mjpeg", attached_pic=True),
+        ]
+
+        assert jobs.verify_success(M4A, streams) == ()
 
     def test_last_resort_notes_are_pinned(self):
         reencode = jobs.retries(M4A, [])[-1]
@@ -1523,6 +1617,8 @@ class TestProfileArgvPinning:
         ]
 
     def test_mp3_cheap_attempt(self):
+        """Issue #77, `docs/specs/spec-stream-disposition.md`: the disposition
+        map and "-c copy" replace the plain audio-only "-c:a copy" form."""
         argv = build_argv("ffmpeg", "in.wav", jobs.first_attempt(MP3).options, "out.mp3")
 
         assert argv == [
@@ -1536,7 +1632,9 @@ class TestProfileArgvPinning:
             "in.wav",
             "-map",
             "0:a?",
-            "-c:a",
+            "-map",
+            "0:disp:attached_pic?",
+            "-c",
             "copy",
             "out.mp3",
         ]
@@ -1555,7 +1653,9 @@ class TestProfileArgvPinning:
             "in.wav",
             "-map",
             "0:a?",
-            "-c:a",
+            "-map",
+            "0:disp:attached_pic?",
+            "-c",
             "copy",
             "out.flac",
         ]
@@ -1649,6 +1749,10 @@ class TestProfileArgvPinning:
         ]
 
     def test_m4a_cheap_attempt(self):
+        """Trap 1 (`docs/specs/spec-stream-disposition.md`): "-c:a copy" would
+        leave the picture uncovered, and the ipod muxer re-encodes it to h264
+        by default and then rejects it -- "-c copy" is load-bearing here, not
+        cosmetic like it is for mp3/flac."""
         argv = build_argv("ffmpeg", "in.wav", jobs.first_attempt(M4A).options, "out.m4a")
 
         assert argv == [
@@ -1662,7 +1766,9 @@ class TestProfileArgvPinning:
             "in.wav",
             "-map",
             "0:a?",
-            "-c:a",
+            "-map",
+            "0:disp:attached_pic?",
+            "-c",
             "copy",
             "out.m4a",
         ]

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -42,6 +42,16 @@ from converter.profiles import (
 #: unlisted letter is exactly what `mapped_types`'s own assertion below is for.
 MAP_LETTERS = {"v": "video", "a": "audio", "s": "subtitle", "t": "attachment", "d": "data"}
 
+#: Disposition qualifiers a "0:disp:<qualifier>?" selector can carry, mapped to
+#: the rule key they resolve to -- the third selector kind
+#: `docs/design/degradation-ladder.md` names: it carries a colon-separated
+#: qualifier the way an index-named selector does, but behaves like a blind
+#: one (measured, one such map carries *every* matching stream, not one).
+#: Extend this the same way `MAP_LETTERS` is extended, when a profile
+#: introduces another disposition selector. Only `attached_pic` exists today
+#: (docs/specs/spec-stream-disposition.md).
+DISPOSITION_QUALIFIERS = {"attached_pic": "attached_pic"}
+
 #: Every profile the registry ships. A new one joins the invariant checks here.
 SHIPPED = [
     MP4,
@@ -164,6 +174,18 @@ def mapped_types(profile: Profile) -> dict[str, bool]:
         assert value.startswith("0:"), f"{profile.label}: -map selector not recognised: {value!r}"
         selector = value[2:].removesuffix("?")
         letter = selector.split(":")[0]
+        if letter == "disp":
+            # "0:disp:attached_pic?" reads like an index-named selector -- it
+            # carries a colon-separated qualifier -- but behaves like a blind
+            # one (degradation-ladder.md's third selector kind), so it is
+            # resolved by the qualifier rather than by MAP_LETTERS and always
+            # recorded as blind.
+            qualifier = selector.split(":", 1)[1] if ":" in selector else ""
+            assert qualifier in DISPOSITION_QUALIFIERS, (
+                f"{profile.label}: -map disposition selector not recognised: {value!r}"
+            )
+            mapped[DISPOSITION_QUALIFIERS[qualifier]] = True
+            continue
         assert letter in MAP_LETTERS, f"{profile.label}: -map selector not recognised: {value!r}"
         # "0:a?" selects every audio stream; "0:a:0" names exactly one.
         mapped[MAP_LETTERS[letter]] = ":" not in selector
@@ -193,6 +215,11 @@ def named_index_counts(profile: Profile) -> dict[str, int]:
         selector = value[2:].removesuffix("?")
         parts = selector.split(":")
         letter = parts[0]
+        if letter == "disp":
+            # A disposition selector carries a colon-separated qualifier but
+            # is blind, not index-named (see mapped_types) -- skipped here so
+            # it is never mistaken for a named index.
+            continue
         if letter in MAP_LETTERS and len(parts) > 1:
             kind = MAP_LETTERS[letter]
             counts[kind] = counts.get(kind, 0) + 1
@@ -885,9 +912,22 @@ class TestMp3Profile:
     def test_no_container_options(self):
         assert MP3.container_options == ()
 
-    def test_cheap_attempt_maps_audio_blindly(self):
+    def test_cheap_attempt_maps_audio_and_attached_pictures_blindly(self):
+        """Issue #77, `docs/specs/spec-stream-disposition.md`:
+        `-map 0:disp:attached_pic?` maps an embedded cover picture and nothing
+        else -- measured, it never matches a real video stream. `-c copy`
+        replaces `-c:a copy` deliberately: with no codec option covering the
+        picture, ffmpeg would re-encode it to the muxer's default instead of
+        copying it, an undeclared loss the mask would hide."""
         assert MP3.explicit_streams is False
-        assert MP3.cheap_attempt.options == ("-map", "0:a?", "-c:a", "copy")
+        assert MP3.cheap_attempt.options == (
+            "-map",
+            "0:a?",
+            "-map",
+            "0:disp:attached_pic?",
+            "-c",
+            "copy",
+        )
 
     def test_cheap_attempt_carries_the_standing_non_audio_note(self):
         assert MP3.cheap_attempt.notes == (
@@ -897,8 +937,8 @@ class TestMp3Profile:
     def test_cheap_attempt_is_declared_partial(self):
         assert MP3.partial_mapping is True
 
-    def test_declares_only_an_audio_rule(self):
-        assert set(MP3.rules) == {"audio"}
+    def test_declares_an_audio_rule_and_an_attached_pic_rule(self):
+        assert set(MP3.rules) == {"audio", "attached_pic"}
 
     def test_audio_rule_mask_and_fallback(self):
         rule = MP3.rules["audio"]
@@ -912,6 +952,22 @@ class TestMp3Profile:
         """The mp3 muxer, not this mapping, enforces it -- the muxer-enforced
         `stream_limit` exemption `docs/design/degradation-ladder.md` names."""
         assert MP3.rules["audio"].stream_limit == 1
+
+    def test_attached_pic_rule_accepts_any_codec_with_no_stream_limit(self):
+        """Accept-anything mask, the same mechanism MKV's attachment rule
+        uses: the decision resting on this rule is the disposition, not the
+        codec. No `stream_limit`: one `-map 0:disp:attached_pic?` carries
+        *every* picture a source holds (measured), so a limit of 1 would
+        report a carried picture as dropped (Prior decisions,
+        spec-stream-disposition.md)."""
+        rule = MP3.rules["attached_pic"]
+
+        assert "png" in rule.copy_mask
+        assert "mjpeg" in rule.copy_mask
+        assert len(rule.copy_mask) == 0
+        assert rule.accept_options == ("-c:v:{n}", "copy")
+        assert rule.fallback_options is None
+        assert rule.stream_limit is None
 
     def test_declares_the_pinned_last_resort(self):
         assert MP3.last_resort is not None
@@ -933,9 +989,17 @@ class TestFlacProfile:
     def test_no_container_options(self):
         assert FLAC.container_options == ()
 
-    def test_cheap_attempt_maps_audio_blindly(self):
+    def test_cheap_attempt_maps_audio_and_attached_pictures_blindly(self):
+        """Same disposition addition as MP3's -- see its comment."""
         assert FLAC.explicit_streams is False
-        assert FLAC.cheap_attempt.options == ("-map", "0:a?", "-c:a", "copy")
+        assert FLAC.cheap_attempt.options == (
+            "-map",
+            "0:a?",
+            "-map",
+            "0:disp:attached_pic?",
+            "-c",
+            "copy",
+        )
 
     def test_cheap_attempt_carries_the_standing_non_audio_note(self):
         assert FLAC.cheap_attempt.notes == (
@@ -945,8 +1009,8 @@ class TestFlacProfile:
     def test_cheap_attempt_is_declared_partial(self):
         assert FLAC.partial_mapping is True
 
-    def test_declares_only_an_audio_rule(self):
-        assert set(FLAC.rules) == {"audio"}
+    def test_declares_an_audio_rule_and_an_attached_pic_rule(self):
+        assert set(FLAC.rules) == {"audio", "attached_pic"}
 
     def test_audio_rule_mask_and_fallback(self):
         rule = FLAC.rules["audio"]
@@ -963,6 +1027,17 @@ class TestFlacProfile:
     def test_audio_rule_stream_limit_is_one(self):
         """The flac muxer, not this mapping, enforces it, same as mp3's."""
         assert FLAC.rules["audio"].stream_limit == 1
+
+    def test_attached_pic_rule_accepts_any_codec_with_no_stream_limit(self):
+        """Same accept-anything shape as MP3's -- see its comment."""
+        rule = FLAC.rules["attached_pic"]
+
+        assert "png" in rule.copy_mask
+        assert "mjpeg" in rule.copy_mask
+        assert len(rule.copy_mask) == 0
+        assert rule.accept_options == ("-c:v:{n}", "copy")
+        assert rule.fallback_options is None
+        assert rule.stream_limit is None
 
     def test_declares_the_pinned_last_resort(self):
         assert FLAC.last_resort is not None
@@ -984,9 +1059,23 @@ class TestM4aProfile:
     def test_no_container_options(self):
         assert M4A.container_options == ()
 
-    def test_cheap_attempt_maps_audio_blindly(self):
+    def test_cheap_attempt_maps_audio_and_attached_pictures_blindly(self):
+        """Same disposition addition as MP3's, and the same reason
+        "-c:a copy" becomes "-c copy" -- trap 1 in
+        `docs/specs/spec-stream-disposition.md`. Measured, this one matters
+        most: the ipod muxer's *default* video encoder is h264, which ipod
+        then rejects, so leaving "-c:a copy" in place would fail every
+        artwork-bearing `--to m4a` at rung 1 rather than silently
+        mis-encoding as mp3/flac would."""
         assert M4A.explicit_streams is False
-        assert M4A.cheap_attempt.options == ("-map", "0:a?", "-c:a", "copy")
+        assert M4A.cheap_attempt.options == (
+            "-map",
+            "0:a?",
+            "-map",
+            "0:disp:attached_pic?",
+            "-c",
+            "copy",
+        )
 
     def test_cheap_attempt_carries_the_standing_non_audio_note(self):
         assert M4A.cheap_attempt.notes == (
@@ -996,8 +1085,19 @@ class TestM4aProfile:
     def test_cheap_attempt_is_declared_partial(self):
         assert M4A.partial_mapping is True
 
-    def test_declares_only_an_audio_rule(self):
-        assert set(M4A.rules) == {"audio"}
+    def test_declares_an_audio_rule_and_an_attached_pic_rule(self):
+        assert set(M4A.rules) == {"audio", "attached_pic"}
+
+    def test_attached_pic_rule_accepts_any_codec_with_no_stream_limit(self):
+        """Same accept-anything shape as MP3's -- see its comment."""
+        rule = M4A.rules["attached_pic"]
+
+        assert "png" in rule.copy_mask
+        assert "mjpeg" in rule.copy_mask
+        assert len(rule.copy_mask) == 0
+        assert rule.accept_options == ("-c:v:{n}", "copy")
+        assert rule.fallback_options is None
+        assert rule.stream_limit is None
 
     def test_audio_rule_mask_and_fallback(self):
         """The mask is `{aac, alac}`, not `MP4_AUDIO_CODECS`: `.m4a` selects


### PR DESCRIPTION
## Summary

- `mp3`, `m4a` and `flac` now carry an embedded cover picture through a conversion instead of dropping it, by mapping only attached pictures (`-map 0:disp:attached_pic?`) rather than video in general.
- Each cheap attempt becomes exactly `flags("-map 0:a? -map 0:disp:attached_pic? -c copy")`, including the `-c:a copy` -> `-c copy` change (trap 1: without it, ffmpeg re-encodes an uncovered picture to the muxer's default -- h264 for ipod, which ipod then rejects, failing every artwork-bearing `--to m4a` at rung 1).
- Each profile gains an `attached_pic` rule reusing `_AcceptAnyCodec` (MKV's attachment mechanism) with no `stream_limit` (one such map carries every picture a source holds, so a limit of 1 would report a carried picture as dropped).
- `tests/test_profiles.py`'s `mapped_types`/`named_index_counts` learn the `0:disp:<qualifier>?` selector as the third, blind selector kind `docs/design/degradation-ladder.md` names. All three shipped invariants still pass over all 17 profiles.
- Cheap-attempt standing notes are left untouched deliberately -- their removal is issue #78, which depends on this one.

Spec: `docs/specs/spec-stream-disposition.md` (decision log entry added). Depends on #75 and #76 (both merged).

## Test plan

- [x] `scripts/verify.py` green (951 tests)
- [x] Real ffmpeg 9.0 smoke test with distinct-stem fixtures: artwork survives `--to mp3`, `--to m4a`, `--to flac`, including the selective-rung case (`art-flac.flac` -> `--to mp3`, which forces an audio re-encode)
- [x] `vid-h264.mkv` and `vid-mjpeg.mkv` -> `--to m4a`/`--to mp3`: audio only, real video dropped with a note
- [x] Two-picture source carried whole with no loss note, on both the cheap-attempt and selective-rung paths
- [x] `--to ogg`/`--to wav` over an artwork-bearing source unaffected
- [x] Second run over a converted tree: 0 converted, exit 0
- [x] Every new assertion proven non-vacuous by mutating a profile copy (dropping the `attached_pic` rule, or giving it `stream_limit=1`) in a scratch script outside the repo, and confirming the shipped invariants fail against the mutation

Closes #77