### PR TITLE
fix(jobs): don't advise on cover art the flac rung only copies

### DIFF
--- a/converter/jobs.py
+++ b/converter/jobs.py
@@ -266,6 +266,15 @@ def _lossy_source_notes(profile: Profile, streams: Sequence[Stream]) -> tuple[st
     check :func:`_build_selective` uses (:func:`_structural_drop`), rather than
     reusing that pass's own accounting, so this function can stay entirely
     outside the plan it describes.
+
+    A kept stream still needs its matched rule checked before it qualifies:
+    FLAC's `attached_pic` rule (spec-stream-disposition.md, issue #77) accepts
+    any codec and never re-encodes, so a copied-through JPEG cover image is
+    carried byte-for-byte -- nothing was discarded and nothing the target
+    "cannot restore". Only a stream that actually takes the *fallback* branch
+    (`stream-decision.md`'s ENC node) is written into the target's own codec,
+    which is the only case this advisory is about; a stream the rule copies
+    verbatim, or would drop for a codec reason (D3), is excluded the same way.
     """
     if profile.name not in _LOSSY_SOURCE_ADVISORY_TARGETS:
         return ()
@@ -275,7 +284,11 @@ def _lossy_source_notes(profile: Profile, streams: Sequence[Stream]) -> tuple[st
         if _structural_drop(profile, stream, counts) is not None:
             continue
         counts[stream.codec_type] = counts.get(stream.codec_type, 0) + 1
-        if stream.codec_name in LOSSY_CODECS:
+        rule = profile.rules[_rule_key(profile, stream)]
+        was_reencoded = (
+            stream.codec_name not in rule.copy_mask and rule.fallback_options is not None
+        )
+        if was_reencoded and stream.codec_name in LOSSY_CODECS:
             notes.append(_lossy_source_note(stream, profile))
     return tuple(notes)
 

--- a/docs/specs/spec-lossy-source-notes.md
+++ b/docs/specs/spec-lossy-source-notes.md
@@ -429,3 +429,29 @@ New-Item -ItemType Directory -Force in
   `docs/design/stream-decision.md`) are issue #89's scope, not this one's --
   confirmed against the actual issue text, which depends on #88 and owns
   exactly those two files -- so they are left untouched here.
+- 2026-08-27 (fix, post-#88 merge): issue #77's `feat(profiles): carry cover
+  art into mp3, m4a and flac` (#95) landed in `main` between #88's review and
+  its merge, giving `flac` an `attached_pic` rule whose copy mask
+  (`_AcceptAnyCodec`) accepts every codec and declares no fallback, so a cover
+  picture is always copied byte-for-byte, never re-encoded. `_lossy_source_notes`
+  had gated only on `_structural_drop` plus `LOSSY_CODECS` membership, which
+  was sound for the audio rule (its copy mask is `{"flac"}` alone, so reaching
+  a `LOSSY_CODECS` member there was only possible via the re-encode branch) but
+  not for the new `attached_pic` rule, where a `LOSSY_CODECS` member (`mjpeg`
+  cover art is the common case) reaches the check via the copy branch instead.
+  Measured against real ffmpeg 9.0: an mp3-with-cover-art source produced
+  `"video stream 1 (mjpeg) was already lossy before this file reached FLAC;
+  FLAC cannot restore what mjpeg discarded"` for a stream copied unchanged --
+  a false claim, since nothing was discarded. Exactly the "latent divergence"
+  the review round on #88 flagged as "not reachable today"; it became reachable
+  the moment #95 merged first. Fixed by checking the *matched rule*, not just
+  structural survival: a stream now qualifies only when
+  `stream.codec_name not in rule.copy_mask and rule.fallback_options is not
+  None` -- i.e. it actually took the fallback/re-encode branch
+  (`stream-decision.md`'s ENC node) -- mirroring `_decide_stream`'s own branch
+  logic exactly, so a copied-through stream (or a codec-level D3 drop, not
+  currently reachable for `flac` but excluded on the same footing) can never
+  draw the advisory. Regression test added:
+  `TestLossySourceAdvisory.test_copied_through_cover_art_carries_no_advisory`.
+  Landed as a fast-follow PR rather than amending #96, since #96 was already
+  squash-merged before the gap was found.

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -907,6 +907,40 @@ class TestLossySourceAdvisory:
 
         assert selective.notes == ()
 
+    def test_copied_through_cover_art_carries_no_advisory(self):
+        """Regression: `main` gained FLAC's `attached_pic` rule (issue #77,
+        `docs/specs/spec-stream-disposition.md`) between this issue's review
+        and its merge. That rule's copy mask (`_AcceptAnyCodec`) accepts every
+        codec and the rule declares no fallback, so a cover picture is always
+        copied byte-for-byte, never re-encoded into FLAC's own codec -- unlike
+        the audio rule, where reaching `LOSSY_CODECS` membership implies the
+        fallback branch ran. A common `mjpeg` cover image is a `LOSSY_CODECS`
+        member, so without this guard the copy-through would wrongly read as
+        "FLAC cannot restore what mjpeg discarded" for a stream nothing was
+        discarded from.
+        """
+        streams = [
+            Stream(0, "audio", "mp3"),
+            Stream(1, "video", "mjpeg", attached_pic=True),
+        ]
+
+        selective = jobs.retries(FLAC, streams)[0]
+
+        assert selective.options == (
+            "-map",
+            "0:0",
+            "-map",
+            "0:1",
+            "-c:a",
+            "flac",
+            "-c:v:0",
+            "copy",
+        )
+        assert selective.notes == (
+            "audio stream 0 (mp3) was already lossy before this file reached "
+            "FLAC; FLAC cannot restore what mp3 discarded",
+        )
+
     def test_end_to_end_advisory_and_probe_count(self, tmp_path, fake_ffmpeg, monkeypatch):
         """Full `convert_one` path, not just `jobs.retries` in isolation: the
         advisory must survive into `Result.notes`, and


### PR DESCRIPTION
## Summary
- Fast-follow to #96 (issue #88, the lossy-source advisory). #95 (issue #77, "carry cover art into mp3, m4a and flac") landed in `main` between #96's review and its squash-merge, giving FLAC an `attached_pic` rule (`_AcceptAnyCodec` copy mask, no fallback) that always copies a cover picture byte-for-byte, never re-encodes it.
- `_lossy_source_notes` (added in #96) checked only "not structurally dropped" plus `LOSSY_CODECS` membership. That was sound for FLAC's audio rule (copy mask is `{"flac"}` alone, so a `LOSSY_CODECS` member there could only arrive via the re-encode branch) but not for the new `attached_pic` rule, where a common `mjpeg` cover image reaches the same membership check via the *copy* branch instead.
- Measured against real ffmpeg 9.0: an mp3-with-cover-art source produced a **false** `"video stream 1 (mjpeg) was already lossy before this file reached FLAC; FLAC cannot restore what mjpeg discarded"` for a stream that was carried through completely unchanged.
- Fix: gate the advisory on the matched rule actually taking the fallback/re-encode branch (`stream.codec_name not in rule.copy_mask and rule.fallback_options is not None`), mirroring `_decide_stream`'s own MASK/ENC branch logic exactly, instead of inferring it from "kept + lossy codec name".
- Decision-log entry added to `docs/specs/spec-lossy-source-notes.md` explaining the gap and the fix.

## Test plan
- [x] `.venv\Scripts\python.exe scripts\verify.py` green (966 tests)
- [x] New regression test `TestLossySourceAdvisory::test_copied_through_cover_art_carries_no_advisory` in `tests/test_batch.py`, proven to catch the original bug by reverting the fix in a scratch mutation and confirming the test fails, then restoring
- [x] Real ffmpeg 9.0 smoke test: an mp3 (audio) + mjpeg (attached_pic cover art) source converted `--to flac` now prints only the audio-stream advisory naming stream 0/mp3; the cover art is silent and the output FLAC correctly holds both the re-encoded audio and the untouched copied picture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pdnJyntsFJyawGBSGj4cV