### PR TITLE
feat(jobs): the lossy-source advisory on flac's selective rung

### DIFF
--- a/converter/jobs.py
+++ b/converter/jobs.py
@@ -19,7 +19,7 @@ from dataclasses import replace
 from typing import TypeVar
 
 from converter.ffmpegtool import Stream
-from converter.profiles import Attempt, Profile
+from converter.profiles import LOSSY_CODECS, Attempt, Profile
 
 #: What a stream is counted under -- either its full :func:`_stream_key` or its
 #: bare type. :func:`_surplus` does the same arithmetic for both.
@@ -53,6 +53,24 @@ def _reencode_note(stream: Stream, target_codec: str) -> str:
     kind = stream.codec_type or "unknown"
     codec = stream.codec_name or "unknown"
     return f"{kind} stream {stream.index} ({codec}) re-encoded to {target_codec}"
+
+
+def _lossy_source_note(stream: Stream, profile: Profile) -> str:
+    """The lossy-source advisory (spec-lossy-source-notes.md, `LOSSY_CODECS`).
+
+    Unlike :func:`_drop_note` and :func:`_reencode_note`, this reports no
+    decision *this* conversion made: the stream is carried faithfully, exactly
+    as the rung already planned. It answers a different question -- what the
+    source had already given up before this run ever started -- which is why
+    ``docs/constitution.md`` names it an advisory rather than a degradation
+    note (`docs/design/stream-decision.md`'s carve-out).
+    """
+    kind = stream.codec_type or "unknown"
+    codec = stream.codec_name or "unknown"
+    return (
+        f"{kind} stream {stream.index} ({codec}) was already lossy before this file "
+        f"reached {profile.label}; {profile.label} cannot restore what {codec} discarded"
+    )
 
 
 def _room_reason(profile: Profile, stream_type: str, limit: int) -> str:
@@ -225,6 +243,43 @@ def _build_selective(profile: Profile, streams: Sequence[Stream]) -> Attempt | N
     return Attempt("selective", (*maps, *codecs), tuple(notes))
 
 
+#: The only target this phase's advisory covers (Prior decisions,
+#: spec-lossy-source-notes.md, "Only flac carries the advisory"). The other
+#: four lossless targets (`wav`, `png`, `tiff`, `bmp`) always succeed their
+#: cheap attempt, so the only place they could carry a codec-level statement is
+#: the success-side verification -- deliberately, and unchanged, off limits to
+#: any codec claim (:func:`verify_success`, issue #18).
+_LOSSY_SOURCE_ADVISORY_TARGETS = frozenset({"flac"})
+
+
+def _lossy_source_notes(profile: Profile, streams: Sequence[Stream]) -> tuple[str, ...]:
+    """The lossy-source advisory pass, run only after the selective rung exists.
+
+    Appended by :func:`retries`, never folded into :func:`_build_selective`'s own
+    ``notes`` list: that list feeds the short-circuit
+    ``if profile.explicit_streams and not notes: return None`` that keeps the
+    rung skipped for `wav` today. An advisory added inside the plan would give
+    `wav` a non-empty ``notes`` list and resurrect a rung the ladder
+    deliberately never builds for it -- the trap this phase's issue names first.
+
+    Recomputes which streams the rung actually carries with the same structural
+    check :func:`_build_selective` uses (:func:`_structural_drop`), rather than
+    reusing that pass's own accounting, so this function can stay entirely
+    outside the plan it describes.
+    """
+    if profile.name not in _LOSSY_SOURCE_ADVISORY_TARGETS:
+        return ()
+    notes: list[str] = []
+    counts: dict[str, int] = {}
+    for stream in streams:
+        if _structural_drop(profile, stream, counts) is not None:
+            continue
+        counts[stream.codec_type] = counts.get(stream.codec_type, 0) + 1
+        if stream.codec_name in LOSSY_CODECS:
+            notes.append(_lossy_source_note(stream, profile))
+    return tuple(notes)
+
+
 def first_attempt(profile: Profile) -> Attempt:
     """Rung 1 of degradation-ladder.md: *profile*'s own cheap attempt."""
     return _with_container_options(profile.cheap_attempt, profile)
@@ -235,6 +290,9 @@ def retries(profile: Profile, streams: Sequence[Stream]) -> list[Attempt]:
     attempts: list[Attempt] = []
     selective = _build_selective(profile, streams)
     if selective is not None:
+        advisories = _lossy_source_notes(profile, streams)
+        if advisories:
+            selective = replace(selective, notes=(*selective.notes, *advisories))
         attempts.append(_with_container_options(selective, profile))
     if profile.last_resort is not None:
         attempts.append(_with_container_options(profile.last_resort, profile))

--- a/docs/specs/spec-lossy-source-notes.md
+++ b/docs/specs/spec-lossy-source-notes.md
@@ -403,3 +403,29 @@ New-Item -ItemType Directory -Force in
   the ADPCM paragraph already demonstrates the shape of, not an
   undiscovered instance of the round-3 reachability bug. No membership
   change; comment only.
+- 2026-08-27 (issue #88): the advisory itself landed in `converter/jobs.py`,
+  scoped to `flac` alone as the gate resolved. Implementation note beyond what
+  the Prior decisions table already records: the advisory is computed by a new
+  `_lossy_source_notes` pass, called from `retries()` only after
+  `_build_selective` has already returned a non-`None` attempt, and appended
+  onto that attempt's existing `notes` tuple via `dataclasses.replace` --
+  never folded into `_build_selective`'s own `notes` list, which the
+  `if profile.explicit_streams and not notes: return None` short-circuit reads
+  to decide whether the rung exists at all. Proven by a scratch simulation
+  (not committed) that folding the advisory inside the plan does resurrect
+  `wav`'s skipped rung for an MP3 source, while the shipped implementation
+  leaves `jobs.retries(WAV, ...)` at `[]` exactly as before. The pass is gated
+  by a private `_LOSSY_SOURCE_ADVISORY_TARGETS = frozenset({"flac"})` rather
+  than the registry-wide lossless criterion `lossless_target_names` computes
+  in `tests/test_profiles.py` -- the gate's decision was `flac` only, not
+  every profile satisfying that criterion, and `converter/profiles.py` is
+  issue #77's concurrent territory for this issue, so no field was added to
+  `Profile` to carry the restriction. Tests landed in `tests/test_batch.py`
+  (`TestLossySourceAdvisory`), not `tests/test_argv.py`, per this issue's file
+  ownership; `tests/test_argv.py`'s existing pinned `flac`/`mp3`/`m4a`/`wav`
+  cases were re-run unmodified and still pass, since none of their fixture
+  streams carry a `LOSSY_CODECS` member into `flac`. The two foundation-doc
+  amendments the spec's In-scope list also names (`docs/constitution.md`,
+  `docs/design/stream-decision.md`) are issue #89's scope, not this one's --
+  confirmed against the actual issue text, which depends on #88 and owns
+  exactly those two files -- so they are left untouched here.

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -4,10 +4,25 @@ from pathlib import Path
 
 import pytest
 
-from converter import batch
+from converter import batch, jobs
 from converter.batch import Outcome, Result, Task, convert_one, run_batch, summarise
 from converter.ffmpegtool import CommandResult, ProbeError, Stream, Tools
-from converter.profiles import FLAC, MKV, MOV, MP4, WAV, WEBM, Attempt, Profile, StreamRule, flags
+from converter.profiles import (
+    BMP,
+    FLAC,
+    MKV,
+    MOV,
+    MP3,
+    MP4,
+    PNG,
+    TIFF,
+    WAV,
+    WEBM,
+    Attempt,
+    Profile,
+    StreamRule,
+    flags,
+)
 
 TOOLS = Tools(ffmpeg="ffmpeg", ffprobe="ffprobe")
 
@@ -807,6 +822,110 @@ class TestRunBatch:
             run_batch(MP4, tasks, TOOLS, jobs=1, progress=False)
 
         assert len(calls) == 3
+
+
+class TestLossySourceAdvisory:
+    """Issue #88, `docs/specs/spec-lossy-source-notes.md`: the advisory that
+    fires when a lossy source reaches FLAC's selective (failure-side) rung --
+    "your FLAC came from a 128 kbit/s MP3." Scoped to `jobs.retries` /
+    `convert_one` behaviour; profile definitions and `test_argv.py` are #77's
+    concurrent territory and stay untouched.
+    """
+
+    def test_lossy_source_into_flac_names_index_and_codec(self):
+        """The motivating case: an MP3 fails FLAC's `-c:a copy` cheap attempt,
+        lands on the selective rung, and today (pre-#88) that rung carries no
+        note at all -- verified unaffected for `test_argv.py`'s own pinned
+        cases, none of which name a lossy codec.
+        """
+        streams = [Stream(0, "audio", "mp3")]
+
+        selective = jobs.retries(FLAC, streams)[0]
+
+        assert selective.options == ("-map", "0:0", "-c:a", "flac")
+        assert selective.notes == (
+            "audio stream 0 (mp3) was already lossy before this file reached "
+            "FLAC; FLAC cannot restore what mp3 discarded",
+        )
+
+    def test_lossless_alac_into_flac_carries_no_advisory(self):
+        """The negative that actually exercises the guard (spec Verification):
+        ALAC fails FLAC's `-c:a copy` cheap attempt exactly like an MP3 does and
+        reaches the identical selective rung, so only `LOSSY_CODECS` membership
+        -- not merely "reached the rung" -- decides whether the advisory fires.
+        """
+        streams = [Stream(0, "audio", "alac")]
+
+        selective = jobs.retries(FLAC, streams)[0]
+
+        assert selective.notes == ()
+
+    def test_flac_into_flac_is_a_rung_1_control_and_never_reaches_the_rung(self):
+        """flac-into-flac copies and wins at rung 1 (`first_attempt`); it never
+        reaches the selective rung the advisory lives on, so it is kept only as
+        the control the spec's Verification section names, proving nothing
+        about the guard on its own.
+        """
+        assert jobs.first_attempt(FLAC).notes == (
+            "non-audio streams, including cover art, are not carried into FLAC",
+        )
+
+    def test_lossy_source_into_a_lossy_target_keeps_the_ordinary_note_only(self):
+        """Lossy-to-lossy is out of scope by decision: the engine's own
+        re-encode note is the honest report there, and the advisory -- scoped
+        to `flac` alone -- must not add a second line.
+        """
+        streams = [Stream(0, "audio", "opus")]
+
+        selective = jobs.retries(MP3, streams)[0]
+
+        assert selective.notes == ("audio stream 0 (opus) re-encoded to mp3",)
+
+    def test_wav_selective_rung_stays_skipped_trap_1(self):
+        """Trap 1, named first in the issue: folding the advisory *inside*
+        `_build_selective`'s plan would give its notes list a non-empty entry
+        for a lossy source and defeat
+        ``if profile.explicit_streams and not notes: return None`` --
+        resurrecting the rung WAV's `explicit_streams=True` deliberately skips
+        today. Appending the advisory only in `retries`, after that check has
+        already run, keeps this `[]` exactly as it was before #88.
+        """
+        assert jobs.retries(WAV, [Stream(0, "audio", "mp3")]) == []
+
+    @pytest.mark.parametrize("profile", [PNG, TIFF, BMP], ids=lambda p: p.name)
+    def test_the_other_lossless_targets_stay_silent(self, profile):
+        """The accepted inconsistency (spec Prior decisions, resolved at the
+        gate): only `flac` carries the advisory. `wav`, `png`, `tiff` and `bmp`
+        always succeed their cheap attempt in practice, but even called
+        directly their selective rung must still report nothing for a lossy
+        video source -- pinned per profile so a change scoped too widely to
+        `jobs.py` cannot silently start naming any of the other four.
+        """
+        streams = [Stream(0, "video", "mjpeg")]
+
+        selective = jobs.retries(profile, streams)[0]
+
+        assert selective.notes == ()
+
+    def test_end_to_end_advisory_and_probe_count(self, tmp_path, fake_ffmpeg, monkeypatch):
+        """Full `convert_one` path, not just `jobs.retries` in isolation: the
+        advisory must survive into `Result.notes`, and
+        `docs/constitution.md`'s probe budget -- at most one probe on this
+        failure-then-succeed path -- must stay exactly what it was before #88.
+        The advisory reads only the stream list `retries` already receives, so
+        it must not be the thing that adds a second probe.
+        """
+        task = make_task(tmp_path)
+        task.dst.parent.mkdir(parents=True)
+        fake_ffmpeg.exit_codes = [1, 0]
+        fake_ffmpeg.streams = [Stream(0, "audio", "mp3")]
+        probes = spy_on_probe(monkeypatch, [Stream(0, "audio", "mp3")])
+
+        result = convert_one(FLAC, task, TOOLS, overwrite=False)
+
+        assert result.outcome is Outcome.CONVERTED
+        assert any("was already lossy" in note for note in result.notes)
+        assert probes == [task.src]
 
 
 class TestSummarise:


### PR DESCRIPTION
## Summary
- Add the lossy-source advisory (spec-lossy-source-notes.md) to the FLAC selective (failure-side) rung: converting an already-lossy source into FLAC now names the stream index and source codec, e.g. `audio stream 0 (mp3) was already lossy before this file reached FLAC; FLAC cannot restore what mp3 discarded`.
- Scoped to `flac` alone (the gate's resolved decision). Computed by a new `converter/jobs.py::_lossy_source_notes` pass, invoked from `retries()` only *after* `_build_selective` has already decided whether the rung exists, and appended onto that attempt's notes — never folded into the plan itself, which would resurrect `wav`'s deliberately-skipped rung (trap 1 in the issue).
- No advisory for a lossless source reaching the rung (ALAC into flac), none for a lossy target (ordinary re-encode note only), and `wav`/`png`/`tiff`/`bmp` stay silent — the accepted inconsistency the spec pins.
- Probe count per file and the success-side verification's refusal of codec-level statements are both unchanged.
- Decision-log entry added to `docs/specs/spec-lossy-source-notes.md`.

Out of scope for this PR (issue #89, which depends on this one): the `docs/constitution.md` degradation-note-vs-advisory line and the `docs/design/stream-decision.md` carve-out sentence.

## Test plan
- [x] `.venv\Scripts\python.exe scripts\verify.py` green (956 tests: 947 baseline + 9 new in `tests/test_batch.py::TestLossySourceAdvisory`)
- [x] `tests/test_argv.py` (owned by the concurrent #77 work) re-run unmodified and still green — no regression
- [x] Trap-1 evidence: a scratch simulation proved folding the advisory inside `_build_selective`'s plan resurrects `wav`'s skipped selective rung; the shipped implementation keeps `jobs.retries(WAV, [mp3 stream]) == []`
- [x] Mutation testing: 4 targeted mutations (drop the profile-name guard, fold the advisory inside the plan, ignore `LOSSY_CODECS` membership, strip the note wording) each made the relevant new assertion(s) fail, then reverted
- [x] Real ffmpeg 9.0 smoke test in a temp directory: mp3→flac prints the advisory naming stream 0/mp3 on a valid FLAC output; alac→flac and flac→flac print none; mp3→mp3, opus→mp3, opus→opus keep their ordinary re-encode/standing notes only; mp3→wav and jpg→png stay silent; a second run over a converted tree reports `0 converted`, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pdnJyntsFJyawGBSGj4cV