### PR TITLE
docs(constitution): define an advisory as distinct from a degradation note

### DIFF
--- a/docs/constitution.md
+++ b/docs/constitution.md
@@ -52,6 +52,10 @@
 - ffmpeg options are written through `flags("...")`, so a recipe reads like the
   command line you would type.
 - Windows is a first-class target, not an afterthought.
+- A **degradation note** says what *this conversion* gave up; an **advisory**
+  says what *the source* had already given up before the tool ever saw it — the
+  tool takes nothing away, so an advisory is not a claim that this run destroyed
+  anything.
 
 ## Quality gates
 

--- a/docs/design/stream-decision.md
+++ b/docs/design/stream-decision.md
@@ -64,7 +64,12 @@ flowchart TD
   The one note that names no stream is the ladder's *unverified-run* note, which
   exists precisely because no stream list could be obtained
   (`degradation-ladder.md`); it reports the absence of the facts this rule
-  demands, and is not a per-stream verdict at all.
+  demands, and is not a per-stream verdict at all. An advisory
+  (`docs/specs/spec-lossy-source-notes.md`) is exempt on the same footing: it
+  names the stream and its codec, but what it reports is the source's own
+  history, not this conversion's sacrifice, so it is not bound by this rule the
+  way a degradation note is (`docs/constitution.md`'s degradation-note/advisory
+  distinction).
 - **A re-encode that gives up nothing carries no note.** Decoding to a container's
   only codec is the definition of that target format, not a loss — WAV's PCM rule
   declares no note, MP4's `aac` and `h264` fallbacks do. Whether the note exists

--- a/docs/specs/spec-lossy-source-notes.md
+++ b/docs/specs/spec-lossy-source-notes.md
@@ -455,3 +455,20 @@ New-Item -ItemType Directory -Force in
   `TestLossySourceAdvisory.test_copied_through_cover_art_carries_no_advisory`.
   Landed as a fast-follow PR rather than amending #96, since #96 was already
   squash-merged before the gap was found.
+- 2026-08-27 (issue #89): the two foundation-doc amendments landed.
+  `docs/constitution.md` gained one Conventions bullet distinguishing a
+  **degradation note** (what this conversion gave up) from an **advisory**
+  (what the source had already given up before the tool saw it).
+  `docs/design/stream-decision.md` gained a carve-out sentence on its "every
+  note names three things" bullet, in the same form as the existing precedent
+  for the ladder's unverified-run note: an advisory names the stream and its
+  codec, but what it reports is the source's own history rather than this
+  conversion's sacrifice, so it is not bound by that rule the way a
+  degradation note is. `docs/architecture.md` Key flow 1,
+  `docs/design/degradation-ladder.md` and the engine docstring were left
+  untouched, per this issue's scope. Verified against a real run: `--to flac`
+  over a 128 kbit/s MP3 fixture (ffmpeg 9.0) printed exactly `audio stream 0
+  (mp3) was already lossy before this file reached FLAC; FLAC cannot restore
+  what mp3 discarded`, matching `converter/jobs.py::_lossy_source_note`
+  verbatim -- the wording the new doc lines describe was read off the shipped
+  code, not reinvented.


### PR DESCRIPTION
## Summary
- `docs/constitution.md` gains one Conventions bullet distinguishing a **degradation note** (what this conversion gave up) from an **advisory** (what the source had already given up before the tool saw it).
- `docs/design/stream-decision.md` gains a carve-out sentence on its "every note names three things" bullet — an advisory is exempt the way the ladder's existing unverified-run note already is.
- `docs/specs/spec-lossy-source-notes.md` gets a Decision log entry recording both amendments and the wording verified against a real run.
- `docs/architecture.md` Key flow 1, `docs/design/degradation-ladder.md` and the engine docstring are deliberately untouched, per this issue's scope.

## Verification
- `scripts/verify.py` green (ruff check, ruff format --check, pytest — 966 passed).
- Manually ran `--to flac` over a 128 kbit/s MP3 fixture with real ffmpeg 9.0; observed advisory: `audio stream 0 (mp3) was already lossy before this file reached FLAC; FLAC cannot restore what mp3 discarded` — matches `converter/jobs.py::_lossy_source_note` verbatim.

Closes #89

https://claude.ai/code/session_013pdnJyntsFJyawGBSGj4cV