### PR TITLE
refactor(profiles): retire the redundant cheap-attempt standing notes

### DIFF
--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -639,18 +639,16 @@ MP3 = Profile(
     # muxer's default instead of copying it, an undeclared loss the mask would
     # hide; "-c copy" behaves identically to "-c:a copy" for the audio stream
     # since the map now selects only audio and pictures.
+    # Issue #78, docs/specs/spec-stream-disposition.md: the standing note this
+    # cheap attempt used to carry alongside the map is retired.
+    # partial_mapping's success-side verification (jobs.verify_success) already
+    # names every dropped stream -- index, codec and reason -- so the blanket
+    # line was pure duplication for a plain video/subtitle drop, and for cover
+    # art specifically it had already gone false the moment artwork started
+    # being carried (issue #77).
     cheap_attempt=Attempt(
         label="remux",
         options=flags("-map 0:a? -map 0:disp:attached_pic? -c copy"),
-        # partial_mapping's success-side verification (docs/design/degradation-
-        # ladder.md) already names a dropped stream precisely when the ladder
-        # actually drops one; this line is the standing note the audio-formats
-        # spec's gate chose to keep alongside it -- always true, so it costs
-        # nothing to state even for the many files that had nothing to lose.
-        # (Now stale for cover art specifically -- issue #78, a dependent of
-        # this one, retires it once the verifier's per-stream note is the only
-        # place that claim needs to live.)
-        notes=("non-audio streams, including cover art, are not carried into MP3",),
     ),
     explicit_streams=False,
     # "-map 0:a?" selects no video, subtitle or attachment stream, so any of
@@ -703,11 +701,10 @@ FLAC = Profile(
     #
     # Same disposition addition as MP3's, and the same "-c copy" reasoning --
     # see its comment (docs/specs/spec-stream-disposition.md).
+    # Standing note retired -- issue #78, see MP3's identical comment.
     cheap_attempt=Attempt(
         label="remux",
         options=flags("-map 0:a? -map 0:disp:attached_pic? -c copy"),
-        # Stale for cover art -- see MP3's identical note and its comment.
-        notes=("non-audio streams, including cover art, are not carried into FLAC",),
     ),
     explicit_streams=False,
     partial_mapping=True,
@@ -755,11 +752,10 @@ M4A = Profile(
     # the ipod muxer's *default* video encoder is h264, which ipod then
     # rejects, so leaving "-c:a copy" in place would fail every artwork-bearing
     # "--to m4a" at rung 1 rather than silently mis-encoding as mp3/flac would.
+    # Standing note retired -- issue #78, see MP3's identical comment.
     cheap_attempt=Attempt(
         label="remux",
         options=flags("-map 0:a? -map 0:disp:attached_pic? -c copy"),
-        # Stale for cover art -- see MP3's identical note and its comment.
-        notes=("non-audio streams, including cover art, are not carried into M4A",),
     ),
     explicit_streams=False,
     partial_mapping=True,
@@ -807,10 +803,15 @@ OGG = Profile(
     # through as a whole video file renamed ".ogg" -- the same defect that
     # rules m4a out. The cheap attempt maps audio only, so the two spellings
     # behave identically; "-c copy" is what the spec pins.
+    # Issue #78, docs/specs/spec-stream-disposition.md: the standing note this
+    # cheap attempt used to carry alongside the map is retired -- ogg gains no
+    # artwork rule (Out of scope), so a cover-art stream here is an ordinary
+    # video stream and partial_mapping's success-side verification
+    # (jobs.verify_success) already names its drop per stream, the same as any
+    # other unsupported type. The blanket line was pure duplication.
     cheap_attempt=Attempt(
         label="remux",
         options=flags("-map 0:a? -c copy"),
-        notes=("non-audio streams, including cover art, are not carried into OGG",),
     ),
     explicit_streams=False,
     partial_mapping=True,
@@ -849,10 +850,10 @@ OPUS = Profile(
     # every already-Opus file through libopus would be a real generation loss
     # on the common case to prevent a mislabel reachable only from an Ogg
     # source.
+    # Standing note retired -- issue #78, see OGG's identical comment.
     cheap_attempt=Attempt(
         label="remux",
         options=flags("-map 0:a? -c copy"),
-        notes=("non-audio streams, including cover art, are not carried into OPUS",),
     ),
     explicit_streams=False,
     partial_mapping=True,

--- a/docs/specs/spec-stream-disposition.md
+++ b/docs/specs/spec-stream-disposition.md
@@ -386,3 +386,36 @@ New-Item -ItemType Directory -Force in
   `attached_pic` rule, or giving it `stream_limit=1`) and confirming both the
   scratch check and the shipped `tests/test_profiles.py` invariants fail
   against the mutation.
+- 2026-08-27 (issue #78): the cheap-attempt standing note is retired from all
+  five audio profiles that carried one -- `mp3`, `flac`, `m4a`, `ogg`, `opus`
+  -- leaving `Attempt(label="remux", options=...)` with no `notes` argument at
+  all rather than an empty tuple, the same shape a profile that never carried
+  one already had. Nothing named by a removed note is now unsaid: for `mp3`,
+  `m4a` and `flac`, `jobs.verify_success` already named a real drop (a video,
+  subtitle or attachment stream) per stream via `_structural_drop`'s "not
+  supported by `<LABEL>`" branch before this issue touched anything, and the
+  note's cover-art half had already gone false the moment #77 started
+  carrying artwork -- so removing it deletes a statement that was either
+  redundant or already wrong, never one still true and unreplaced. `ogg` and
+  `opus` gain no `attached_pic` rule (Out of scope), so a cover-art stream
+  there resolves to the plain `video` rule same as any other video stream and
+  is dropped with the identical per-stream note -- proven by new tests
+  (`TestOggJob`/`TestOpusJob::test_cover_art_is_dropped_with_a_note_same_as_any_other_video_stream`)
+  rather than assumed. `last_resort` notes on all five profiles are untouched
+  and pinned unchanged (`tests/test_profiles.py::TestStandingNoteRetirement`),
+  since that rung is never verified and its note is the only place its claim
+  exists. `ogg`, `opus` and `wav` argv is byte-for-byte unchanged -- `wav`
+  needed no edit at all, since it carried no standing note to begin with.
+  Verified against real ffmpeg 9.0 with distinct-stem fixtures: a plain
+  matching-codec source into its own target (`tone-mp3.mp3 --to mp3`, and the
+  `flac`/`m4a`/`ogg`/`opus` equivalents) converts and prints no note at all --
+  the change a user notices first; artwork still survives the cheap-attempt
+  and selective-rung paths into `mp3`/`m4a`/`flac` with no false drop; a real
+  h264 and a real mjpeg video stream are still dropped with a note into `mp3`
+  and `m4a`; an artwork-bearing source into `ogg`, `opus` and `wav` still
+  drops the picture with a per-stream note; a second run over a converted tree
+  reports 0 converted, exit 0. Every new or changed assertion was proven
+  non-vacuous by mutating a profile copy in a scratch script outside the repo
+  (restoring the removed standing note, adding an `attached_pic` rule to
+  `ogg`, emptying a `last_resort` note) and confirming the same assertion the
+  shipped test uses fails against each mutation.

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -171,7 +171,9 @@ class TestMp3Job:
     compatible single-stream source still gets a selective rung -- the same
     shape MP4 has (`TestMp4Retries.test_selective_copies_compatible_streams`)."""
 
-    def test_first_attempt_carries_the_standing_note(self):
+    def test_first_attempt_carries_no_standing_note(self):
+        """Issue #78: the standing note is retired -- a source with nothing
+        to lose now prints nothing at all, the change a user notices first."""
         attempt = jobs.first_attempt(MP3)
 
         assert attempt.options == (
@@ -182,9 +184,7 @@ class TestMp3Job:
             "-c",
             "copy",
         )
-        assert attempt.notes == (
-            "non-audio streams, including cover art, are not carried into MP3",
-        )
+        assert attempt.notes == ()
 
     def test_single_mp3_stream_reaches_a_selective_copy(self):
         streams = [Stream(0, "audio", "mp3")]
@@ -258,6 +258,16 @@ class TestMp3Job:
 
         assert jobs.verify_success(MP3, streams) == ()
 
+    def test_a_source_with_nothing_to_lose_prints_no_note_at_all(self):
+        """Acceptance, issue #78 -- the change a user notices first. The
+        retired cheap-attempt note is gone, and `verify_success` predicts
+        nothing for an ordinary matching-codec source; together (`batch.py`'s
+        `attempt.notes + extra`) that is what a caller reports."""
+        streams = [Stream(0, "audio", "mp3")]
+
+        assert jobs.first_attempt(MP3).notes == ()
+        assert jobs.verify_success(MP3, streams) == ()
+
     def test_last_resort_notes_are_pinned(self):
         """The explicit-index last resort cannot name a per-stream drop itself
         (unlike the selective rung), so what it gives up has to be its own
@@ -277,7 +287,8 @@ class TestFlacJob:
     as `MP3`, but flac's fallback carries no `fallback_name`, so a re-encode
     into flac itself is never reported as a loss."""
 
-    def test_first_attempt_carries_the_standing_note(self):
+    def test_first_attempt_carries_no_standing_note(self):
+        """Issue #78 -- see `TestMp3Job`'s equivalent for why."""
         attempt = jobs.first_attempt(FLAC)
 
         assert attempt.options == (
@@ -288,9 +299,7 @@ class TestFlacJob:
             "-c",
             "copy",
         )
-        assert attempt.notes == (
-            "non-audio streams, including cover art, are not carried into FLAC",
-        )
+        assert attempt.notes == ()
 
     def test_single_flac_stream_reaches_a_selective_copy(self):
         streams = [Stream(0, "audio", "flac")]
@@ -353,6 +362,13 @@ class TestFlacJob:
 
         assert jobs.verify_success(FLAC, streams) == ()
 
+    def test_a_source_with_nothing_to_lose_prints_no_note_at_all(self):
+        """Acceptance, issue #78 -- see `TestMp3Job`'s equivalent for why."""
+        streams = [Stream(0, "audio", "flac")]
+
+        assert jobs.first_attempt(FLAC).notes == ()
+        assert jobs.verify_success(FLAC, streams) == ()
+
     def test_last_resort_notes_are_pinned(self):
         """Unlike its `StreamRule.fallback_name=None`, the last resort still
         needs its own note: it is an explicit-index attempt, so it cannot name
@@ -372,7 +388,8 @@ class TestM4aJob:
     as `MP3`/`FLAC`, but `m4a` declares no `stream_limit` -- the ipod muxer
     holds several audio streams, so every one the source has is carried."""
 
-    def test_first_attempt_carries_the_standing_note(self):
+    def test_first_attempt_carries_no_standing_note(self):
+        """Issue #78 -- see `TestMp3Job`'s equivalent for why."""
         attempt = jobs.first_attempt(M4A)
 
         assert attempt.options == (
@@ -383,9 +400,7 @@ class TestM4aJob:
             "-c",
             "copy",
         )
-        assert attempt.notes == (
-            "non-audio streams, including cover art, are not carried into M4A",
-        )
+        assert attempt.notes == ()
 
     def test_single_matching_stream_reaches_a_selective_copy(self):
         streams = [Stream(0, "audio", "aac")]
@@ -482,6 +497,13 @@ class TestM4aJob:
 
         assert jobs.verify_success(M4A, streams) == ()
 
+    def test_a_source_with_nothing_to_lose_prints_no_note_at_all(self):
+        """Acceptance, issue #78 -- see `TestMp3Job`'s equivalent for why."""
+        streams = [Stream(0, "audio", "aac")]
+
+        assert jobs.first_attempt(M4A).notes == ()
+        assert jobs.verify_success(M4A, streams) == ()
+
     def test_last_resort_notes_are_pinned(self):
         reencode = jobs.retries(M4A, [])[-1]
 
@@ -498,13 +520,14 @@ class TestOggJob:
     with a wider copy mask and no stream limit either -- the ogg muxer holds
     several audio streams too."""
 
-    def test_first_attempt_carries_the_standing_note(self):
+    def test_first_attempt_carries_no_standing_note(self):
+        """Issue #78: argv is byte-for-byte unchanged -- ogg gains no
+        disposition map, since it gains no artwork rule -- only the note is
+        gone."""
         attempt = jobs.first_attempt(OGG)
 
         assert attempt.options == ("-map", "0:a?", "-c", "copy")
-        assert attempt.notes == (
-            "non-audio streams, including cover art, are not carried into OGG",
-        )
+        assert attempt.notes == ()
 
     def test_single_matching_stream_reaches_a_selective_copy(self):
         streams = [Stream(0, "audio", "vorbis")]
@@ -573,6 +596,28 @@ class TestOggJob:
 
         assert selective.notes == ("video stream 1 (h264) dropped: not supported by OGG",)
 
+    def test_cover_art_is_dropped_with_a_note_same_as_any_other_video_stream(self):
+        """Issue #78: ogg gains no `attached_pic` rule (Out of scope), so a
+        disposition-marked stream is still an ordinary video stream to this
+        profile -- `verify_success` names its drop exactly as the retired
+        standing note used to claim, per stream rather than as a blanket
+        line."""
+        streams = [
+            Stream(0, "audio", "vorbis"),
+            Stream(1, "video", "mjpeg", attached_pic=True),
+        ]
+
+        notes = jobs.verify_success(OGG, streams)
+
+        assert notes == ("video stream 1 (mjpeg) dropped: not supported by OGG",)
+
+    def test_a_source_with_nothing_to_lose_prints_no_note_at_all(self):
+        """Acceptance, issue #78 -- see `TestMp3Job`'s equivalent for why."""
+        streams = [Stream(0, "audio", "vorbis")]
+
+        assert jobs.first_attempt(OGG).notes == ()
+        assert jobs.verify_success(OGG, streams) == ()
+
     def test_last_resort_notes_are_pinned(self):
         reencode = jobs.retries(OGG, [])[-1]
 
@@ -590,13 +635,13 @@ class TestOpusJob:
     decisions) -- the mask below governs only the failure-side selective rung,
     where a Vorbis stream is re-encoded rather than copied."""
 
-    def test_first_attempt_carries_the_standing_note(self):
+    def test_first_attempt_carries_no_standing_note(self):
+        """Issue #78: argv is byte-for-byte unchanged -- see `TestOggJob`'s
+        equivalent for why."""
         attempt = jobs.first_attempt(OPUS)
 
         assert attempt.options == ("-map", "0:a?", "-c", "copy")
-        assert attempt.notes == (
-            "non-audio streams, including cover art, are not carried into OPUS",
-        )
+        assert attempt.notes == ()
 
     def test_single_matching_stream_reaches_a_selective_copy(self):
         streams = [Stream(0, "audio", "opus")]
@@ -668,6 +713,24 @@ class TestOpusJob:
         selective = jobs.retries(OPUS, streams)[0]
 
         assert selective.notes == ("video stream 1 (h264) dropped: not supported by OPUS",)
+
+    def test_cover_art_is_dropped_with_a_note_same_as_any_other_video_stream(self):
+        """Issue #78 -- see `TestOggJob`'s equivalent for why."""
+        streams = [
+            Stream(0, "audio", "opus"),
+            Stream(1, "video", "mjpeg", attached_pic=True),
+        ]
+
+        notes = jobs.verify_success(OPUS, streams)
+
+        assert notes == ("video stream 1 (mjpeg) dropped: not supported by OPUS",)
+
+    def test_a_source_with_nothing_to_lose_prints_no_note_at_all(self):
+        """Acceptance, issue #78 -- see `TestMp3Job`'s equivalent for why."""
+        streams = [Stream(0, "audio", "opus")]
+
+        assert jobs.first_attempt(OPUS).notes == ()
+        assert jobs.verify_success(OPUS, streams) == ()
 
     def test_last_resort_notes_are_pinned(self):
         reencode = jobs.retries(OPUS, [])[-1]

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -865,10 +865,14 @@ class TestLossySourceAdvisory:
         reaches the selective rung the advisory lives on, so it is kept only as
         the control the spec's Verification section names, proving nothing
         about the guard on its own.
+
+        Issue #78, docs/specs/spec-stream-disposition.md: rung 1's standing
+        note is retired -- `jobs.verify_success` already names any drop this
+        note used to describe, per stream. This control now asserts the
+        rung carries no notes of its own at all, still proving nothing about
+        the advisory (which lives on the selective rung, never reached here).
         """
-        assert jobs.first_attempt(FLAC).notes == (
-            "non-audio streams, including cover art, are not carried into FLAC",
-        )
+        assert jobs.first_attempt(FLAC).notes == ()
 
     def test_lossy_source_into_a_lossy_target_keeps_the_ordinary_note_only(self):
         """Lossy-to-lossy is out of scope by decision: the engine's own

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -930,10 +930,12 @@ class TestMp3Profile:
             "copy",
         )
 
-    def test_cheap_attempt_carries_the_standing_non_audio_note(self):
-        assert MP3.cheap_attempt.notes == (
-            "non-audio streams, including cover art, are not carried into MP3",
-        )
+    def test_cheap_attempt_carries_no_standing_note(self):
+        """Issue #78: the standing note is retired -- `jobs.verify_success`
+        already names every dropped stream per stream, and the blanket line
+        had gone false for cover art specifically once #77 started carrying
+        it. See `tests/test_argv.py::TestMp3Job` for the per-stream proof."""
+        assert MP3.cheap_attempt.notes == ()
 
     def test_cheap_attempt_is_declared_partial(self):
         assert MP3.partial_mapping is True
@@ -1002,10 +1004,9 @@ class TestFlacProfile:
             "copy",
         )
 
-    def test_cheap_attempt_carries_the_standing_non_audio_note(self):
-        assert FLAC.cheap_attempt.notes == (
-            "non-audio streams, including cover art, are not carried into FLAC",
-        )
+    def test_cheap_attempt_carries_no_standing_note(self):
+        """Issue #78 -- see `TestMp3Profile`'s equivalent for why."""
+        assert FLAC.cheap_attempt.notes == ()
 
     def test_cheap_attempt_is_declared_partial(self):
         assert FLAC.partial_mapping is True
@@ -1078,10 +1079,9 @@ class TestM4aProfile:
             "copy",
         )
 
-    def test_cheap_attempt_carries_the_standing_non_audio_note(self):
-        assert M4A.cheap_attempt.notes == (
-            "non-audio streams, including cover art, are not carried into M4A",
-        )
+    def test_cheap_attempt_carries_no_standing_note(self):
+        """Issue #78 -- see `TestMp3Profile`'s equivalent for why."""
+        assert M4A.cheap_attempt.notes == ()
 
     def test_cheap_attempt_is_declared_partial(self):
         assert M4A.partial_mapping is True
@@ -1153,10 +1153,12 @@ class TestOggProfile:
         assert OGG.explicit_streams is False
         assert OGG.cheap_attempt.options == ("-map", "0:a?", "-c", "copy")
 
-    def test_cheap_attempt_carries_the_standing_non_audio_note(self):
-        assert OGG.cheap_attempt.notes == (
-            "non-audio streams, including cover art, are not carried into OGG",
-        )
+    def test_cheap_attempt_carries_no_standing_note(self):
+        """Issue #78: ogg gains no artwork rule, so this note's claim was
+        never about a false statement -- it was pure duplication of the
+        per-stream drop `jobs.verify_success` already names for any non-audio
+        stream, cover art included. See `tests/test_argv.py::TestOggJob`."""
+        assert OGG.cheap_attempt.notes == ()
 
     def test_cheap_attempt_is_declared_partial(self):
         assert OGG.partial_mapping is True
@@ -1208,10 +1210,9 @@ class TestOpusProfile:
         assert OPUS.explicit_streams is False
         assert OPUS.cheap_attempt.options == ("-map", "0:a?", "-c", "copy")
 
-    def test_cheap_attempt_carries_the_standing_non_audio_note(self):
-        assert OPUS.cheap_attempt.notes == (
-            "non-audio streams, including cover art, are not carried into OPUS",
-        )
+    def test_cheap_attempt_carries_no_standing_note(self):
+        """Issue #78 -- see `TestOggProfile`'s equivalent for why."""
+        assert OPUS.cheap_attempt.notes == ()
 
     def test_cheap_attempt_is_declared_partial(self):
         assert OPUS.partial_mapping is True
@@ -1242,6 +1243,58 @@ class TestOpusProfile:
     def test_declares_the_pinned_last_resort(self):
         assert OPUS.last_resort is not None
         assert OPUS.last_resort.options == ("-map", "0:a:0", "-c:a", "libopus", "-b:a", "128k")
+
+
+#: The five audio profiles a cheap-attempt standing note used to sit on
+#: (Acceptance, issue #78, docs/specs/spec-stream-disposition.md). `wav` is
+#: deliberately absent: it carries none, so there is nothing for it to retire.
+AUDIO_PROFILES_WITH_A_RETIRED_NOTE = [MP3, FLAC, M4A, OGG, OPUS]
+
+#: Each profile's `last_resort.notes`, exactly as declared before this issue --
+#: unchanged, since that rung maps `-map 0:a:0` explicitly and is never
+#: verified (Out of scope, docs/specs/spec-stream-disposition.md: "`last_resort`
+#: notes ... the only place that information exists").
+_LAST_RESORT_NOTES = {
+    MP3.name: (
+        "non-audio streams, and any audio stream beyond the first, are not carried into MP3",
+    ),
+    FLAC.name: (
+        "non-audio streams, and any audio stream beyond the first, are not carried into FLAC",
+    ),
+    M4A.name: (
+        "non-audio streams, and any audio stream beyond the first, are not carried into M4A",
+    ),
+    OGG.name: (
+        "non-audio streams, and any audio stream beyond the first, are not carried into OGG",
+    ),
+    OPUS.name: (
+        "non-audio streams, and any audio stream beyond the first, are not carried into OPUS",
+    ),
+}
+
+
+class TestStandingNoteRetirement:
+    """Issue #78: the cheap-attempt standing note is gone from every audio
+    profile that used to carry one, and `last_resort` -- never verified, so
+    its note is the only place that information exists -- is untouched."""
+
+    @pytest.mark.parametrize(
+        "profile", AUDIO_PROFILES_WITH_A_RETIRED_NOTE, ids=lambda profile: profile.label
+    )
+    def test_no_audio_profile_carries_a_cheap_attempt_standing_note(self, profile):
+        assert profile.cheap_attempt.notes == ()
+
+    def test_wav_never_carried_one_either(self):
+        """The sixth audio profile, named explicitly since it is absent from
+        `AUDIO_PROFILES_WITH_A_RETIRED_NOTE` above -- nothing to retire."""
+        assert WAV.cheap_attempt.notes == ()
+
+    @pytest.mark.parametrize(
+        "profile", AUDIO_PROFILES_WITH_A_RETIRED_NOTE, ids=lambda profile: profile.label
+    )
+    def test_last_resort_notes_are_unchanged(self, profile):
+        assert profile.last_resort is not None
+        assert profile.last_resort.notes == _LAST_RESORT_NOTES[profile.name]
 
 
 #: One tuple per image2 profile this phase adds: the profile itself, the codec


### PR DESCRIPTION
## Summary

- Removes the cheap-attempt standing note from the five audio profiles that carried one (`mp3`, `flac`, `m4a`, `ogg`, `opus`) — `wav` carries none. `jobs.verify_success` already names every dropped stream per stream (index + codec), making the blanket line pure duplication, and for `mp3`/`m4a`/`flac` it had already gone false once #77 started carrying cover art.
- `last_resort` notes are untouched on all five profiles — that rung is never verified, so its note is the only place that information exists.
- `ogg`, `opus` and `wav` argv stays byte-for-byte unchanged.

## Test plan

- [x] `.venv/Scripts/python.exe scripts/verify.py` green (974 tests)
- [x] New/changed unit tests: `tests/test_profiles.py::TestStandingNoteRetirement` (no standing note on any audio profile, `last_resort.notes` unchanged) and `tests/test_argv.py`'s per-profile "no note at all" / "cover art still dropped with a note" tests
- [x] Real ffmpeg 9.0 smoke test with distinct-stem fixtures: a matching-codec source with nothing to lose converts and prints no note at all; artwork survives the cheap-attempt and selective-rung paths into mp3/m4a/flac; a real h264/mjpeg video stream is still dropped with a note into mp3/m4a; an artwork-bearing source into ogg/opus/wav still drops the picture with a per-stream note; a second run over a converted tree reports `0 converted`, exit 0
- [x] New/changed assertions proven non-vacuous by mutating a profile copy in a scratch script outside the repo

Closes #78

https://claude.ai/code/session_013pdnJyntsFJyawGBSGj4cV