### PR TITLE
docs: close out phases 6-7 (stream-disposition, lossy-source-notes)

### DIFF
--- a/converter/ffmpegtool.py
+++ b/converter/ffmpegtool.py
@@ -71,7 +71,7 @@ class Stream:
     #: embedded picture (cover art). Not a general disposition set -- only
     #: this one flag has a decision resting on it, because ``mjpeg`` and
     #: ``png`` are the codec of both a cover picture and a real video and
-    #: nothing else distinguishes them (docs/specs/spec-stream-disposition.md).
+    #: nothing else distinguishes them (docs/specs/archive/spec-stream-disposition.md).
     #: Defaults to false so existing construction sites are unaffected.
     attached_pic: bool = False
 

--- a/converter/profiles.py
+++ b/converter/profiles.py
@@ -107,7 +107,7 @@ MP4_AUDIO_CODECS = frozenset({"aac", "mp3", "ac3", "eac3", "alac", "opus", "flac
 TEXT_SUBTITLE_CODECS = frozenset({"subrip", "srt", "ass", "ssa", "mov_text", "webvtt", "text"})
 
 #: Codecs that discard source information when they encode -- curated by hand
-#: for `docs/specs/spec-lossy-source-notes.md`'s advisory ("this lossless target
+#: for `docs/specs/archive/spec-lossy-source-notes.md`'s advisory ("this lossless target
 #: cannot restore what a lossy source had already given up"), the same kind of
 #: hand-maintained artifact as the copy masks above and for the same reason:
 #: ffmpeg can be asked what a build contains, never how *this* project judges a
@@ -395,7 +395,7 @@ MKV = Profile(
     # streams, which no "v/a/s/t" map -- MKV's included -- carries at all
     # (measured).
     #
-    # Issue #67, docs/specs/spec-stream-disposition.md: the standing note this
+    # Issue #67, docs/specs/archive/spec-stream-disposition.md: the standing note this
     # cheap attempt used to carry alongside the map is retired. jobs.verify_success
     # already names a real data or timecode drop per stream via _structural_drop's
     # "not supported by MKV" branch -- MKV declares no "data" rule, so any such
@@ -570,7 +570,7 @@ WEBM = Profile(
     # timecode streams, which no "v/a/s" map -- WebM's included -- carries at
     # all (measured).
     #
-    # Issue #67, docs/specs/spec-stream-disposition.md: the standing note this
+    # Issue #67, docs/specs/archive/spec-stream-disposition.md: the standing note this
     # cheap attempt used to carry alongside the map is retired. WebM declares
     # no "attachment" or "data" rule, so jobs.verify_success's
     # _structural_drop already names any attachment, data or timecode stream
@@ -648,7 +648,7 @@ MP3 = Profile(
     # below, the muxer-enforced exemption docs/design/degradation-ladder.md
     # names, rather than WAV's index-named one.
     #
-    # "-map 0:disp:attached_pic?" (docs/specs/spec-stream-disposition.md): the
+    # "-map 0:disp:attached_pic?" (docs/specs/archive/spec-stream-disposition.md): the
     # disposition specifier maps an embedded cover picture and nothing else --
     # measured, it never matches a real video stream, so this cheap attempt
     # still never sees one. "-c copy" replaces "-c:a copy" deliberately: with
@@ -656,7 +656,7 @@ MP3 = Profile(
     # muxer's default instead of copying it, an undeclared loss the mask would
     # hide; "-c copy" behaves identically to "-c:a copy" for the audio stream
     # since the map now selects only audio and pictures.
-    # Issue #78, docs/specs/spec-stream-disposition.md: the standing note this
+    # Issue #78, docs/specs/archive/spec-stream-disposition.md: the standing note this
     # cheap attempt used to carry alongside the map is retired.
     # partial_mapping's success-side verification (jobs.verify_success) already
     # names every dropped stream -- index, codec and reason -- so the blanket
@@ -717,7 +717,7 @@ FLAC = Profile(
     # muxer enforces "at most one audio stream" itself.
     #
     # Same disposition addition as MP3's, and the same "-c copy" reasoning --
-    # see its comment (docs/specs/spec-stream-disposition.md).
+    # see its comment (docs/specs/archive/spec-stream-disposition.md).
     # Standing note retired -- issue #78, see MP3's identical comment.
     cheap_attempt=Attempt(
         label="remux",
@@ -765,7 +765,7 @@ M4A = Profile(
     #
     # Same disposition addition as MP3's cheap attempt, and the same reason
     # "-c:a copy" becomes "-c copy": trap 1 in
-    # docs/specs/spec-stream-disposition.md. Measured, this one matters most --
+    # docs/specs/archive/spec-stream-disposition.md. Measured, this one matters most --
     # the ipod muxer's *default* video encoder is h264, which ipod then
     # rejects, so leaving "-c:a copy" in place would fail every artwork-bearing
     # "--to m4a" at rung 1 rather than silently mis-encoding as mp3/flac would.
@@ -820,7 +820,7 @@ OGG = Profile(
     # through as a whole video file renamed ".ogg" -- the same defect that
     # rules m4a out. The cheap attempt maps audio only, so the two spellings
     # behave identically; "-c copy" is what the spec pins.
-    # Issue #78, docs/specs/spec-stream-disposition.md: the standing note this
+    # Issue #78, docs/specs/archive/spec-stream-disposition.md: the standing note this
     # cheap attempt used to carry alongside the map is retired -- ogg gains no
     # artwork rule (Out of scope), so a cover-art stream here is an ordinary
     # video stream and partial_mapping's success-side verification
@@ -957,7 +957,7 @@ PNG = Profile(
     ),
 )
 
-# Issue #67, docs/specs/spec-stream-disposition.md: the QA finding this issue
+# Issue #67, docs/specs/archive/spec-stream-disposition.md: the QA finding this issue
 # was filed against reads "standing notes fire when nothing was lost **and
 # name no stream**" -- this covers JPG's, GIF's and AVIF's standing notes
 # below (transparency, colour palette, frame reduction). Review round 2 of

--- a/docs/design/stream-decision.md
+++ b/docs/design/stream-decision.md
@@ -65,7 +65,7 @@ flowchart TD
   exists precisely because no stream list could be obtained
   (`degradation-ladder.md`); it reports the absence of the facts this rule
   demands, and is not a per-stream verdict at all. An advisory
-  (`docs/specs/spec-lossy-source-notes.md`) is exempt on the same footing: it
+  (`docs/specs/archive/spec-lossy-source-notes.md`) is exempt on the same footing: it
   names the stream and its codec, but what it reports is the source's own
   history, not this conversion's sacrifice, so it is not bound by this rule the
   way a degradation note is (`docs/constitution.md`'s degradation-note/advisory

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,8 +16,8 @@
 | 3 | audio-formats | [spec-audio-formats.md](specs/archive/spec-audio-formats.md) | [#3](https://github.com/bhemsen/converter/milestone/3) |
 | 4 | video-formats | [spec-video-formats.md](specs/archive/spec-video-formats.md) | [#4](https://github.com/bhemsen/converter/milestone/4) |
 | 5 | image-formats | [spec-image-formats.md](specs/archive/spec-image-formats.md) | [#5](https://github.com/bhemsen/converter/milestone/5) |
-| 6 | stream-disposition | [spec-stream-disposition.md](specs/spec-stream-disposition.md) | [#6](https://github.com/bhemsen/converter/milestone/6) |
-| 7 | lossy-source-notes | [spec-lossy-source-notes.md](specs/spec-lossy-source-notes.md) | [#7](https://github.com/bhemsen/converter/milestone/7) |
+| 6 | stream-disposition | [spec-stream-disposition.md](specs/archive/spec-stream-disposition.md) | [#6](https://github.com/bhemsen/converter/milestone/6) |
+| 7 | lossy-source-notes | [spec-lossy-source-notes.md](specs/archive/spec-lossy-source-notes.md) | [#7](https://github.com/bhemsen/converter/milestone/7) |
 
 A phase gets a Spec link once `/plan` drafts it, and a Milestone link once the
 spec is merged. The milestone (open/closed + issue progress) is where status

--- a/docs/specs/archive/spec-lossy-source-notes.md
+++ b/docs/specs/archive/spec-lossy-source-notes.md
@@ -101,7 +101,7 @@ the codec-level restriction they carry stays exactly as it is.)
 
 ## Prior art
 
-- [Generation-loss advisories (Phase 7)](../prior-art.md#generation-loss-advisories-phase-7)
+- [Generation-loss advisories (Phase 7)](../../prior-art.md#generation-loss-advisories-phase-7)
   — the concern seeded for this phase, whose recorded weakness this cycle closes.
   The seed noted that research mode `none` had been chosen and that nobody had
   checked whether any comparable converter warns at all. Checked now: the
@@ -111,7 +111,7 @@ the codec-level restriction they carry stays exactly as it is.)
   The second half is narrower than the seed hoped: ffmpeg **does** classify codecs
   as lossy or lossless (`-codecs`, columns `L` and `S`), so a list does exist --
   it is simply not usable here, for the three reasons the decision row gives.
-- [Container/codec capability modelling (Phase 1)](../prior-art.md#containercodec-capability-modelling-phase-1)
+- [Container/codec capability modelling (Phase 1)](../../prior-art.md#containercodec-capability-modelling-phase-1)
   -- the method: a curated set, hand-maintained. Note the phase-1 argument does
   **not** transfer unchanged: its claim is that `-codecs` lists what a build
   contains, "never which codec is LEGAL in which muxer" -- a statement about
@@ -472,3 +472,11 @@ New-Item -ItemType Directory -Force in
   what mp3 discarded`, matching `converter/jobs.py::_lossy_source_note`
   verbatim -- the wording the new doc lines describe was read off the shipped
   code, not reinvented.
+- 2026-08-27: Close-out. The final QA gate ran against real ffmpeg 9.0 on
+  Windows 11, reproducing every behavioural promise of this milestone and of
+  milestone 6 (stream-disposition) end-to-end. Verdict: PASS WITH FINDINGS, no
+  code defect. The gate's one documentation finding and two coverage gaps are
+  recorded in `docs/specs/archive/spec-stream-disposition.md`'s Decision log,
+  since both concern that milestone's material. Issue #101 (the
+  `jpg`/`gif`/`avif` within-stream notes still firing unconditionally and
+  naming no stream, tracked against milestone 6) remains open by design.

--- a/docs/specs/archive/spec-stream-disposition.md
+++ b/docs/specs/archive/spec-stream-disposition.md
@@ -43,7 +43,10 @@ The fix is not to sort it out afterwards but never to map it: ffmpeg has a
       still is.
 - [ ] The five audio profiles' cheap-attempt standing notes are gone, and nothing
       they said is lost: every claim is made per stream by `jobs.verify_success`,
-      or is no longer true. `last_resort` notes are untouched.
+      or is no longer true. `last_resort` notes are retained on every profile —
+      none is retired or newly added; issue #67 reworded exactly one, `gif`'s,
+      from an action claim to a fact claim (the same fix it gave that profile's
+      `cheap_attempt` note), which is not a regression against this bullet.
 - [ ] `ogg`, `opus` and `wav` are byte-for-byte unchanged in argv, and unchanged
       in notes except for the standing note this phase removes from `ogg` and
       `opus`.
@@ -100,7 +103,7 @@ The fix is not to sort it out afterwards but never to map it: ffmpeg has a
 
 ## Prior art
 
-- [Cover art and stream disposition (Phase 6)](../prior-art.md#cover-art-and-stream-disposition-phase-6)
+- [Cover art and stream disposition (Phase 6)](../../prior-art.md#cover-art-and-stream-disposition-phase-6)
   — the concern seeded for this phase. beets' `convert` plugin is the **stance**
   to adopt: artwork is a first-class, default-on concern of a conversion pipeline
   (`embed: yes`), not an incidental stream. Its **mechanism** is the AVOID — it
@@ -570,3 +573,30 @@ New-Item -ItemType Directory -Force in
   than an arbitrary h264/aac stand-in; and AVIF's back-reference to the
   module-level comment now points at the block actually above JPG rather than
   claiming it sits "above GIF".
+- 2026-08-27: Close-out QA gate, coverage gap. The sub-ffmpeg-7.1 degradation
+  path (Prior decisions row: below 7.1, `-map 0:disp:attached_pic?` aborts the
+  cheap attempt with `Invalid disposition specifier`, exit 127, and the ladder
+  reaches the same result via the selective rung at one wasted process per
+  file) was checked as **text** against the shipped code and confirmed
+  unenforced -- the three cheap attempts of `mp3`, `m4a` and `flac` are
+  unconditional, matching the Verification bullet's claim -- but was not
+  **exercised**: the QA machine has only ffmpeg 9.0 installed. Testing it for
+  real needs a 6.x or 5.x binary. Recorded as an unverified coverage gap, not a
+  defect.
+- 2026-08-27: Close-out QA gate, coverage gap. The `last_resort` rung of the
+  five audio profiles (`mp3`, `m4a`, `flac`, `ogg`, `opus`) was not reached
+  end-to-end during the gate: reaching it needs both the cheap attempt and the
+  selective rung to fail on an audio target, and no realistic fixture produced
+  that. Their note text was instead verified by direct registry comparison
+  against the pre-milestone commit, not by a real conversion. (`jpg`'s
+  `last_resort` note, from the same issue #67 work, *was* exercised
+  end-to-end -- the gap is specific to the five audio profiles, not to
+  `last_resort` notes in general.)
+- 2026-08-27: Close-out. The final QA gate ran against real ffmpeg 9.0 on
+  Windows 11, reproducing every behavioural promise of this milestone and of
+  milestone 7 (lossy-source-notes) end-to-end. Verdict: PASS WITH FINDINGS, no
+  code defect. The one documentation finding -- this spec's Outcome section
+  saying `last_resort` notes were "untouched" where "retained" was meant -- is
+  fixed above. The two coverage gaps above are recorded rather than mistaken
+  for coverage. Issue #101 (the `jpg`/`gif`/`avif` within-stream notes still
+  firing unconditionally and naming no stream) remains open by design.

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -231,7 +231,7 @@ class TestMp3Job:
         assert selective.notes == ("video stream 1 (h264) dropped: not supported by MP3",)
 
     def test_a_carried_picture_is_not_reported_as_dropped_while_a_real_video_still_is(self):
-        """Issue #77, `docs/specs/spec-stream-disposition.md`: the distinction
+        """Issue #77, `docs/specs/archive/spec-stream-disposition.md`: the distinction
         the whole phase is for, proven against the real `MP3` profile rather
         than a stand-in. Both streams share the codec `mjpeg` -- the codec of
         both a cover picture and a real video (Prior art) -- so the note this
@@ -1067,7 +1067,7 @@ class TestMkvDegradationNotes:
         muxer; that MKV's *real* muxer (unlike MOV/MP4's) never regenerates one
         to forgive is a claim about ffmpeg, not about this suite, and is
         recorded against real ffmpeg 9.0 in
-        docs/specs/spec-stream-disposition.md's decision log instead."""
+        docs/specs/archive/spec-stream-disposition.md's decision log instead."""
         streams = [
             Stream(0, "video", "h264"),
             Stream(1, "audio", "aac"),
@@ -1735,7 +1735,7 @@ class TestProfileArgvPinning:
         ]
 
     def test_mp3_cheap_attempt(self):
-        """Issue #77, `docs/specs/spec-stream-disposition.md`: the disposition
+        """Issue #77, `docs/specs/archive/spec-stream-disposition.md`: the disposition
         map and "-c copy" replace the plain audio-only "-c:a copy" form."""
         argv = build_argv("ffmpeg", "in.wav", jobs.first_attempt(MP3).options, "out.mp3")
 
@@ -1867,7 +1867,7 @@ class TestProfileArgvPinning:
         ]
 
     def test_m4a_cheap_attempt(self):
-        """Trap 1 (`docs/specs/spec-stream-disposition.md`): "-c:a copy" would
+        """Trap 1 (`docs/specs/archive/spec-stream-disposition.md`): "-c:a copy" would
         leave the picture uncovered, and the ipod muxer re-encodes it to h264
         by default and then rejects it -- "-c copy" is load-bearing here, not
         cosmetic like it is for mp3/flac."""

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -856,7 +856,7 @@ class TestRunBatch:
 
 
 class TestLossySourceAdvisory:
-    """Issue #88, `docs/specs/spec-lossy-source-notes.md`: the advisory that
+    """Issue #88, `docs/specs/archive/spec-lossy-source-notes.md`: the advisory that
     fires when a lossy source reaches FLAC's selective (failure-side) rung --
     "your FLAC came from a 128 kbit/s MP3." Scoped to `jobs.retries` /
     `convert_one` behaviour; profile definitions and `test_argv.py` are #77's
@@ -897,7 +897,7 @@ class TestLossySourceAdvisory:
         the control the spec's Verification section names, proving nothing
         about the guard on its own.
 
-        Issue #78, docs/specs/spec-stream-disposition.md: rung 1's standing
+        Issue #78, docs/specs/archive/spec-stream-disposition.md: rung 1's standing
         note is retired -- `jobs.verify_success` already names any drop this
         note used to describe, per stream. This control now asserts the
         rung carries no notes of its own at all, still proving nothing about
@@ -944,7 +944,7 @@ class TestLossySourceAdvisory:
 
     def test_copied_through_cover_art_carries_no_advisory(self):
         """Regression: `main` gained FLAC's `attached_pic` rule (issue #77,
-        `docs/specs/spec-stream-disposition.md`) between this issue's review
+        `docs/specs/archive/spec-stream-disposition.md`) between this issue's review
         and its merge. That rule's copy mask (`_AcceptAnyCodec`) accepts every
         codec and the rule declares no fallback, so a cover picture is always
         copied byte-for-byte, never re-encoded into FLAC's own codec -- unlike

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -50,7 +50,7 @@ MAP_LETTERS = {"v": "video", "a": "audio", "s": "subtitle", "t": "attachment", "
 #: one (measured, one such map carries *every* matching stream, not one).
 #: Extend this the same way `MAP_LETTERS` is extended, when a profile
 #: introduces another disposition selector. Only `attached_pic` exists today
-#: (docs/specs/spec-stream-disposition.md).
+#: (docs/specs/archive/spec-stream-disposition.md).
 DISPOSITION_QUALIFIERS = {"attached_pic": "attached_pic"}
 
 #: Every profile the registry ships. A new one joins the invariant checks here.
@@ -925,7 +925,7 @@ class TestMp3Profile:
         assert MP3.container_options == ()
 
     def test_cheap_attempt_maps_audio_and_attached_pictures_blindly(self):
-        """Issue #77, `docs/specs/spec-stream-disposition.md`:
+        """Issue #77, `docs/specs/archive/spec-stream-disposition.md`:
         `-map 0:disp:attached_pic?` maps an embedded cover picture and nothing
         else -- measured, it never matches a real video stream. `-c copy`
         replaces `-c:a copy` deliberately: with no codec option covering the
@@ -1075,7 +1075,7 @@ class TestM4aProfile:
     def test_cheap_attempt_maps_audio_and_attached_pictures_blindly(self):
         """Same disposition addition as MP3's, and the same reason
         "-c:a copy" becomes "-c copy" -- trap 1 in
-        `docs/specs/spec-stream-disposition.md`. Measured, this one matters
+        `docs/specs/archive/spec-stream-disposition.md`. Measured, this one matters
         most: the ipod muxer's *default* video encoder is h264, which ipod
         then rejects, so leaving "-c:a copy" in place would fail every
         artwork-bearing `--to m4a` at rung 1 rather than silently
@@ -1257,13 +1257,13 @@ class TestOpusProfile:
 
 
 #: The five audio profiles a cheap-attempt standing note used to sit on
-#: (Acceptance, issue #78, docs/specs/spec-stream-disposition.md). `wav` is
+#: (Acceptance, issue #78, docs/specs/archive/spec-stream-disposition.md). `wav` is
 #: deliberately absent: it carries none, so there is nothing for it to retire.
 AUDIO_PROFILES_WITH_A_RETIRED_NOTE = [MP3, FLAC, M4A, OGG, OPUS]
 
 #: Each profile's `last_resort.notes`, exactly as declared before this issue --
 #: unchanged, since that rung maps `-map 0:a:0` explicitly and is never
-#: verified (Out of scope, docs/specs/spec-stream-disposition.md: "`last_resort`
+#: verified (Out of scope, docs/specs/archive/spec-stream-disposition.md: "`last_resort`
 #: notes ... the only place that information exists").
 _LAST_RESORT_NOTES = {
     MP3.name: (
@@ -1890,7 +1890,7 @@ class TestRegistryTargetCoherence:
 
 
 class TestLossyCodecs:
-    """`LOSSY_CODECS` (issue #87, `docs/specs/spec-lossy-source-notes.md`): the
+    """`LOSSY_CODECS` (issue #87, `docs/specs/archive/spec-lossy-source-notes.md`): the
     curated set the source-codec advisory checks against, hand-maintained
     because ffmpeg's own `-codecs` classification cannot be read wholesale --
     see the constant's own docstring in `converter/profiles.py` for the full


### PR DESCRIPTION
## Summary

Both full-spec milestones (#6-#7) are complete and the final QA gate has run against real ffmpeg 9.0 on Windows 11, reproducing every behavioural promise of both milestones end-to-end: verdict **PASS WITH FINDINGS**, no code defect.

- Fixed the gate's one documentation finding before archiving: `spec-stream-disposition.md`'s Outcome section said `last_resort` notes were "untouched", which issue #67's deliberate rewording of `gif`'s note (an action claim corrected to a fact claim) makes inaccurate verbatim, even though "retained" still holds. Reworded, without touching any note text in `converter/profiles.py`.
- Recorded the gate's two coverage gaps in the spec's Decision log so they are not mistaken for coverage: the sub-ffmpeg-7.1 degradation path was checked as text only (no pre-7.1 binary on the QA machine); the five audio profiles' `last_resort` rung was never reached end-to-end (verified by registry diff instead). Issue #101 remains open by design.
- Archived both specs to `docs/specs/archive/` per the workflow contract's close-out convention and repointed every reference to the old paths across the docs and the codebase (comments in `converter/ffmpegtool.py`, `converter/profiles.py`, `docs/design/stream-decision.md`, and test docstrings in `tests/test_argv.py`, `tests/test_batch.py`, `tests/test_profiles.py`, plus `docs/roadmap.md`'s phase table).
- Rebased the two moved specs' own relative `../prior-art.md` links to `../../prior-art.md` — archiving adds a path segment, the same trap PR #74 hit — and verified each resolves on disk.

This PR closes no issue; `docs:` is exempt from the spec-trace rule.

## Test plan

- [x] `.venv/Scripts/python.exe scripts/verify.py` green: ruff check, ruff format --check, 997 tests passed.
- [x] Every rewritten reference (code comments, test docstrings, `docs/roadmap.md`, `docs/design/stream-decision.md`, and the two moved specs' own relative prior-art links) confirmed to resolve to a file that exists on disk.
- [ ] CI green on both OS legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pdnJyntsFJyawGBSGj4cV