### PR TITLE
refactor(profiles): retire the mkv/webm standing notes, keep jpg/gif/avif's

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,29 @@ note    Show.S01E02.mkv: subtitle stream 2 (hdmv_pgs_subtitle) dropped: bitmap s
   audio streams, the first one is converted and the rest are dropped. For MP3
   and FLAC that limit is the container's own muxer, not a choice this tool
   makes.
-* **MP3 and FLAC never carry video.** Any non-audio stream — including
-  embedded cover art — is left out. A straight copy says so even when the
-  source had nothing to lose; when the audio itself has to be re-encoded, the
-  dropped stream is still named, just without the extra line.
+* **MP3, FLAC and M4A carry embedded cover art, but nothing else non-audio.**
+  A picture stream survives a straight copy untouched, byte for byte. Any
+  other video, subtitle or attachment stream is left out, and — like every
+  other target — is only reported when one was actually present to drop;
+  nothing prints for a source that never had one.
+* **MKV, MOV and WebM name a dropped attachment, data or timecode stream
+  individually, by index and codec, rather than with a blanket warning.** MKV
+  keeps font attachments and drops data or timecode streams; MOV rejects a
+  mapped attachment outright, so its loss surfaces through the same rung a
+  genuinely incompatible codec would, and its muxer regenerates a `tmcd`
+  timecode track from source metadata on its own, so that one is not
+  reported as dropped even though nothing mapped it; WebM silently discards
+  an attachment, data or timecode stream at exit 0. None of the three prints
+  anything for a source that carries none of these.
+* **JPG, GIF and AVIF always state the format's structural limits, even when
+  the source had nothing to lose.** JPEG and GIF cannot hold an alpha
+  channel, GIF is limited to a 256-colour palette, and AVIF's muxer keeps
+  only one frame of an animated source no matter what is asked of it — but
+  the notes for these say so on every conversion, not only the ones where the
+  source actually had transparency, extra colours or extra frames to give
+  up. Unlike a per-stream drop, this is a loss inside a stream that is still
+  kept, which the engine has no way to measure from the source today, so it
+  is announced unconditionally rather than confirmed.
 * **`--to opus` can hand you a `.opus` file that is actually Vorbis.** A
   Vorbis source (typically a `.ogg`/`.oga` file) is stream-copied into the
   `.opus` container without transcoding — genuinely lossless, but `.opus` is a

--- a/README.md
+++ b/README.md
@@ -189,9 +189,13 @@ note    Show.S01E02.mkv: subtitle stream 2 (hdmv_pgs_subtitle) dropped: bitmap s
   makes.
 * **MP3, FLAC and M4A carry embedded cover art, but nothing else non-audio.**
   A picture stream survives a straight copy untouched, byte for byte. Any
-  other video, subtitle or attachment stream is left out, and — like every
-  other target — is only reported when one was actually present to drop;
-  nothing prints for a source that never had one.
+  other video, subtitle or attachment stream a straight copy leaves out is
+  reported only when one was actually present to drop; nothing prints for a
+  source that never had one. The one place that is not true is each format's
+  re-encode rung, reached only when a matching codec's copy is refused
+  outright: its note names what that rung structurally cannot carry
+  regardless of whether this particular source had any to give up, the same
+  as it always has.
 * **MKV, MOV and WebM name a dropped attachment, data or timecode stream
   individually, by index and codec, rather than with a blanket warning.** MKV
   keeps font attachments and drops data or timecode streams; MOV rejects a

--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -957,41 +957,50 @@ PNG = Profile(
     ),
 )
 
-#: Issue #67, docs/specs/spec-stream-disposition.md: the QA finding this issue
-#: was filed against reads "standing notes fire when nothing was lost **and
-#: name no stream**" -- JPG's, GIF's and AVIF's standing notes below
-#: (transparency, colour palette, frame reduction) still have both halves of
-#: that problem, for different reasons, and neither is fixed here:
-#:
-#: * They are worded as *format facts* ("transparency is not carried by
-#:   JPEG"), true of every conversion to that target regardless of what the
-#:   source held -- not a claim that *this* file's transparency was dropped, so
-#:   they do not over-report the way the retired MKV/WEBM notes did. The one
-#:   exception was GIF's "colours are reduced to GIF's 256-colour palette",
-#:   worded as an action rather than a fact; measured, an already-GIF,
-#:   already-<=256-colour source re-encodes pixel-identically, so that wording
-#:   was a genuine false claim for that file (unlike its four siblings) and is
-#:   reworded below to the same fact-not-action shape as the rest.
-#: * None of the five names a stream index or codec, unlike a per-stream drop
-#:   note -- because none of these is a per-stream drop: the video stream
-#:   itself is still mapped and kept, only something inside it (an alpha
-#:   channel, a colour count, a frame count) is gone.
-#:   `jobs.verify_success`/`_structural_drop` only ever reasons about whether a
-#:   stream was mapped at all (D1/D2 of stream-decision.md), so it has no
-#:   opinion on what survived inside one, and a profile's `notes` tuple is
-#:   static data with no access to the source's probed streams at all -- naming
-#:   an index and codec here would need both a `pix_fmt`/frame-count field on
-#:   `Stream` (converter/ffmpegtool.py) and new decision logic in `jobs.py`'s
-#:   engine to compare a kept stream's measured properties against what its
-#:   target actually holds. Both are out of this issue's file boundary
-#:   (`jobs.py` was read-only for this work), so the gap is recorded as a
-#:   finding for a follow-up issue rather than attempted piecemeal.
-#:
-#: Retiring these notes outright, leaving the within-stream loss unsaid
-#: entirely, would violate docs/constitution.md's "never report success for a
-#: conversion that silently dropped something" -- an unmeasured loss is still
-#: a loss the constitution forbids leaving unsaid -- so all five stay
-#: unconditional standing notes rather than being deleted.
+# Issue #67, docs/specs/spec-stream-disposition.md: the QA finding this issue
+# was filed against reads "standing notes fire when nothing was lost **and
+# name no stream**" -- this covers JPG's, GIF's and AVIF's standing notes
+# below (transparency, colour palette, frame reduction). Review round 2 of
+# this PR flagged the summary this comment used to open with ("neither half
+# is fixed here") as false about this PR's own contents, since half one is
+# fixed for the one note that actually needed it -- restated precisely below.
+#
+# * Half one -- firing when nothing was lost. Four of the five notes are
+#   worded as claims about what *this profile's pipeline always does*
+#   ("transparency is not carried by JPEG" -- true of JPEG the format;
+#   AVIF's own notes are true of this profile's forced
+#   "-still-picture 1"/no-alpha pipeline specifically, not of the AVIF format,
+#   which does support alpha and multiple frames elsewhere), true of every
+#   conversion through that profile regardless of what the source held -- not
+#   a claim that *this* file's transparency was dropped, so they do not
+#   over-report the way the retired MKV/WEBM notes did. Half one's one real
+#   defect was GIF's "colours are reduced to GIF's 256-colour palette", worded
+#   as an action rather than a fact; measured, an already-GIF,
+#   already-<=256-colour source re-encodes pixel-identically, so that wording
+#   was a genuine false claim for that file (unlike its four siblings). It is
+#   fixed below, reworded to the same fact-not-action shape as the rest; the
+#   other four needed no change.
+# * Half two -- naming a stream index and codec. None of the five names one,
+#   and this half is not fixed for any of them, only recorded. None of these
+#   is a per-stream drop: the video stream itself is still mapped and kept,
+#   only something inside it (an alpha channel, a colour count, a frame
+#   count) is gone. `jobs.verify_success`/`_structural_drop` only ever
+#   reasons about whether a stream was mapped at all (D1/D2 of
+#   stream-decision.md), so it has no opinion on what survived inside one,
+#   and a profile's `notes` tuple is static data with no access to the
+#   source's probed streams at all -- naming an index and codec here would
+#   need both a `pix_fmt`/frame-count field on `Stream`
+#   (converter/ffmpegtool.py) and new decision logic in `jobs.py`'s engine to
+#   compare a kept stream's measured properties against what its target
+#   actually holds. Both are out of this issue's file boundary (`jobs.py` was
+#   read-only for this work), so the gap is recorded as a finding for a
+#   follow-up issue rather than attempted piecemeal.
+#
+# Retiring these notes outright, leaving the within-stream loss unsaid
+# entirely, would violate docs/constitution.md's "never report success for a
+# conversion that silently dropped something" -- an unmeasured loss is still
+# a loss the constitution forbids leaving unsaid -- so all five stay
+# unconditional standing notes rather than being deleted.
 JPG = Profile(
     label="JPG",
     name="jpg",
@@ -1128,7 +1137,7 @@ GIF = Profile(
         # wins (it forces the encoder unconditionally), so it is the only rung
         # whose notes are ever actually reported for the overwhelming majority
         # of inputs -- the same shape JPG's cheap-attempt note is. Retained
-        # unconditionally -- issue #67, see JPG's module-level comment above
+        # unconditionally -- issue #67, see the module-level comment above JPG
         # for why: both are a within-stream loss no per-stream drop note can
         # replace. Both wordings are format facts, true of every conversion to
         # GIF regardless of what the source held -- not a claim that *this*
@@ -1217,7 +1226,7 @@ AVIF = Profile(
         # this is the only place AVIF's one silent loss this phase cannot
         # avoid -- the muxer keeps one frame no matter what is asked of it --
         # is ever actually named. Retained unconditionally -- issue #67, see
-        # JPG's module-level comment above GIF for why: both are a
+        # the module-level comment above JPG for why: both are a
         # within-stream loss no per-stream drop note can replace. Measured: a
         # single-frame, alpha-less source still prints both notes.
         notes=(

--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -393,12 +393,21 @@ MKV = Profile(
     # subtitle, *and* attachment ("-map 0:t?"), which no earlier profile has
     # needed. Still not "-map 0": that would also select data and timecode
     # streams, which no "v/a/s/t" map -- MKV's included -- carries at all
-    # (measured), so the standing note below says so instead of ffmpeg silently
-    # dropping them off a bare "-map 0".
+    # (measured).
+    #
+    # Issue #67, docs/specs/spec-stream-disposition.md: the standing note this
+    # cheap attempt used to carry alongside the map is retired. jobs.verify_success
+    # already names a real data or timecode drop per stream via _structural_drop's
+    # "not supported by MKV" branch -- MKV declares no "data" rule, so any such
+    # stream is caught regardless of what the map above did or did not select.
+    # Unlike MOV/MP4, MKV's muxer never regenerates one from source metadata
+    # (measured, ffmpeg 9.0: a source carrying a `tmcd` timecode track converts
+    # to MKV holding video and audio only, nothing put back), so no
+    # confirm_drops forgiveness is even in play -- the per-stream note is exact
+    # every time.
     cheap_attempt=Attempt(
         label="remux",
         options=flags("-map 0:v? -map 0:a? -map 0:s? -map 0:t? -c copy"),
-        notes=("data and timecode streams are not carried into MKV",),
     ),
     explicit_streams=False,
     # The blind "?" selectors carry every video, audio, subtitle and attachment
@@ -560,16 +569,24 @@ WEBM = Profile(
     # only the standing note below can say so, since nothing ever fails on one.
     # Still not "-map 0": that would also select data and timecode streams,
     # which no "v/a/s" map -- WebM's included -- carries at all (measured).
+    #
+    # Issue #67, docs/specs/spec-stream-disposition.md: the standing note this
+    # cheap attempt used to carry alongside the map is retired. WebM declares
+    # no "attachment" or "data" rule, so jobs.verify_success's
+    # _structural_drop already names any attachment, data or timecode stream
+    # per stream via its "not supported by WebM" branch -- regardless of the
+    # map above never selecting one, the same mechanism MP4's own attachment
+    # gap already relies on. Measured, ffmpeg 9.0: WebM's muxer regenerates
+    # nothing from source metadata (unlike MOV/MP4's `tmcd`), so no
+    # confirm_drops forgiveness is in play here either.
     cheap_attempt=Attempt(
         label="remux",
         options=flags("-map 0:v? -map 0:a? -map 0:s? -c copy -c:s webvtt"),
-        notes=("attachments, data and timecode streams are not carried into WebM",),
     ),
     explicit_streams=False,
     # The blind "?" selectors carry every video, audio and subtitle stream
     # WebM's muxer can hold, but never an attachment, data or timecode stream --
-    # exactly the standing note's claim, verified once per successful cheap
-    # attempt rather than assumed.
+    # a real one is still named by the success-side verification, per stream.
     partial_mapping=True,
     rules={
         "video": StreamRule(
@@ -940,6 +957,23 @@ PNG = Profile(
     ),
 )
 
+#: Issue #67, docs/specs/spec-stream-disposition.md: JPG's, GIF's and AVIF's
+#: standing notes below (transparency, colour quantisation, frame reduction)
+#: were found to fire even on a source with nothing to lose -- a plain opaque
+#: `yuvj420p` JPEG still claims transparency was dropped. Unlike MKV's and
+#: WEBM's retired notes, none of these has a per-stream replacement:
+#: `jobs.verify_success` only ever names a stream the mapping left *out*
+#: entirely (D1/D2 of stream-decision.md), and every one of these three is a
+#: *within-stream* loss -- the video stream itself is still mapped and kept,
+#: only something inside it (an alpha channel, a colour count, a frame count)
+#: is gone. `Stream` (converter/ffmpegtool.py) carries no `pix_fmt` or frame
+#: count today, and the decision of whether a given source actually had the
+#: property would have to live in `jobs.py`'s engine (data, not code, is what
+#: `profiles.py` is for) -- both out of this issue's scope. Retiring the notes
+#: anyway would violate docs/constitution.md's "never report success for a
+#: conversion that silently dropped something", so all three stay unconditional
+#: standing notes; making them conditional on the source's actual pixel format
+#: and frame count is recorded as a finding for a follow-up issue instead.
 JPG = Profile(
     label="JPG",
     name="jpg",
@@ -952,7 +986,8 @@ JPG = Profile(
         # Standing note, not a fallback-branch one: this cheap attempt always
         # wins for an ordinary single-frame image (it forces the encoder
         # unconditionally), so it is the only rung whose notes are ever
-        # actually reported for the overwhelming majority of inputs.
+        # actually reported for the overwhelming majority of inputs. Retained
+        # unconditionally -- see the module-level comment above this profile.
         notes=("transparency is not carried by JPEG; the image was re-encoded",),
     ),
     explicit_streams=False,
@@ -1074,7 +1109,11 @@ GIF = Profile(
         # Standing notes, not fallback-branch ones: this cheap attempt always
         # wins (it forces the encoder unconditionally), so it is the only rung
         # whose notes are ever actually reported for the overwhelming majority
-        # of inputs -- the same shape JPG's cheap-attempt note is.
+        # of inputs -- the same shape JPG's cheap-attempt note is. Retained
+        # unconditionally -- issue #67, see JPG's module-level comment above
+        # for why: both are a within-stream loss no per-stream drop note can
+        # replace. Measured: a source that is itself already a GIF (already
+        # <=256 colours, already alpha-less) still prints both notes.
         notes=(
             "transparency is not carried by GIF",
             "colours are reduced to GIF's 256-colour palette",
@@ -1154,7 +1193,10 @@ AVIF = Profile(
         # Standing notes: the cheap attempt always wins (forced encoder), so
         # this is the only place AVIF's one silent loss this phase cannot
         # avoid -- the muxer keeps one frame no matter what is asked of it --
-        # is ever actually named.
+        # is ever actually named. Retained unconditionally -- issue #67, see
+        # JPG's module-level comment above GIF for why: both are a
+        # within-stream loss no per-stream drop note can replace. Measured: a
+        # single-frame, alpha-less source still prints both notes.
         notes=(
             "transparency is not carried by AVIF",
             "a multi-frame source is reduced to a single frame",

--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -411,9 +411,8 @@ MKV = Profile(
     ),
     explicit_streams=False,
     # The blind "?" selectors carry every video, audio, subtitle and attachment
-    # stream MKV's muxer can hold, but never a data or timecode one -- exactly
-    # the standing note's claim, verified once per successful cheap attempt
-    # rather than assumed.
+    # stream MKV's muxer can hold, but never a data or timecode one -- a real
+    # one is still named by the success-side verification, per stream.
     partial_mapping=True,
     rules={
         "video": StreamRule(
@@ -484,11 +483,11 @@ MOV = Profile(
     # "-map 0": that would also select data and timecode streams, which no
     # "v/a/s/t" map -- MOV's included -- selects at all (measured).
     #
-    # No standing note about data and timecode streams, unlike MKV's otherwise
-    # identical shape: MOV's muxer *regenerates* a tmcd timecode track from the
-    # source's metadata even though no selector maps it, so the blanket claim
-    # was measurably false for the commonest data stream a MOV source carries
-    # (issue #66). What actually reaches the output is settled per file by the
+    # Unlike MKV's and WebM's otherwise identical shape (issue #67), MOV's
+    # muxer *regenerates* a tmcd timecode track from the source's metadata even
+    # though no selector maps it -- a data drop a blanket claim would have
+    # gotten wrong for the commonest data stream a MOV source carries (issue
+    # #66). What actually reaches the output is settled per file by the
     # success-side verification, which reads the written file rather than the
     # mapping -- a real data drop still gets its own per-stream note there.
     cheap_attempt=Attempt(
@@ -565,10 +564,11 @@ WEBM = Profile(
     # Unlike MKV and MOV, deliberately does NOT map "0:t?": WebM does not reject
     # a mapped attachment, it silently discards it at exit 0 (measured), so
     # mapping it would buy nothing -- the "map to force a failure" trick MOV
-    # uses does not work here. A source with an attachment still loses it, but
-    # only the standing note below can say so, since nothing ever fails on one.
-    # Still not "-map 0": that would also select data and timecode streams,
-    # which no "v/a/s" map -- WebM's included -- carries at all (measured).
+    # uses does not work here. A source with an attachment still loses it, and
+    # the success-side verification is what says so, per stream, since nothing
+    # ever fails on one. Still not "-map 0": that would also select data and
+    # timecode streams, which no "v/a/s" map -- WebM's included -- carries at
+    # all (measured).
     #
     # Issue #67, docs/specs/spec-stream-disposition.md: the standing note this
     # cheap attempt used to carry alongside the map is retired. WebM declares
@@ -620,8 +620,8 @@ WEBM = Profile(
         # equality, the same way MP4 declares no "attachment" rule. A source
         # that has one still succeeds the cheap attempt, and the success-side
         # verification (jobs.verify_success) names the drop per stream because
-        # no rule matches "attachment" -- the standing note above restates it
-        # unconditionally alongside that per-stream note.
+        # no rule matches "attachment" -- the only place that drop is ever
+        # reported (issue #67).
     },
     last_resort=Attempt(
         label="re-encode",
@@ -957,23 +957,41 @@ PNG = Profile(
     ),
 )
 
-#: Issue #67, docs/specs/spec-stream-disposition.md: JPG's, GIF's and AVIF's
-#: standing notes below (transparency, colour quantisation, frame reduction)
-#: were found to fire even on a source with nothing to lose -- a plain opaque
-#: `yuvj420p` JPEG still claims transparency was dropped. Unlike MKV's and
-#: WEBM's retired notes, none of these has a per-stream replacement:
-#: `jobs.verify_success` only ever names a stream the mapping left *out*
-#: entirely (D1/D2 of stream-decision.md), and every one of these three is a
-#: *within-stream* loss -- the video stream itself is still mapped and kept,
-#: only something inside it (an alpha channel, a colour count, a frame count)
-#: is gone. `Stream` (converter/ffmpegtool.py) carries no `pix_fmt` or frame
-#: count today, and the decision of whether a given source actually had the
-#: property would have to live in `jobs.py`'s engine (data, not code, is what
-#: `profiles.py` is for) -- both out of this issue's scope. Retiring the notes
-#: anyway would violate docs/constitution.md's "never report success for a
-#: conversion that silently dropped something", so all three stay unconditional
-#: standing notes; making them conditional on the source's actual pixel format
-#: and frame count is recorded as a finding for a follow-up issue instead.
+#: Issue #67, docs/specs/spec-stream-disposition.md: the QA finding this issue
+#: was filed against reads "standing notes fire when nothing was lost **and
+#: name no stream**" -- JPG's, GIF's and AVIF's standing notes below
+#: (transparency, colour palette, frame reduction) still have both halves of
+#: that problem, for different reasons, and neither is fixed here:
+#:
+#: * They are worded as *format facts* ("transparency is not carried by
+#:   JPEG"), true of every conversion to that target regardless of what the
+#:   source held -- not a claim that *this* file's transparency was dropped, so
+#:   they do not over-report the way the retired MKV/WEBM notes did. The one
+#:   exception was GIF's "colours are reduced to GIF's 256-colour palette",
+#:   worded as an action rather than a fact; measured, an already-GIF,
+#:   already-<=256-colour source re-encodes pixel-identically, so that wording
+#:   was a genuine false claim for that file (unlike its four siblings) and is
+#:   reworded below to the same fact-not-action shape as the rest.
+#: * None of the five names a stream index or codec, unlike a per-stream drop
+#:   note -- because none of these is a per-stream drop: the video stream
+#:   itself is still mapped and kept, only something inside it (an alpha
+#:   channel, a colour count, a frame count) is gone.
+#:   `jobs.verify_success`/`_structural_drop` only ever reasons about whether a
+#:   stream was mapped at all (D1/D2 of stream-decision.md), so it has no
+#:   opinion on what survived inside one, and a profile's `notes` tuple is
+#:   static data with no access to the source's probed streams at all -- naming
+#:   an index and codec here would need both a `pix_fmt`/frame-count field on
+#:   `Stream` (converter/ffmpegtool.py) and new decision logic in `jobs.py`'s
+#:   engine to compare a kept stream's measured properties against what its
+#:   target actually holds. Both are out of this issue's file boundary
+#:   (`jobs.py` was read-only for this work), so the gap is recorded as a
+#:   finding for a follow-up issue rather than attempted piecemeal.
+#:
+#: Retiring these notes outright, leaving the within-stream loss unsaid
+#: entirely, would violate docs/constitution.md's "never report success for a
+#: conversion that silently dropped something" -- an unmeasured loss is still
+#: a loss the constitution forbids leaving unsaid -- so all five stay
+#: unconditional standing notes rather than being deleted.
 JPG = Profile(
     label="JPG",
     name="jpg",
@@ -1112,11 +1130,16 @@ GIF = Profile(
         # of inputs -- the same shape JPG's cheap-attempt note is. Retained
         # unconditionally -- issue #67, see JPG's module-level comment above
         # for why: both are a within-stream loss no per-stream drop note can
-        # replace. Measured: a source that is itself already a GIF (already
-        # <=256 colours, already alpha-less) still prints both notes.
+        # replace. Both wordings are format facts, true of every conversion to
+        # GIF regardless of what the source held -- not a claim that *this*
+        # file's transparency or colour count was actually reduced (issue #67
+        # review: an already-GIF, already <=256-colour source re-encodes
+        # pixel-identically, measured, so "colours are reduced" would have
+        # been a false claim of an action that did not happen for that file;
+        # "holds at most" makes the same point as a limit instead).
         notes=(
             "transparency is not carried by GIF",
-            "colours are reduced to GIF's 256-colour palette",
+            "GIF holds at most a 256-colour palette",
         ),
     ),
     explicit_streams=False,
@@ -1142,7 +1165,7 @@ GIF = Profile(
             # the same reasoning JPG's last_resort carries its transparency
             # note for.
             "transparency is not carried by GIF",
-            "the image was re-quantised to GIF's 256-colour palette",
+            "GIF holds at most a 256-colour palette",
             "non-video streams, and any video stream beyond the first, are not carried into GIF",
         ),
     ),

--- a/docs/specs/spec-stream-disposition.md
+++ b/docs/specs/spec-stream-disposition.md
@@ -445,33 +445,49 @@ New-Item -ItemType Directory -Force in
   `tmcd` regeneration made the blanket claim measurably false.
 
   **`jpg`, `gif` and `avif` keep theirs, unconditional, by decision rather
-  than oversight.** All three notes this issue's QA finding named for these
-  profiles -- JPEG's and GIF's transparency loss, GIF's colour quantisation,
+  than oversight -- and neither half of the QA finding's title is actually
+  fixed for these three.** All five notes this issue's QA finding named for
+  these profiles -- JPEG's and GIF's transparency loss, GIF's colour palette,
   AVIF's frame reduction -- describe a *within-stream* loss: the video
   stream is still mapped and kept, only something inside it (an alpha
   channel, a colour count, a frame count) is gone. `_structural_drop` only
   ever reasons about whether a stream was mapped at all, so it has no
-  opinion on what survived inside one, and confirmed by measurement rather
-  than assumed: a source already in the target format (a GIF converted to
-  GIF, already alpha-less and already <=256 colours; a single-frame source
-  into AVIF) still prints every one of these notes, exactly the QA finding's
-  own example of a plain opaque `yuvj420p` JPEG still claiming a
-  transparency loss. Making them conditional -- firing only when the source
-  actually had the property -- would need `Stream` (`converter/ffmpegtool.py`)
-  to carry a pixel format and a frame count, neither of which it does today,
-  and the decision of whether a given source had one would have to live in
-  `jobs.py`'s engine, since `converter/profiles.py` is data, not code (`docs/
-  constitution.md`) -- both changes are out of this issue's file boundary
+  opinion on what survived inside one.
+
+  *Half one -- firing when nothing was lost.* Four of the five notes are
+  worded as **format facts** ("transparency is not carried by JPEG"), true of
+  every conversion to that target regardless of what the source held, not a
+  claim that *this* file's transparency was dropped -- so, unlike the retired
+  `mkv`/`webm` notes, they do not over-report a specific event that did not
+  happen; they state a limit. Review of this PR's first draft found the
+  fifth, GIF's "colours are reduced to GIF's 256-colour palette", worded as
+  an *action* rather than a fact, and measured that an already-GIF,
+  already-<=256-colour source re-encodes pixel-identically (the module
+  comment above `GIF` in `converter/profiles.py` already recorded this,
+  unconnected until the review) -- so that wording, alone among the five, was
+  a genuine false claim for such a file. It is reworded here to "GIF holds at
+  most a 256-colour palette", the same fact-not-action shape as its four
+  siblings, closing that one real gap; the other four were already
+  accurate as written and needed no change.
+
+  *Half two -- naming a stream index and codec.* None of the five names one,
+  and this half is **not fixed, only recorded**. A profile's `notes` tuple is
+  static data with no access to the source's probed streams at all, so naming
+  an index and codec here would need a `pix_fmt` and a frame-count field on
+  `Stream` (`converter/ffmpegtool.py`), plus new decision logic in `jobs.py`'s
+  engine to compare a kept stream's measured properties against what its
+  target actually holds -- both out of this issue's file boundary
   (`converter/jobs.py` was read-only for this work; `converter/ffmpegtool.py`
-  was not in scope either). Retiring the notes without that replacement would
-  violate `docs/constitution.md`'s "never report success for a conversion
-  that silently dropped something" -- an unmeasured within-stream loss is
-  still a loss the constitution forbids leaving unsaid, so over-reporting
-  stays the safer failure mode until the probing exists. **Finding, not
-  fixed in this issue:** conditional firing for `jpg`/`gif`/`avif` needs a
-  `pix_fmt` and a frame-count field on `Stream`, plus new engine logic in
-  `jobs.py` to compare a kept stream's measured properties against what its
-  target actually holds -- recorded here for a follow-up issue rather than
+  was not in scope either), and `converter/profiles.py` is data, not code
+  (`docs/constitution.md`), so the comparison logic could not live there even
+  if the field existed. Retiring these notes outright rather than leaving them
+  as an imprecise-but-true statement would violate `docs/constitution.md`'s
+  "never report success for a conversion that silently dropped something" --
+  an unmeasured within-stream loss is still a loss the constitution forbids
+  leaving unsaid -- so all five stay unconditional standing notes. **Finding,
+  not fixed in this issue:** both halves above are recorded for a follow-up
+  issue -- conditional firing needs the `pix_fmt`/frame-count probing, and
+  per-stream naming needs the engine to consult it -- rather than either being
   attempted piecemeal against the file boundary this issue was scoped to.
 
   Verified against real ffmpeg 9.0 with distinct-stem fixtures: a source with
@@ -493,11 +509,33 @@ New-Item -ItemType Directory -Force in
   the same source at `0xfe`/`0xff` only because they keep an alpha channel at
   all (WebP: `yuva420p`, alpha `0xfe`); a multi-frame GIF source (3 frames,
   measured via `ffprobe -count_frames`) into `avif` prints the frame-reduction
-  note and the output genuinely holds 1 frame; a second run over each
-  converted tree reports 0 converted, exit 0. Every new or changed assertion
-  was proven non-vacuous by mutating a profile copy in a scratch script
-  outside the repo (restoring `mkv`'s and `webm`'s removed standing notes,
-  and separately giving each profile a bogus `data` rule that would make
-  `verify_success` stop predicting the drop the shipped test pins) and
+  note and the output genuinely holds 1 frame; a re-run of an already-`.gif`
+  source into `gif` still prints the reworded "GIF holds at most a 256-colour
+  palette" -- true and unchanged in substance, but no longer a false claim
+  that a reduction happened to that specific, already-quantised file; a
+  second run over each converted tree reports 0 converted, exit 0. Every new
+  or changed assertion was proven non-vacuous by mutating a profile copy in a
+  scratch script outside the repo (restoring `mkv`'s and `webm`'s removed
+  standing notes, giving each profile a bogus `data` rule that would make
+  `verify_success` stop predicting the drop the shipped test pins, and
+  restoring GIF's pre-review "colours are reduced to..." wording) and
   confirming the shipped assertion's expected value no longer matches against
-  either mutation.
+  any of the three mutations.
+
+  **Review round 1** (fresh-agent gate) found four comments in
+  `converter/profiles.py` left over from before the standing note they
+  described was retired -- MKV's `partial_mapping` comment and MOV's
+  contrast with MKV still claiming a standing note that no longer exists on
+  either side, and two WebM comments still pointing at "the standing note
+  below/above" -- all four corrected to describe the code as it now reads. It
+  also found the README bullet for MP3/FLAC/M4A overstated ("nothing prints
+  for a source that never had one") against `last_resort`'s own unconditional
+  note, corrected with the same carve-out `last_resort` has always needed,
+  and found GIF's "colours are reduced to GIF's 256-colour palette" was a
+  genuine false claim -- not merely an over-broad one -- for an already-GIF
+  source, unlike its four unconditional-but-true siblings; reworded to "GIF
+  holds at most a 256-colour palette" (`cheap_attempt` and `last_resort`
+  both), the fix recorded above. It also asked whether the "second half" of
+  the QA finding's own title -- naming no stream index or codec -- was
+  addressed for `jpg`/`gif`/`avif`; it was not, and the profile comment and
+  this entry now say so explicitly rather than only discussing conditionality.

--- a/docs/specs/spec-stream-disposition.md
+++ b/docs/specs/spec-stream-disposition.md
@@ -419,3 +419,85 @@ New-Item -ItemType Directory -Force in
   (restoring the removed standing note, adding an `attached_pic` rule to
   `ogg`, emptying a `last_resort` note) and confirming the same assertion the
   shipped test uses fails against each mutation.
+- 2026-08-27 (issue #67): the finding this issue was filed to fix -- the
+  cheap-attempt standing note firing even when a source had nothing for the
+  target to drop, and naming neither a stream index nor a codec -- is
+  resolved differently for the six profiles it covers, depending on what the
+  note actually described.
+
+  **`mkv` and `webm` retire theirs outright**, the same resolution #78 gave
+  the five audio profiles: `jobs.verify_success`'s `_structural_drop` already
+  names any stream of a type the profile declares no rule for, per stream,
+  via its "not supported by `<LABEL>`" branch -- `mkv` declares no `data`
+  rule and `webm` declares neither `attachment` nor `data`, so an attachment,
+  data or timecode stream a partial cheap attempt could not have mapped was
+  already named individually before this issue touched anything; the
+  standing note was pure duplication, never a statement with no
+  replacement. Measured against real ffmpeg 9.0, and pinned by new tests
+  (`tests/test_argv.py::TestMkvDegradationNotes`/`TestWebmDegradationNotes`):
+  unlike `mov`/`mp4` (issue #66), neither `mkv`'s nor `webm`'s muxer
+  regenerates a data or timecode stream from source metadata -- a `.mov`
+  source carrying a real `tmcd` timecode track converts to both containers
+  holding video and audio only, nothing put back -- so no `confirm_drops`
+  forgiveness is even in play and the per-stream prediction is exact on every
+  file, not merely on average. `mov` needed no change: it already carries no
+  standing note, having lost it to issue #66's finding that its muxer's own
+  `tmcd` regeneration made the blanket claim measurably false.
+
+  **`jpg`, `gif` and `avif` keep theirs, unconditional, by decision rather
+  than oversight.** All three notes this issue's QA finding named for these
+  profiles -- JPEG's and GIF's transparency loss, GIF's colour quantisation,
+  AVIF's frame reduction -- describe a *within-stream* loss: the video
+  stream is still mapped and kept, only something inside it (an alpha
+  channel, a colour count, a frame count) is gone. `_structural_drop` only
+  ever reasons about whether a stream was mapped at all, so it has no
+  opinion on what survived inside one, and confirmed by measurement rather
+  than assumed: a source already in the target format (a GIF converted to
+  GIF, already alpha-less and already <=256 colours; a single-frame source
+  into AVIF) still prints every one of these notes, exactly the QA finding's
+  own example of a plain opaque `yuvj420p` JPEG still claiming a
+  transparency loss. Making them conditional -- firing only when the source
+  actually had the property -- would need `Stream` (`converter/ffmpegtool.py`)
+  to carry a pixel format and a frame count, neither of which it does today,
+  and the decision of whether a given source had one would have to live in
+  `jobs.py`'s engine, since `converter/profiles.py` is data, not code (`docs/
+  constitution.md`) -- both changes are out of this issue's file boundary
+  (`converter/jobs.py` was read-only for this work; `converter/ffmpegtool.py`
+  was not in scope either). Retiring the notes without that replacement would
+  violate `docs/constitution.md`'s "never report success for a conversion
+  that silently dropped something" -- an unmeasured within-stream loss is
+  still a loss the constitution forbids leaving unsaid, so over-reporting
+  stays the safer failure mode until the probing exists. **Finding, not
+  fixed in this issue:** conditional firing for `jpg`/`gif`/`avif` needs a
+  `pix_fmt` and a frame-count field on `Stream`, plus new engine logic in
+  `jobs.py` to compare a kept stream's measured properties against what its
+  target actually holds -- recorded here for a follow-up issue rather than
+  attempted piecemeal against the file boundary this issue was scoped to.
+
+  Verified against real ffmpeg 9.0 with distinct-stem fixtures: a source with
+  no data or timecode stream into `mkv`/`webm` now prints nothing at all,
+  where the retired standing note used to fire unconditionally -- the change
+  a user notices first; a source carrying a real `tmcd`-tagged data stream
+  (built with `-timecode 00:00:00:00`) into `mkv` prints exactly
+  `data stream 2 (unknown) dropped: not supported by MKV`, nothing more, and
+  the output genuinely holds no data stream; a font-attachment-bearing MKV
+  source into `webm` prints exactly
+  `attachment stream 2 (ttf) dropped: not supported by WebM`; the same
+  attachment source into `mov` still fails the cheap attempt and is dropped
+  with `attachment stream 1 (unknown) dropped: not supported by MOV` at the
+  selective rung, unchanged; an alpha-bearing PNG (measured source alpha byte
+  `0x7e`) into `jpg`, `gif` and `avif` prints the transparency note and the
+  loss is real and measured -- `ffprobe` reports `yuvj444p`/no-alpha `gbrp`
+  pixel formats on the `jpg`/`avif` outputs, and the decoded alpha byte comes
+  back `0xff` (opaque) on all three, where PNG, TIFF, BMP and WebP round-trip
+  the same source at `0xfe`/`0xff` only because they keep an alpha channel at
+  all (WebP: `yuva420p`, alpha `0xfe`); a multi-frame GIF source (3 frames,
+  measured via `ffprobe -count_frames`) into `avif` prints the frame-reduction
+  note and the output genuinely holds 1 frame; a second run over each
+  converted tree reports 0 converted, exit 0. Every new or changed assertion
+  was proven non-vacuous by mutating a profile copy in a scratch script
+  outside the repo (restoring `mkv`'s and `webm`'s removed standing notes,
+  and separately giving each profile a bogus `data` rule that would make
+  `verify_success` stop predicting the drop the shipped test pins) and
+  confirming the shipped assertion's expected value no longer matches against
+  either mutation.

--- a/docs/specs/spec-stream-disposition.md
+++ b/docs/specs/spec-stream-disposition.md
@@ -433,42 +433,54 @@ New-Item -ItemType Directory -Force in
   data or timecode stream a partial cheap attempt could not have mapped was
   already named individually before this issue touched anything; the
   standing note was pure duplication, never a statement with no
-  replacement. Measured against real ffmpeg 9.0, and pinned by new tests
-  (`tests/test_argv.py::TestMkvDegradationNotes`/`TestWebmDegradationNotes`):
-  unlike `mov`/`mp4` (issue #66), neither `mkv`'s nor `webm`'s muxer
-  regenerates a data or timecode stream from source metadata -- a `.mov`
-  source carrying a real `tmcd` timecode track converts to both containers
-  holding video and audio only, nothing put back -- so no `confirm_drops`
-  forgiveness is even in play and the per-stream prediction is exact on every
-  file, not merely on average. `mov` needed no change: it already carries no
-  standing note, having lost it to issue #66's finding that its muxer's own
-  `tmcd` regeneration made the blanket claim measurably false.
+  replacement. The per-stream prediction itself is pinned by new tests
+  (`tests/test_argv.py::TestMkvDegradationNotes`/`TestWebmDegradationNotes`,
+  `tests/test_batch.py::TestDropsAreConfirmedAgainstTheOutput`), which use the
+  project's usual stubbed subprocess boundary and so prove the *logic*, not
+  ffmpeg's own behaviour. That neither `mkv`'s nor `webm`'s real muxer
+  regenerates a data or timecode stream from source metadata -- unlike
+  `mov`/`mp4` (issue #66) -- is a claim about ffmpeg 9.0 itself, and is
+  established the same way issue #66's original finding was: measured by
+  hand, recorded in this entry's ffmpeg-9.0 verification paragraph below. A
+  `.mov` source carrying a real `tmcd` timecode track converts to both
+  containers holding video and audio only, nothing put back -- so no
+  `confirm_drops` forgiveness is even in play and the per-stream prediction is
+  exact on every file, not merely on average. `mov` needed no change: it
+  already carries no standing note, having lost it to issue #66's finding
+  that its muxer's own `tmcd` regeneration made the blanket claim measurably
+  false.
 
   **`jpg`, `gif` and `avif` keep theirs, unconditional, by decision rather
-  than oversight -- and neither half of the QA finding's title is actually
-  fixed for these three.** All five notes this issue's QA finding named for
-  these profiles -- JPEG's and GIF's transparency loss, GIF's colour palette,
+  than oversight.** All five notes this issue's QA finding named for these
+  profiles -- JPEG's and GIF's transparency loss, GIF's colour palette,
   AVIF's frame reduction -- describe a *within-stream* loss: the video
   stream is still mapped and kept, only something inside it (an alpha
   channel, a colour count, a frame count) is gone. `_structural_drop` only
   ever reasons about whether a stream was mapped at all, so it has no
-  opinion on what survived inside one.
+  opinion on what survived inside one. Review round 2 of this PR flagged an
+  earlier version of this entry's own summary sentence here ("neither half
+  is fixed here") as false about its own contents -- half one *is* fixed, for
+  the one note that needed it. Restated precisely below.
 
   *Half one -- firing when nothing was lost.* Four of the five notes are
-  worded as **format facts** ("transparency is not carried by JPEG"), true of
-  every conversion to that target regardless of what the source held, not a
-  claim that *this* file's transparency was dropped -- so, unlike the retired
-  `mkv`/`webm` notes, they do not over-report a specific event that did not
-  happen; they state a limit. Review of this PR's first draft found the
-  fifth, GIF's "colours are reduced to GIF's 256-colour palette", worded as
-  an *action* rather than a fact, and measured that an already-GIF,
-  already-<=256-colour source re-encodes pixel-identically (the module
-  comment above `GIF` in `converter/profiles.py` already recorded this,
-  unconnected until the review) -- so that wording, alone among the five, was
-  a genuine false claim for such a file. It is reworded here to "GIF holds at
-  most a 256-colour palette", the same fact-not-action shape as its four
-  siblings, closing that one real gap; the other four were already
-  accurate as written and needed no change.
+  worded as claims about what *this profile's pipeline always does*
+  ("transparency is not carried by JPEG" -- true of JPEG the format; AVIF's
+  own notes are true of this profile's forced `-still-picture 1`/no-alpha
+  pipeline specifically, not of the AVIF format, which does support alpha and
+  multiple frames elsewhere), true of every conversion through that profile
+  regardless of what the source held -- not a claim that *this* file's
+  transparency was dropped -- so, unlike the retired `mkv`/`webm` notes, they
+  do not over-report a specific event that did not happen; they state a
+  limit. Review of this PR's first draft found the fifth, GIF's "colours are
+  reduced to GIF's 256-colour palette", worded as an *action* rather than a
+  fact, and measured that an already-GIF, already-<=256-colour source
+  re-encodes pixel-identically (the module comment above `GIF` in
+  `converter/profiles.py` already recorded this, unconnected until the
+  review) -- so that wording, alone among the five, was a genuine false claim
+  for such a file. It is reworded here to "GIF holds at most a 256-colour
+  palette", the same fact-not-action shape as its four siblings, closing that
+  one real gap; the other four were already accurate as written and needed no
+  change.
 
   *Half two -- naming a stream index and codec.* None of the five names one,
   and this half is **not fixed, only recorded**. A profile's `notes` tuple is
@@ -539,3 +551,22 @@ New-Item -ItemType Directory -Force in
   the QA finding's own title -- naming no stream index or codec -- was
   addressed for `jpg`/`gif`/`avif`; it was not, and the profile comment and
   this entry now say so explicitly rather than only discussing conditionality.
+
+  **Review round 2** (fresh-agent gate) found the round-1 sweep for stale
+  standing-note comments had missed one: `tests/test_profiles.py`'s MOV test
+  still said "the standing note MKV still carries" after MKV's own note was
+  retired earlier in this same PR -- corrected to describe both profiles'
+  current shape. It also found this entry's and `converter/profiles.py`'s own
+  "neither half is fixed here" summary sentence contradicted the GIF rewording
+  the same PR makes -- corrected above to say precisely which half is fixed
+  for which note -- and that calling all five within-stream notes "format
+  facts" mischaracterised AVIF's two, which are true of this profile's forced
+  pipeline rather than of the AVIF format (which does support alpha and
+  multiple frames elsewhere) -- corrected the same way. Non-blocking nits
+  also addressed: the muxer-regeneration claim's docstring/spec wording no
+  longer credits the (stubbed) test suite with proving something only the
+  manual ffmpeg-9.0 record can; `tests/test_batch.py`'s new end-to-end test
+  uses each profile's own real copy-mask codecs (vp9/opus for WebM) rather
+  than an arbitrary h264/aac stand-in; and AVIF's back-reference to the
+  module-level comment now points at the block actually above JPG rather than
+  claiming it sits "above GIF".

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -1062,9 +1062,12 @@ class TestMkvDegradationNotes:
     def test_a_real_data_or_timecode_drop_is_still_named_per_stream(self):
         """What the retired standing note used to claim, now the only place it
         is said -- with the index and codec the blanket line never carried.
-        `tests/test_argv.py::TestConfirmDrops` proves this against the written
-        output too, and that MKV's muxer (unlike MOV/MP4's) never regenerates
-        one to forgive."""
+        `tests/test_batch.py::TestDropsAreConfirmedAgainstTheOutput` proves the
+        same prediction survives `confirm_drops`' output check with a stubbed
+        muxer; that MKV's *real* muxer (unlike MOV/MP4's) never regenerates one
+        to forgive is a claim about ffmpeg, not about this suite, and is
+        recorded against real ffmpeg 9.0 in
+        docs/specs/spec-stream-disposition.md's decision log instead."""
         streams = [
             Stream(0, "video", "h264"),
             Stream(1, "audio", "aac"),
@@ -2553,7 +2556,7 @@ class TestAnimatedProfileArgvPinning:
         ]
         assert last_resort.notes == (
             "transparency is not carried by GIF",
-            "the image was re-quantised to GIF's 256-colour palette",
+            "GIF holds at most a 256-colour palette",
             "non-video streams, and any video stream beyond the first, are not carried into GIF",
         )
 

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -1046,6 +1046,35 @@ class TestMkvDegradationNotes:
 
         assert selective.notes == ("subtitle stream 1 (mov_text) re-encoded to subrip",)
 
+    def test_no_standing_note_on_the_cheap_attempt(self):
+        """Issue #67: retired -- see MKV's profile comment for why."""
+        assert jobs.first_attempt(MKV).notes == ()
+
+    def test_a_source_with_nothing_to_lose_prints_no_note_at_all(self):
+        """Acceptance, issue #67 -- the change a user notices first. A source
+        with no data or timecode stream now prints nothing at all, where the
+        retired standing note used to fire unconditionally."""
+        streams = [Stream(0, "video", "h264"), Stream(1, "audio", "aac")]
+
+        assert jobs.first_attempt(MKV).notes == ()
+        assert jobs.verify_success(MKV, streams) == ()
+
+    def test_a_real_data_or_timecode_drop_is_still_named_per_stream(self):
+        """What the retired standing note used to claim, now the only place it
+        is said -- with the index and codec the blanket line never carried.
+        `tests/test_argv.py::TestConfirmDrops` proves this against the written
+        output too, and that MKV's muxer (unlike MOV/MP4's) never regenerates
+        one to forgive."""
+        streams = [
+            Stream(0, "video", "h264"),
+            Stream(1, "audio", "aac"),
+            Stream(2, "data", "bin_data"),
+        ]
+
+        assert jobs.verify_success(MKV, streams) == (
+            "data stream 2 (bin_data) dropped: not supported by MKV",
+        )
+
     def test_last_resort_notes_are_pinned(self):
         reencode = jobs.retries(MKV, [])[-1]
 
@@ -1374,19 +1403,42 @@ class TestWebmDegradationNotes:
             "bitmap subtitles cannot be stored in WebM",
         )
 
-    def test_standing_note_names_attachments_data_and_timecode(self):
-        assert jobs.first_attempt(WEBM).notes == (
-            "attachments, data and timecode streams are not carried into WebM",
-        )
+    def test_no_standing_note_on_the_cheap_attempt(self):
+        """Issue #67: retired -- see WEBM's profile comment for why."""
+        assert jobs.first_attempt(WEBM).notes == ()
+
+    def test_a_source_with_nothing_to_lose_prints_no_note_at_all(self):
+        """Acceptance, issue #67 -- the change a user notices first. A source
+        with no attachment, data or timecode stream now prints nothing at
+        all, where the retired standing note used to fire unconditionally."""
+        streams = [Stream(0, "video", "vp9"), Stream(1, "audio", "opus")]
+
+        assert jobs.first_attempt(WEBM).notes == ()
+        assert jobs.verify_success(WEBM, streams) == ()
 
     def test_attachment_drop_via_success_side_verification_is_exact(self):
         """WebM never maps an attachment, so a successful cheap attempt still
         leaves one behind; the success-side verifier (`jobs.verify_success`)
-        names it per stream, alongside the standing note above -- the same
-        mechanism MP4 already uses for its own attachment gap."""
+        names it per stream -- what the retired standing note used to claim
+        in a blanket line, the same mechanism MP4 already uses for its own
+        attachment gap."""
         notes = jobs.verify_success(WEBM, [Stream(0, "attachment", "unknown")])
 
         assert notes == ("attachment stream 0 (unknown) dropped: not supported by WebM",)
+
+    def test_a_real_data_or_timecode_drop_is_still_named_per_stream(self):
+        """The other half of the retired standing note's claim. WebM's muxer
+        regenerates nothing from source metadata (measured, unlike MOV/MP4's
+        `tmcd`), so the prediction is exact every time."""
+        streams = [
+            Stream(0, "video", "vp9"),
+            Stream(1, "audio", "opus"),
+            Stream(2, "data", "bin_data"),
+        ]
+
+        assert jobs.verify_success(WEBM, streams) == (
+            "data stream 2 (bin_data) dropped: not supported by WebM",
+        )
 
     def test_last_resort_notes_are_pinned(self):
         reencode = jobs.retries(WEBM, [])[-1]

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -556,17 +556,27 @@ class TestDropsAreConfirmedAgainstTheOutput:
             f"data stream 2 (unknown) dropped: not supported by {profile.label}",
         )
 
-    @pytest.mark.parametrize("profile", [MKV, WEBM], ids=lambda profile: profile.label)
+    @pytest.mark.parametrize(
+        ("profile", "video_codec", "audio_codec"),
+        [(MKV, "h264", "aac"), (WEBM, "vp9", "opus")],
+        ids=lambda value: value.label if isinstance(value, Profile) else value,
+    )
     def test_a_source_with_nothing_to_lose_reports_nothing_end_to_end(
-        self, tmp_path, fake_ffmpeg, profile
+        self, tmp_path, fake_ffmpeg, profile, video_codec, audio_codec
     ):
         """Acceptance, issue #67 -- the change a user notices first, proved
         through the same `convert_one`/`fake_ffmpeg` harness the rest of this
         class uses, not just `jobs.verify_success` in isolation. No data or
         timecode stream at all, so the retired standing note's absence is the
-        only thing that could still print something here."""
+        only thing that could still print something here. Each profile's own
+        copy-mask codecs, matching the sibling `test_argv.py` tests -- vp9/opus
+        is what a real WebM cheap attempt would actually copy, not an
+        arbitrary stand-in."""
         task = self._task(tmp_path, profile.target_suffix.lstrip("."))
-        fake_ffmpeg.streams = [Stream(0, "video", "h264"), Stream(1, "audio", "aac")]
+        fake_ffmpeg.streams = [
+            Stream(0, "video", video_codec),
+            Stream(1, "audio", audio_codec),
+        ]
         fake_ffmpeg.output_streams = list(fake_ffmpeg.streams)
 
         result = convert_one(profile, task, TOOLS, overwrite=False)

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -509,6 +509,12 @@ class TestDropsAreConfirmedAgainstTheOutput:
     WebM really do leave it behind. Every test here drives the
     cheap-attempt-succeeds path through `convert_one`, so it exercises the
     success-side verification rather than `jobs.confirm_drops` in isolation.
+
+    MKV's and WebM's cheap-attempt standing note that used to sit alongside
+    this per-stream note is retired (issue #67) -- the tuples below are
+    pinned directly rather than built from `profile.cheap_attempt.notes`, so
+    a standing note re-added to either profile by mistake would fail this
+    test rather than being silently absorbed by it.
     """
 
     #: What ffprobe reports for a `tmcd` stream: a data stream whose codec name
@@ -546,10 +552,7 @@ class TestDropsAreConfirmedAgainstTheOutput:
 
         result = convert_one(profile, task, TOOLS, overwrite=False)
 
-        # The full tuple, not a membership check: the standing note these two
-        # profiles still carry is part of what must not have changed.
         assert result.notes == (
-            *profile.cheap_attempt.notes,
             f"data stream 2 (unknown) dropped: not supported by {profile.label}",
         )
 

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -556,6 +556,24 @@ class TestDropsAreConfirmedAgainstTheOutput:
             f"data stream 2 (unknown) dropped: not supported by {profile.label}",
         )
 
+    @pytest.mark.parametrize("profile", [MKV, WEBM], ids=lambda profile: profile.label)
+    def test_a_source_with_nothing_to_lose_reports_nothing_end_to_end(
+        self, tmp_path, fake_ffmpeg, profile
+    ):
+        """Acceptance, issue #67 -- the change a user notices first, proved
+        through the same `convert_one`/`fake_ffmpeg` harness the rest of this
+        class uses, not just `jobs.verify_success` in isolation. No data or
+        timecode stream at all, so the retired standing note's absence is the
+        only thing that could still print something here."""
+        task = self._task(tmp_path, profile.target_suffix.lstrip("."))
+        fake_ffmpeg.streams = [Stream(0, "video", "h264"), Stream(1, "audio", "aac")]
+        fake_ffmpeg.output_streams = list(fake_ffmpeg.streams)
+
+        result = convert_one(profile, task, TOOLS, overwrite=False)
+
+        assert result.outcome is Outcome.CONVERTED
+        assert result.notes == ()
+
     def test_an_ambiguous_surplus_forgives_nothing(self, tmp_path, fake_ffmpeg):
         """Two streams the probe cannot tell apart are predicted dropped and one
         comes back. Which one survived is unknowable, so both keep their note --

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -728,10 +728,12 @@ class TestMovProfile:
 
     def test_cheap_attempt_carries_no_standing_note(self):
         """MOV's muxer regenerates a `tmcd` timecode track from source metadata
-        even though no selector maps it, so the standing note MKV still carries
-        was measurably false here (issue #66). The per-file success-side
-        verification reads the written output and names a real data drop
-        itself, so nothing is lost by dropping the blanket claim."""
+        even though no selector maps it, so a standing note here would have
+        been measurably false (issue #66) -- unlike MKV's and WebM's own
+        retired notes (issue #67), which needed no such exemption since
+        neither muxer regenerates one. The per-file success-side verification
+        reads the written output and names a real data drop itself, so
+        nothing is lost by dropping the blanket claim."""
         assert MOV.cheap_attempt.notes == ()
 
     def test_last_resort_excludes_container_options(self):

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1306,6 +1306,57 @@ class TestStandingNoteRetirement:
         assert profile.last_resort.notes == _LAST_RESORT_NOTES[profile.name]
 
 
+#: The video containers whose cheap-attempt standing note is retired by issue
+#: #67 -- `mkv` and `webm`. `mov` is deliberately absent: it lost its own
+#: standing note earlier, to issue #66's finding that its muxer's `tmcd`
+#: regeneration made the blanket claim measurably false, so it has nothing
+#: left for this issue to retire.
+VIDEO_PROFILES_WITH_A_RETIRED_STANDING_NOTE = [MKV, WEBM]
+
+#: Each video container's `last_resort.notes`, exactly as declared before this
+#: issue -- unchanged, since that rung is never verified (the same "only place
+#: that information exists" reasoning `_LAST_RESORT_NOTES` above records for
+#: the audio profiles).
+_VIDEO_LAST_RESORT_NOTES = {
+    MKV.name: (
+        "re-encoded to h264/aac (lossy); subtitles and extra video streams dropped",
+        "10-bit or HDR sources are reduced to 8-bit yuv420p for player compatibility",
+    ),
+    MOV.name: (
+        "re-encoded to h264/aac (lossy); subtitles and extra video streams dropped",
+        "10-bit or HDR sources are reduced to 8-bit yuv420p for player compatibility",
+    ),
+    WEBM.name: ("re-encoded to vp9/opus (lossy); subtitles and extra video streams dropped",),
+}
+
+
+class TestVideoStandingNoteRetirement:
+    """Issue #67: the cheap-attempt standing note is gone from every video
+    container profile that used to carry one, `mov` never carried one for this
+    issue to retire, and `last_resort` -- never verified, so its note is the
+    only place that information exists -- is untouched on all three. A guard
+    against a future profile quietly re-introducing one, the same shape #78's
+    `TestStandingNoteRetirement` above already established for the audio
+    profiles."""
+
+    @pytest.mark.parametrize(
+        "profile", VIDEO_PROFILES_WITH_A_RETIRED_STANDING_NOTE, ids=lambda profile: profile.label
+    )
+    def test_no_video_profile_carries_a_cheap_attempt_standing_note(self, profile):
+        assert profile.cheap_attempt.notes == ()
+
+    def test_mov_never_carried_one_either(self):
+        """The third video container, named explicitly since it is absent from
+        `VIDEO_PROFILES_WITH_A_RETIRED_STANDING_NOTE` above -- nothing for
+        this issue to retire (issue #66 already removed it)."""
+        assert MOV.cheap_attempt.notes == ()
+
+    @pytest.mark.parametrize("profile", [MKV, MOV, WEBM], ids=lambda profile: profile.label)
+    def test_last_resort_notes_are_unchanged(self, profile):
+        assert profile.last_resort is not None
+        assert profile.last_resort.notes == _VIDEO_LAST_RESORT_NOTES[profile.name]
+
+
 #: One tuple per image2 profile this phase adds: the profile itself, the codec
 #: name its own encoder produces (so a copy-mask hit can be constructed), and
 #: whether its lossless re-encode carries a note (Verification,
@@ -1549,10 +1600,14 @@ class TestGifProfile:
 
     def test_cheap_attempt_always_wins_so_its_standing_notes_always_print(self):
         """Forces the encoder unconditionally, so this is the rung whose notes
-        actually print for the overwhelming majority of inputs."""
+        actually print for the overwhelming majority of inputs. Both notes are
+        worded as format facts (issue #67 review) -- "GIF holds at most a
+        256-colour palette", not "colours are reduced", since an already-GIF,
+        already-<=256-colour source re-encodes pixel-identically and a
+        "reduced" claim would be false for it."""
         assert GIF.cheap_attempt.notes == (
             "transparency is not carried by GIF",
-            "colours are reduced to GIF's 256-colour palette",
+            "GIF holds at most a 256-colour palette",
         )
 
     def test_video_rule_copy_mask_is_its_own_codec(self):
@@ -1573,7 +1628,7 @@ class TestGifProfile:
         transparency note for."""
         assert GIF.last_resort is not None
         assert "transparency is not carried by GIF" in GIF.last_resort.notes
-        assert any("re-quantised" in note for note in GIF.last_resort.notes)
+        assert "GIF holds at most a 256-colour palette" in GIF.last_resort.notes
 
 
 class TestWebpProfile:

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -628,8 +628,13 @@ class TestMkvProfile:
         source with either loses it without ffmpeg ever complaining."""
         assert MKV.partial_mapping is True
 
-    def test_cheap_attempt_carries_the_standing_note(self):
-        assert MKV.cheap_attempt.notes == ("data and timecode streams are not carried into MKV",)
+    def test_cheap_attempt_carries_no_standing_note(self):
+        """Issue #67: the standing note is retired -- `jobs.verify_success`
+        already names a real data or timecode drop per stream, and MKV's
+        muxer never regenerates one from source metadata (measured), unlike
+        MOV/MP4's `tmcd`. See `tests/test_argv.py::TestConfirmDrops` for the
+        per-stream proof."""
+        assert MKV.cheap_attempt.notes == ()
 
     def test_last_resort_excludes_container_options(self):
         assert MKV.last_resort is not None
@@ -809,10 +814,14 @@ class TestWebmProfile:
     def test_cheap_attempt_is_declared_partial(self):
         assert WEBM.partial_mapping is True
 
-    def test_cheap_attempt_carries_the_standing_note(self):
-        assert WEBM.cheap_attempt.notes == (
-            "attachments, data and timecode streams are not carried into WebM",
-        )
+    def test_cheap_attempt_carries_no_standing_note(self):
+        """Issue #67: the standing note is retired -- `jobs.verify_success`
+        already names a real attachment, data or timecode drop per stream
+        (WebM declares neither rule), and WebM's muxer regenerates nothing
+        from source metadata (measured). See
+        `tests/test_argv.py::TestWebmDegradationNotes` for the per-stream
+        proof."""
+        assert WEBM.cheap_attempt.notes == ()
 
     def test_last_resort_excludes_container_options(self):
         assert WEBM.last_resort is not None


### PR DESCRIPTION
## Summary

Issue #67 is the other half of the QA finding #78 already fixed for the five audio profiles: a cheap-attempt standing note firing even when a source had nothing for the target to drop, and naming neither a stream index nor a codec.

- **`mkv` and `webm` retire theirs outright**, the same resolution #78 gave the audio profiles: `jobs.verify_success`'s `_structural_drop` already names any stream of a type the profile declares no rule for, per stream — `mkv` has no `data` rule, `webm` has neither `attachment` nor `data`. Measured against real ffmpeg 9.0: unlike `mov`/`mp4` (#66), neither muxer regenerates a data or timecode stream from source metadata, so the per-stream note is exact on every file, not merely on average. `mov` needed no change — it already lost its standing note to #66's finding.
- **`jpg`, `gif` and `avif` keep theirs, unconditional, by decision.** Their notes (transparency, colour quantisation, frame reduction) describe a *within-stream* loss — the video stream is still mapped and kept, only something inside it is gone — which the per-stream drop machinery cannot see, and which `Stream` has no `pix_fmt`/frame-count field to measure today. Building that touches `jobs.py` (read-only for this work) and `ffmpegtool.py` (out of scope), so retiring these without a replacement would violate the constitution's "never report success for a conversion that silently dropped something." Recorded as a finding for a follow-up issue.
- `README.md` documents the resulting behaviour for all six profiles, and corrects a stale MP3/FLAC claim that cover art is never carried (wrong since #77).
- Full inventory, ffmpeg-9.0 measurements (including alpha-byte and frame-count evidence) and mutation-testing proof are in `docs/specs/spec-stream-disposition.md`'s decision log.

Closes #67

## Test plan

- [x] `scripts/verify.py` green (989 tests)
- [x] Real ffmpeg 9.0 smoke tests: nothing-to-lose sources into `mkv`/`webm` now print no note; a real data/timecode-bearing source into `mkv`/`webm` prints exactly the per-stream note with index+codec; an attachment-bearing source into `webm` and `mov` both name the drop; an alpha-bearing source into `jpg`/`gif`/`avif` measurably loses alpha (decoded byte `0x7e` → `0xff`); a multi-frame GIF into `avif` measurably drops to 1 frame; idempotent re-run reports 0 converted, exit 0
- [x] Mutation testing (scratch script outside the repo) proves the new/changed assertions are not vacuous

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pdnJyntsFJyawGBSGj4cV